### PR TITLE
Implement linked products shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[promo-products 10 carousel=true]`: Displays ten products on sale in a carousel format.
 - `[best-sales 10 carousel=true]`: Displays the top ten best-selling products. Optional parameters: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Displays ten random products in a carousel.
+- `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Displays products linked to the current product in a Bootstrap carousel.
 - `{hook h='displayHome'}`: Displays the `displayHome` hook (hooks are not allowed on modals)
 - `[everinstagram]`: Display your latest Instagram photos.
 - `[nativecontact]`: Embed the native PrestaShop contact form.

--- a/views/templates/hook/linkedproducts_carousel.tpl
+++ b/views/templates/hook/linkedproducts_carousel.tpl
@@ -1,0 +1,31 @@
+{*
+ * Linked products carousel template
+ *}
+{if isset($everPresentProducts) && $everPresentProducts}
+  <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
+    <div class="carousel-inner">
+      {assign var="numProductsPerSlide" value=4}
+      {foreach from=$everPresentProducts item=product key=key}
+        {if $key % $numProductsPerSlide == 0}
+          <div class="carousel-item{if $key == 0} active{/if}">
+            <div class="row">
+        {/if}
+        <div class="col-md-3">
+          {include file="catalog/_partials/miniatures/product.tpl" product=$product}
+        </div>
+        {if ($key + 1) % $numProductsPerSlide == 0 || $key == count($everPresentProducts) - 1}
+            </div>
+          </div>
+        {/if}
+      {/foreach}
+    </div>
+    <a class="carousel-control-prev" href="#{$carousel_id}" role="button" data-slide="prev" data-bs-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only visually-hidden">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#{$carousel_id}" role="button" data-slide="next" data-bs-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only visually-hidden">Next</span>
+    </a>
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- add `[linkedproducts]` shortcode implementation
- render linked products using a Bootstrap carousel template
- document the new shortcode

## Testing
- `php -l models/EverblockTools.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68405cc13b388322b833b5a8ad1b0a4c