### PR TITLE
Add new cart and newsletter shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[last-products 4]`: Display the last 4 products listed in the store. Supports `carousel=true`.
 - `[best-sales 4]`: Display the 4 best-selling products in your store. Supports `carousel=true`.
 - `[evercart]`: Display dropdown cart.
+- `[cart_total]`: Display the total value of the current cart.
+- `[cart_quantity]`: Display the number of products currently in the cart.
+- `[newsletter_form]`: Display the PrestaShop newsletter subscription form.
 - `[evercontact]`: Display PrestaShop native contact form.
 - `[everstore 4]`: Display store information for store ID 4 (several IDs can be separated with commas).
 - `[video https://www.youtube.com/embed/35kwlY_RR08?si=QfwsUt9sEukni0Gj]`: Display a YouTube iframe of the video whose sharing URL is in the parameter (may also works with Vimeo, Dailymotion, and Vidyard).

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -100,6 +100,15 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[evercart]') !== false) {
             $txt = static::getCartShortcode($txt, $context, $module);
         }
+        if (strpos($txt, '[cart_total]') !== false) {
+            $txt = static::getCartTotalShortcode($txt, $context);
+        }
+        if (strpos($txt, '[cart_quantity]') !== false) {
+            $txt = static::getCartQuantityShortcode($txt, $context);
+        }
+        if (strpos($txt, '[newsletter_form]') !== false) {
+            $txt = static::getNewsletterFormShortcode($txt, $context, $module);
+        }
         if (strpos($txt, '[nativecontact]') !== false) {
             $txt = static::getNativeContactShortcode($txt, $context, $module);
         }
@@ -938,6 +947,39 @@ class EverblockTools extends ObjectModel
         $templatePath = static::getTemplatePath('hook/cart.tpl', $module);
         $replacement = $context->smarty->fetch($templatePath);
         $txt = str_replace('[evercart]', $replacement, $txt);
+        return $txt;
+    }
+
+    public static function getCartTotalShortcode(string $txt, Context $context): string
+    {
+        $total = 0;
+        if (isset($context->cart) && $context->cart->id) {
+            $total = $context->cart->getOrderTotal(true, Cart::BOTH);
+        }
+        $formatted = Tools::displayPrice($total, $context->currency);
+        $txt = str_replace('[cart_total]', $formatted, $txt);
+        return $txt;
+    }
+
+    public static function getCartQuantityShortcode(string $txt, Context $context): string
+    {
+        $quantity = 0;
+        if (isset($context->cart) && $context->cart->id) {
+            $quantity = (int) $context->cart->getProductsQuantity();
+        }
+        $txt = str_replace('[cart_quantity]', (string) $quantity, $txt);
+        return $txt;
+    }
+
+    public static function getNewsletterFormShortcode(string $txt, Context $context, Everblock $module): string
+    {
+        if (Module::isInstalled('ps_emailsubscription') && Module::isEnabled('ps_emailsubscription')) {
+            $newsletter = Module::getInstanceByName('ps_emailsubscription');
+            if (method_exists($newsletter, 'renderWidget')) {
+                $replacement = $newsletter->renderWidget('displayFooter', []);
+                $txt = str_replace('[newsletter_form]', $replacement, $txt);
+            }
+        }
         return $txt;
     }
 


### PR DESCRIPTION
## Summary
- add `[cart_total]`, `[cart_quantity]` and `[newsletter_form]` shortcodes
- document new shortcodes in README

## Testing
- `php -l models/EverblockTools.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840875e1d588322ae263e377a3ce604