### PR TITLE
Add everblock modal button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ Make sure that the hook used in the block matches the criteria of the settings o
 
 Each block can be converted to a modal and can have shortcodes in its content (except hook and store locator shortcodes). You can therefore create contact forms in a modal.
 
+## Triggering modals from a button
+You can trigger an Everblock modal manually from any hook. Add a button with the
+class `everblock-modal-button` and provide the block ID in a `data-evermodal`
+attribute:
+
+```html
+<button class="everblock-modal-button" data-evermodal="12">Open modal</button>
+```
+
+When clicked, the module will load the corresponding modal content via AJAX and
+display it using Bootstrap.
+
 ## Cache & logs
 
 The module uses its own cache system in addition to the Prestashop one.

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -121,6 +121,30 @@ $(document).ready(function(){
             }
         });
     });
+
+    $(document).on('click', '.everblock-modal-button', function(e) {
+        e.preventDefault();
+        let blockId = $(this).data('evermodal');
+        if (!blockId) {
+            return;
+        }
+        $.ajax({
+            url: atob(evermodal_link),
+            type: 'POST',
+            data: { id_everblock: blockId, token: everblock_token, force: 1 },
+            success: function(modal) {
+                $('#everblockModal').remove();
+                $('body').append(modal);
+                $('#everblockModal').modal('show');
+                $('#everblockModal').on('hidden.bs.modal', function () {
+                    $(this).remove();
+                });
+            },
+            error: function(xhr) {
+                console.log(xhr.responseText);
+            }
+        });
+    });
     $('.everModalAutoTrigger').modal('show');
     // Sélectionner tous les éléments avec la classe "ever-slide"
     let sliders = $('.ever-slide');


### PR DESCRIPTION
## Summary
- open Everblock modals when `.everblock-modal-button` is clicked
- document how to use modal buttons in README

## Testing
- `composer validate --no-check-all` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684053713e088322bcb7bcb7f95dd9c8