### PR TITLE
Add carousel option to everimg shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `{hook h='displayHome'}`: Displays the `displayHome` hook (hooks are not allowed on modals)
 - `[everinstagram]`: Display your latest Instagram photos.
 - `[nativecontact]`: Embed the native PrestaShop contact form.
-- `[everimg name="image.jpg" class="img-fluid"]`: Display one or more CMS images.
+- `[everimg name="image.jpg" class="img-fluid" carousel=true]`: Display one or more CMS images. When `carousel=true` and multiple images are provided, a Bootstrap slideshow is rendered.
 - `[displayQcdSvg name="icon" class="myclass" inline=true]`: Display a QCD SVG icon. Module available at [410 Gone](https://www.410-gone.fr/).
 - `[qcdacf field objectType objectId]`: Display a value from QCD ACF fields. Module available at [410 Gone](https://www.410-gone.fr/).
 - `[widget moduleName="mymodule" hookName="displayHome"]`: Render another module's widget.

--- a/views/templates/hook/ever_img_carousel.tpl
+++ b/views/templates/hook/ever_img_carousel.tpl
@@ -1,0 +1,36 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *}
+{if isset($images) && $images}
+  <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
+    <div class="carousel-inner">
+      {foreach from=$images item=image key=key}
+        <div class="carousel-item{if $key == 0} active{/if}">
+          <img src="{$image.src}" class="{$image.class} d-block w-100" width="{$image.width}" height="{$image.height}" alt="{$image.alt}" loading="lazy">
+        </div>
+      {/foreach}
+    </div>
+    <a class="carousel-control-prev" href="#{$carousel_id}" role="button" data-slide="prev" data-bs-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only visually-hidden">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#{$carousel_id}" role="button" data-slide="next" data-bs-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only visually-hidden">Next</span>
+    </a>
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- allow `[everimg]` shortcode to create a Bootstrap carousel when `carousel=true`
- implement new Smarty template for the slideshow
- document new parameter in README

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `php -l models/EverblockTools.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684080cd12308322b2586bbe20b7360e