### PR TITLE
Improve admin UX

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -514,6 +514,7 @@ class Everblock extends Module
             'hook_admin_link' => $hookAdminLink,
             'shortcode_admin_link' => $shortcodeAdminLink,
             'cron_links' => $cronLinks,
+            'modules_list_link' => $this->context->link->getAdminLink('AdminModules'),
         ]);
         $this->html .= $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/header.tpl'

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -17,8 +17,8 @@
 *}
 
 <div class="alert alert-info">
-    <button class="btn btn-info btn-lg" type="button" data-toggle="collapse" data-target="#instructionsContent" aria-expanded="false" aria-controls="instructionsContent">
-        Instructions
+    <button class="btn btn-primary btn-lg mb-2" type="button" data-toggle="collapse" data-target="#instructionsContent" aria-expanded="false" aria-controls="instructionsContent">
+        <i class="icon-info-circle"></i> {l s='Instructions' mod='everblock'}
     </button>
     <div class="collapse" id="instructionsContent">
         <div class="card card-body">

--- a/views/templates/admin/customerConnect.tpl
+++ b/views/templates/admin/customerConnect.tpl
@@ -23,7 +23,12 @@
     <div class="bootstrap cardbody everblock">
         <div class="panel-heading">
         {if isset($login_link) && $login_customer}
-        <p><a href="{$login_link|escape:'htmlall':'UTF-8'}" target="_blank" class="btn btn-info btn-lg"><strong>{l s='Click here to log as' mod='everblock'} {$login_customer->firstname|escape:'htmlall':'UTF-8'} {$login_customer->lastname|escape:'htmlall':'UTF-8'}</strong></a></p>
+        <p>
+            <a href="{$login_link|escape:'htmlall':'UTF-8'}" target="_blank" class="btn btn-primary">
+                <i class="icon-user"></i>
+                {l s='Log in as' mod='everblock'} {$login_customer->firstname|escape:'htmlall':'UTF-8'} {$login_customer->lastname|escape:'htmlall':'UTF-8'}
+            </a>
+        </p>
         {/if}
         </div>
     </div>

--- a/views/templates/admin/footer.tpl
+++ b/views/templates/admin/footer.tpl
@@ -16,19 +16,24 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 
-<div class="panel">
+<div class="panel everblock-footer text-center">
     <h3><i class="icon icon-smile"></i> {l s='Ever Block' mod='everblock'}</h3>
-    <a href="#everlogotop">
-        <img id="everlogobottom" src="{$everblock_dir|escape:'htmlall':'UTF-8'}logo.png" style="max-width: 120px;">
+    <a href="#everlogotop" class="d-block mb-2">
+        <img id="everlogobottom" class="img-fluid" src="{$everblock_dir|escape:'htmlall':'UTF-8'}logo.png" alt="{l s='Ever Block logo' mod='everblock'}" style="max-width: 120px;" />
     </a>
     <p>
         <strong>{l s='Thank you for your confidence :-)' mod='everblock'}</strong><br />
         {l s='Feel free to contact us for more support or help' mod='everblock'}
     </p>
+    <p class="mt-2">
+        <a href="#everlogotop" class="btn btn-default">
+            <i class="process-icon-arrow-up" aria-hidden="true"></i> {l s='Back to top' mod='everblock'}
+        </a>
+    </p>
     {if isset($cron_links) && $cron_links}
     <div class="panel">
         <div class="row">
-            <div class="col-md-12 mt-3">            
+            <div class="col-md-12 mt-3">
                 {foreach from=$cron_links key=action item=cron}
                 <a href="{$cron|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-info" target="_blank">{l s='Cron for' mod='everblock'} {$action}</a>
                 {/foreach}

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -15,24 +15,42 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div class="panel row">
-    <h3><i class="icon icon-smile"></i> {l s='Ever Block' mod='everblock'} {$everblock_version|escape:'htmlall':'UTF-8'}</h3>
-    <div class="col-md-12">
+<div class="panel row everblock-header">
+    <div class="col-md-8">
+        <h3 class="mb-3">
+            <i class="icon icon-smile"></i>
+            {l s='Ever Block' mod='everblock'} {$everblock_version|escape:'htmlall':'UTF-8'}
+        </h3>
         <a href="#everlogobottom">
-          <img id="everlogotop" src="{$everblock_dir|escape:'htmlall':'UTF-8'}logo.png" style="max-width: 120px;">
+            <img id="everlogotop" class="img-fluid" src="{$everblock_dir|escape:'htmlall':'UTF-8'}logo.png" alt="{l s='Ever Block logo' mod='everblock'}" style="max-width: 120px;" />
         </a>
-        <p>{l s='Thanks for using Team Ever\'s modules' mod='everblock'}<br /></p>
+        <p class="mt-2">{l s='Thanks for using Team Ever\'s modules' mod='everblock'}<br /></p>
+    </div>
+    <div class="col-md-4 text-right mt-3">
+        {if isset($modules_list_link)}
+            <a href="{$modules_list_link|escape:'htmlall':'UTF-8'}" class="btn btn-default">
+                <i class="process-icon-back"></i> {l s='Back to modules' mod='everblock'}
+            </a>
+        {/if}
         {if isset($block_admin_link) && $block_admin_link}
-        <a href="{$block_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-success">{l s='Manage blocks' mod='everblock'}</a>
+            <a href="{$block_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-success">
+                {l s='Manage blocks' mod='everblock'}
+            </a>
         {/if}
         {if isset($faq_admin_link) && $faq_admin_link}
-        <a href="{$faq_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-success">{l s='Manage FAQ' mod='everblock'}</a>
+            <a href="{$faq_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-success">
+                {l s='Manage FAQ' mod='everblock'}
+            </a>
         {/if}
         {if isset($hook_admin_link) && $hook_admin_link}
-        <a href="{$hook_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-success">{l s='Manage all hooks' mod='everblock'}</a>
+            <a href="{$hook_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-success">
+                {l s='Manage all hooks' mod='everblock'}
+            </a>
         {/if}
         {if isset($shortcode_admin_link) && $shortcode_admin_link}
-        <a href="{$shortcode_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-success">{l s='Manage shortcodes' mod='everblock'}</a>
+            <a href="{$shortcode_admin_link|escape:'htmlall':'UTF-8'}" class="btn btn-success">
+                {l s='Manage shortcodes' mod='everblock'}
+            </a>
         {/if}
     </div>
 </div>

--- a/views/templates/admin/productTab.tpl
+++ b/views/templates/admin/productTab.tpl
@@ -18,7 +18,7 @@
 <div id="everblock" class="panel">
     <fieldset class="form-group">
         {foreach from=$tabsData key=tabNumber item=everpstabs}
-        <div class="container">
+        <div class="container border rounded p-3 mb-3">
             <div class="row">
                 <div class="col-lg-12 col-xl-12">
                     <input type="hidden" name="{$tabNumber|escape:'htmlall':'UTF-8'}_everblock_id" value="{if isset($everpstabs->id_tab) && $everpstabs->id_tab}{$everpstabs->id_tab|escape:'htmlall':'UTF-8'}{/if}">
@@ -40,7 +40,7 @@
         {/foreach}
 
         {foreach from=$flagsData key=flagNumber item=everpsflags}
-        <div class="container">
+        <div class="container border rounded p-3 mb-3">
             <div class="row">
                 <div class="col-lg-12 col-xl-12">
                     <input type="hidden" name="{$flagNumber|escape:'htmlall':'UTF-8'}_everflag_id" value="{if isset($everpsflags->id_flag) && $everpsflags->id_flag}{$everpsflags->id_flag|escape:'htmlall':'UTF-8'}{/if}">

--- a/views/templates/admin/upgrade.tpl
+++ b/views/templates/admin/upgrade.tpl
@@ -19,7 +19,10 @@
     <div class="panel-body">
         <div class="col-12 col-xs-12 col-lg-12">
             <p class="alert alert-warning">
-                {l s='An upgrade for Ever Block is available on our shop. Please check' mod='everblock'} <a href="https://www.team-ever.com" target="_blank">https://www.team-ever.com</a> {l s='to get latest version of this module' mod='everblock'}
+                {l s='An upgrade for Ever Block is available on our shop.' mod='everblock'}
+                <a class="btn btn-warning ml-2" href="https://www.team-ever.com" target="_blank">
+                    {l s='Get latest version' mod='everblock'}
+                </a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show link back to module list in admin header
- add scroll-to-top link in footer
- add info icon style for instructions toggle
- style upgrade alert as button
- style customer-connect and product-tab templates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840813b794883229ba79dd49415cc4a