### PR TITLE
Allow overriding contact field template

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ A contact form must start with the shortcode `[evercontactform_open]` and end wi
 - `[evercontact type="sento" label="me@email.fr"]` to display the recipient's email in a coded way. The recipient's email will not be clearly displayed on the pages. Not using this means sending the email to the email address defined in your store by default. You can specify multiple emails by separating them with commas. Be sure to use the EI Captcha module to secure email sending.
 - `[evercontact type="submit" label="Submit"]` to display a submit button for your custom contact form
 
+The HTML for each `[evercontact]` field is rendered through the `contact_field.tpl` template located in `views/templates/hook`.  
+Copy this file into your theme (`/themes/your_theme/modules/everblock/views/templates/hook/`) to customize the markup.
+
 No emails are saved on your store.
 A contact form can be added in a block used as a modal.
 

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -104,10 +104,10 @@ class EverblockTools extends ObjectModel
             $txt = static::getNativeContactShortcode($txt, $context, $module);
         }
         if (strpos($txt, '[evercontactform_open]') !== false) {
-            $txt = static::getFormShortcode($txt);
+            $txt = static::getFormShortcode($txt, $context, $module);
         }
         if (strpos($txt, '[everorderform_open]') !== false) {
-            $txt = static::getOrderFormShortcode($txt);
+            $txt = static::getOrderFormShortcode($txt, $context, $module);
         }
         if (strpos($txt, '[random_product') !== false) {
             $txt = static::getRandomProductsShortcode($txt, $context, $module);
@@ -735,7 +735,11 @@ class EverblockTools extends ObjectModel
         return $txt;
     }
 
-    public static function generateFormFromShortcode(string $shortcode)
+    public static function generateFormFromShortcode(
+        string $shortcode,
+        Context $context,
+        Everblock $module
+    )
     {
         preg_match_all('/(\w+)\s*=\s*"([^"]+)"|(\w+)\s*=\s*([^"\s,]+)/', $shortcode, $matches, PREG_SET_ORDER);
         $attributes = [];
@@ -748,126 +752,22 @@ class EverblockTools extends ObjectModel
             $attributes[$attribute_name] = $attribute_value;
         }
 
-        $field_type = htmlspecialchars($attributes['type'], ENT_QUOTES);
-        $label = htmlspecialchars($attributes['label'], ENT_QUOTES);
-        $valueAttribute = isset($attributes['value']) ? ' value="' . htmlspecialchars($attributes['value'], ENT_QUOTES) . '"' : '';
-        $template = '';
-        $isRequired = isset($attributes['required']) && strtolower($attributes['required']) === 'true';
+        $field = [
+            'type' => htmlspecialchars($attributes['type'], ENT_QUOTES),
+            'label' => htmlspecialchars($attributes['label'], ENT_QUOTES),
+            'value' => $attributes['value'] ?? null,
+            'values' => isset($attributes['values']) ? explode(',', $attributes['values']) : [],
+            'required' => isset($attributes['required']) && strtolower($attributes['required']) === 'true',
+            'unique' => ++$uniqueIdentifier,
+        ];
 
-        switch ($field_type) {
-            case 'sento':
-                $template = '<input type="hidden" name="everHide" value="' . base64_encode($label) . '">';
-                break;
+        $context->smarty->assign('field', $field);
+        $templatePath = static::getTemplatePath('hook/contact_field.tpl', $module);
 
-            case 'password':
-            case 'tel':
-            case 'email':
-            case 'datetime-local':
-            case 'date':
-            case 'text':
-            case 'number':
-                $template = '<div class="form-group mb-4"><label for="' . $label . '" class="d-none">' . $label . '</label>';
-                $template .= '<input type="' . $field_type . '" class="form-control" name="' . $label . '" id="' . $label . '" placeholder="' . $label . '"' . $valueAttribute;
-                if ($isRequired) {
-                    $template .= ' required';
-                }
-                $template .= '></div>';
-                break;
-
-            case 'textarea':
-                $textareaValue = htmlspecialchars($attributes['value'] ?? '', ENT_QUOTES);
-                $template = '<div class="form-group mb-4"><label for="' . $label . '" class="d-none">' . $label . '</label>';
-                $template .= '<textarea class="form-control" name="' . $label . '" id="' . $label . '" placeholder="' . $label . '"';
-                if ($isRequired) {
-                    $template .= ' required';
-                }
-                $template .= '>' . $textareaValue . '</textarea></div>';
-                break;
-
-            case 'select':
-                $values = explode(",", $attributes['values']);
-                $selectedValue = $attributes['value'] ?? null;
-                $template = '<div class="form-group mb-4"><label for="' . $label . '" class="d-none">' . $label . '</label>';
-                $template .= '<select class="form-control" name="' . $label . '" id="' . $label . '"';
-                if ($isRequired) {
-                    $template .= ' required';
-                }
-                $template .= '>';
-                $template .= '<option value="" disabled selected>' . $label . '</option>';
-                foreach ($values as $value) {
-                    $trimmedValue = trim($value);
-                    $selected = ($trimmedValue === $selectedValue) ? ' selected' : '';
-                    $template .= '<option value="' . $trimmedValue . '"' . $selected . '>' . $trimmedValue . '</option>';
-                }
-                $template .= '</select></div>';
-                break;
-
-            case 'radio':
-                $values = explode(",", $attributes['values']);
-                $selectedValue = $attributes['value'] ?? null;
-                $template = '<div class="form-group mb-4"><label>' . $label . '</label><div class="form-check">';
-                foreach ($values as $value) {
-                    $uniqueIdentifier++;
-                    $radioId = 'radio_' . $uniqueIdentifier;
-                    $trimmedValue = trim($value);
-                    $checked = ($trimmedValue === $selectedValue) ? ' checked' : '';
-                    $template .= '<div class="form-check-inline">';
-                    $template .= '<input type="radio" class="form-check-input" name="' . $label . '" value="' . $trimmedValue . '" id="' . $radioId . '"' . $checked;
-                    if ($isRequired) {
-                        $template .= ' required';
-                    }
-                    $template .= '>';
-                    $template .= '<label class="form-check-label" for="' . $radioId . '">' . $trimmedValue . '</label></div>';
-                }
-                $template .= '</div></div>';
-                break;
-
-            case 'checkbox':
-                $values = explode(",", $attributes['values']);
-                $checkedValues = isset($attributes['value']) ? explode(",", $attributes['value']) : [];
-                $template = '<div class="form-group mb-4"><label class="d-none">' . $label . '</label><div class="form-check">';
-                foreach ($values as $value) {
-                    $uniqueIdentifier++;
-                    $checkboxId = 'checkbox_' . $uniqueIdentifier;
-                    $trimmedValue = trim($value);
-                    $checked = in_array($trimmedValue, $checkedValues) ? ' checked' : '';
-                    $template .= '<div class="form-check-inline">';
-                    $template .= '<input type="checkbox" class="form-check-input" name="' . $label . '[]" value="' . $trimmedValue . '" id="' . $checkboxId . '"' . $checked;
-                    if ($isRequired) {
-                        $template .= ' required';
-                    }
-                    $template .= '>';
-                    $template .= '<label class="form-check-label" for="' . $checkboxId . '">' . $trimmedValue . '</label></div>';
-                }
-                $template .= '</div></div>';
-                break;
-
-            case 'file':
-                $template = '<div class="form-group mb-4"><label for="' . $label . '" class="d-none">' . $label . '</label>';
-                $template .= '<input type="file" class="form-control-file" name="' . $label . '" id="' . $label . '"';
-                if ($isRequired) {
-                    $template .= ' required';
-                }
-                $template .= '></div>';
-                break;
-
-            case 'submit':
-                $template = '<button type="submit" class="btn btn-primary evercontactsubmit">' . $label . '</button>';
-                break;
-
-            case 'hidden':
-                $template = '<input type="hidden" name="hidden" value="' . $label . '">';
-                break;
-
-            default:
-                $template = '';
-                break;
-        }
-
-        return $template;
+        return $context->smarty->fetch($templatePath);
     }
 
-    public static function getFormShortcode(string $txt): string
+    public static function getFormShortcode(string $txt, Context $context, Everblock $module): string
     {
         // Remplace [evercontactform_open] par le formulaire ouvrant
         $txt = str_replace(
@@ -886,21 +786,21 @@ class EverblockTools extends ObjectModel
 
         // Recherche et remplace tous les shortcodes [evercontact ...]
         $pattern = '/\[evercontact\s[^\]]+\]/';
-        $result = preg_replace_callback($pattern, function ($matches) {
-            return static::generateFormFromShortcode($matches[0]);
+        $result = preg_replace_callback($pattern, function ($matches) use ($context, $module) {
+            return static::generateFormFromShortcode($matches[0], $context, $module);
         }, $txt);
 
         return $result;
     }
 
-    public static function getOrderFormShortcode(string $txt): string
+    public static function getOrderFormShortcode(string $txt, Context $context, Everblock $module): string
     {
         $txt = str_replace('[everorderform_open]', '<div class="container">', $txt);
         $txt = str_replace('[everorderform_close]', '</div>', $txt);
         $pattern = '/\[everorderform\s[^\]]+\]/';
-        $result = preg_replace_callback($pattern, function ($matches) {
+        $result = preg_replace_callback($pattern, function ($matches) use ($context, $module) {
             // $matches[0] contient le shortcode trouvé
-            return static::generateFormFromShortcode($matches[0]);
+            return static::generateFormFromShortcode($matches[0], $context, $module);
         }, $txt);
         return $result;
     }

--- a/views/templates/hook/contact_field.tpl
+++ b/views/templates/hook/contact_field.tpl
@@ -1,0 +1,86 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{assign var="type" value=$field.type}
+{assign var="label" value=$field.label}
+{assign var="required" value=$field.required}
+{assign var="values" value=$field.values}
+{assign var="value" value=$field.value}
+{assign var="unique" value=$field.unique}
+
+{if $type == 'sento'}
+  <input type="hidden" name="everHide" value="{$label|base64_encode}">
+{elseif in_array($type, ['password','tel','email','datetime-local','date','text','number'])}
+  <div class="form-group mb-4">
+    <label for="{$label}" class="d-none">{$label}</label>
+    <input type="{$type}" class="form-control" name="{$label}" id="{$label}" placeholder="{$label}"{if $value} value="{$value|escape:'htmlall':'UTF-8'}"{/if}{if $required} required{/if}>
+  </div>
+{elseif $type == 'textarea'}
+  <div class="form-group mb-4">
+    <label for="{$label}" class="d-none">{$label}</label>
+    <textarea class="form-control" name="{$label}" id="{$label}" placeholder="{$label}"{if $required} required{/if}>{$value|escape:'htmlall':'UTF-8'}</textarea>
+  </div>
+{elseif $type == 'select'}
+  <div class="form-group mb-4">
+    <label for="{$label}" class="d-none">{$label}</label>
+    <select class="form-control" name="{$label}" id="{$label}"{if $required} required{/if}>
+      <option value="" disabled selected>{$label}</option>
+      {foreach from=$values item=val}
+        {assign var='trimmed' value=$val|trim}
+        <option value="{$trimmed}"{if $value == $trimmed} selected{/if}>{$trimmed}</option>
+      {/foreach}
+    </select>
+  </div>
+{elseif $type == 'radio'}
+  <div class="form-group mb-4">
+    <label>{$label}</label>
+    <div class="form-check">
+      {foreach from=$values item=val}
+        {assign var='trimmed' value=$val|trim}
+        {assign var='radioId' value="radio_`$unique`_`$trimmed`"}
+        <div class="form-check-inline">
+          <input type="radio" class="form-check-input" name="{$label}" value="{$trimmed}" id="{$radioId}"{if $value == $trimmed} checked{/if}{if $required} required{/if}>
+          <label class="form-check-label" for="{$radioId}">{$trimmed}</label>
+        </div>
+      {/foreach}
+    </div>
+  </div>
+{elseif $type == 'checkbox'}
+  <div class="form-group mb-4">
+    <label class="d-none">{$label}</label>
+    <div class="form-check">
+      {assign var='checkedValues' value=","|explode:$value}
+      {foreach from=$values item=val}
+        {assign var='trimmed' value=$val|trim}
+        {assign var='checkboxId' value="checkbox_`$unique`_`$trimmed`"}
+        <div class="form-check-inline">
+          <input type="checkbox" class="form-check-input" name="{$label}[]" value="{$trimmed}" id="{$checkboxId}"{if in_array($trimmed,$checkedValues)} checked{/if}{if $required} required{/if}>
+          <label class="form-check-label" for="{$checkboxId}">{$trimmed}</label>
+        </div>
+      {/foreach}
+    </div>
+  </div>
+{elseif $type == 'file'}
+  <div class="form-group mb-4">
+    <label for="{$label}" class="d-none">{$label}</label>
+    <input type="file" class="form-control-file" name="{$label}" id="{$label}"{if $required} required{/if}>
+  </div>
+{elseif $type == 'submit'}
+  <button type="submit" class="btn btn-primary evercontactsubmit">{$label}</button>
+{elseif $type == 'hidden'}
+  <input type="hidden" name="hidden" value="{$label}">
+{/if}


### PR DESCRIPTION
## Summary
- render contact fields through a Smarty template
- expose new `contact_field.tpl` so themes can override it
- document how to override the contact field template

## Testing
- `php` not available, could not run PHP lint or tests

------
https://chatgpt.com/codex/tasks/task_e_684080fa83788322a74562326881cd37