### PR TITLE
Remove unused font generation code

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1505,37 +1505,11 @@ class Everblock extends Module
             if ((bool) Configuration::get('EVERBLOCK_TINYMCE') === true
                 && Tools::getValue('configure') != $this->name
             ) {
-                // Ajouter une variable JS globale pour les polices
-                Media::addJsDef([
-                    'everblock_fonts' => $this->getThemeFonts(),
-                ]);
                 $this->context->controller->addJs($this->_path . 'views/js/adminTinyMce.js');
             }
         }
     }
 
-    public function getThemeFonts()
-    {
-        $themePath = _PS_THEME_DIR_; // Chemin du thème actuel
-        $fontsDir = $themePath . 'assets/fonts'; // Répertoire des polices (à ajuster si nécessaire)
-        $fonts = [];
-
-        if (is_dir($fontsDir)) {
-            $files = scandir($fontsDir);
-            foreach ($files as $file) {
-                // Vérifier si le fichier a une extension de police valide
-                if (preg_match('/\.(ttf|woff|woff2|otf)$/i', $file)) {
-                    $fontName = pathinfo($file, PATHINFO_FILENAME); // Nom de la police sans extension
-                    $fonts[] = [
-                        'name' => ucfirst($fontName), // Nom affichable
-                        'css' => $fontName . ', sans-serif' // Format CSS (par défaut sans-serif, ajustez si nécessaire)
-                    ];
-                }
-            }
-        }
-
-        return $fonts;
-    }
 
     public function hookActionClearCache($params)
     {

--- a/views/backup/js/adminTinyMce.js
+++ b/views/backup/js/adminTinyMce.js
@@ -27,9 +27,6 @@ function initCustomTinyMCE() {
   }
 
   // TinyMCE est chargé, ajoutez vos configurations
-  const fontFormats = generateFontFormats(everblock_fonts);
-
-  console.log('TinyMCE Configuration:', fontFormats);
 
   window.defaultTinyMceConfig = {
     selector: '.evertranslatable',
@@ -49,7 +46,6 @@ function initCustomTinyMCE() {
     relative_urls: false,
     convert_urls: false,
     extended_valid_elements: "em[class|name|id]",
-    font_formats: fontFormats, // Ajouter les polices ici
     menu: {
       edit: { title: 'Edit', items: 'undo redo | cut copy paste | selectall' },
       insert: { title: 'Insert', items: 'media image link | pagebreak' },

--- a/views/backup/js/adminTinyMce.js
+++ b/views/backup/js/adminTinyMce.js
@@ -27,6 +27,9 @@ function initCustomTinyMCE() {
   }
 
   // TinyMCE est chargé, ajoutez vos configurations
+  const fontFormats = generateFontFormats(everblock_fonts);
+
+  console.log('TinyMCE Configuration:', fontFormats);
 
   window.defaultTinyMceConfig = {
     selector: '.evertranslatable',
@@ -46,6 +49,7 @@ function initCustomTinyMCE() {
     relative_urls: false,
     convert_urls: false,
     extended_valid_elements: "em[class|name|id]",
+    font_formats: fontFormats, // Ajouter les polices ici
     menu: {
       edit: { title: 'Edit', items: 'undo redo | cut copy paste | selectall' },
       insert: { title: 'Insert', items: 'media image link | pagebreak' },

--- a/views/js/adminTinyMce.js
+++ b/views/js/adminTinyMce.js
@@ -27,9 +27,6 @@ function initCustomTinyMCE() {
   }
 
   // TinyMCE est chargé, ajoutez vos configurations
-  const fontFormats = generateFontFormats(everblock_fonts);
-
-  console.log('TinyMCE Configuration:', fontFormats);
 
   window.defaultTinyMceConfig = {
     selector: '.evertranslatable',
@@ -49,7 +46,6 @@ function initCustomTinyMCE() {
     relative_urls: false,
     convert_urls: false,
     extended_valid_elements: "em[class|name|id]",
-    font_formats: fontFormats, // Ajouter les polices ici
     menu: {
       edit: { title: 'Edit', items: 'undo redo | cut copy paste | selectall' },
       insert: { title: 'Insert', items: 'media image link | pagebreak' },


### PR DESCRIPTION
## Summary
- drop `generateFontFormats` usage from TinyMCE helper scripts
- remove unused font loading logic from module hook

## Testing
- `php -l everblock.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684059db97a48322b3ce79221de7e6db