### PR TITLE
Add crossselling carousel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[best-sales 10 carousel=true]`: Displays the top ten best-selling products. Optional parameters: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Displays ten random products in a carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Displays products linked to the current product in a Bootstrap carousel.
+- `[crossselling nb=4 orderby="id_product" orderway="asc" carousel=true]`: Show accessories of products currently in the cart. `carousel` parameter makes them display in a carousel. Falls back to best sellers if none found.
 - `{hook h='displayHome'}`: Displays the `displayHome` hook (hooks are not allowed on modals)
 - `[everinstagram]`: Display your latest Instagram photos.
 - `[nativecontact]`: Embed the native PrestaShop contact form.
@@ -299,6 +300,7 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[best-sales 10 carousel=true]` : Affiche les dix meilleures ventes. Paramètres optionnels : `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]` : Affiche dix produits aléatoires en carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]` : Affiche les produits liés au produit courant en carousel Bootstrap.
+- `[crossselling nb=4 orderby="id_product" orderway="asc" carousel=true]` : Affiche les accessoires des produits du panier. Utilisez `carousel=true` pour les afficher en carrousel. Si aucun résultat, les meilleures ventes sont proposées.
 - `{hook h='displayHome'}` : Affiche le hook `displayHome` (les hooks ne sont pas autorisés dans les modales)
 - `[everinstagram]` : Affiche vos dernières photos Instagram.
 - `[nativecontact]` : Intègre le formulaire de contact natif PrestaShop.
@@ -472,6 +474,7 @@ Puedes crear tus propios shortcodes desde la pestaña "Shortcodes" disponible en
 - `[best-sales 10 carousel=true]`: Muestra los diez productos más vendidos. Parámetros opcionales: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Muestra diez productos aleatorios en carrusel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Muestra productos relacionados con el producto actual en un carrusel Bootstrap.
+- `[crossselling nb=4 orderby="id_product" orderway="asc" carousel=true]`: Muestra accesorios de los productos del carrito. Usa `carousel=true` para mostrarlos en carrusel. Si no hay resultados se proponen los más vendidos.
 - `{hook h='displayHome'}`: Muestra el hook `displayHome` (los hooks no están permitidos en modales)
 - `[everinstagram]`: Muestra tus últimas fotos de Instagram.
 - `[nativecontact]`: Inserta el formulario de contacto nativo de PrestaShop.
@@ -645,6 +648,7 @@ Puoi creare i tuoi shortcode dalla scheda "Shortcodes" nel sottomenu "Ever block
 - `[best-sales 10 carousel=true]`: Mostra i dieci prodotti più venduti. Parametri opzionali: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Mostra dieci prodotti casuali in carosello.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Mostra i prodotti collegati a quello attuale in un carosello Bootstrap.
+- `[crossselling nb=4 orderby="id_product" orderway="asc" carousel=true]`: Mostra gli accessori dei prodotti presenti nel carrello. Usa `carousel=true` per mostrarli in un carosello. Se non ci sono risultati vengono mostrati i più venduti.
 - `{hook h='displayHome'}`: Mostra l'hook `displayHome` (gli hook non sono consentiti nelle modali)
 - `[everinstagram]`: Mostra le ultime foto di Instagram.
 - `[nativecontact]`: Inserisce il modulo di contatto nativo di PrestaShop.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -124,6 +124,9 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[linkedproducts') !== false) {
             $txt = static::getLinkedProductsShortcode($txt, $context, $module);
         }
+        if (strpos($txt, '[crossselling') !== false) {
+            $txt = static::getCrossSellingShortcode($txt, $context, $module);
+        }
         if (strpos($txt, '[widget') !== false) {
             $txt = $txt = static::getWidgetShortcode($txt);
         }
@@ -141,6 +144,93 @@ class EverblockTools extends ObjectModel
             $txt = static::obfuscateTextByClass($txt);
         }
         $txt = static::renderSmartyVars($txt, $context);
+        return $txt;
+    }
+
+    public static function getCrossSellingShortcode(string $txt, Context $context, Everblock $module): string
+    {
+        if (!$context->cart || !$context->cart->id) {
+            return $txt;
+        }
+
+        preg_match_all(
+            '/\[crossselling(?:\s+nb="?(\d+)"?)?(?:\s+carousel="?(true|false)"?)?(?:\s+orderby="?(\w+)"?)?(?:\s+orderway="?(ASC|DESC)"?)?\]/i',
+            $txt,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $limit = isset($match[1]) ? (int) $match[1] : 4;
+            $carousel = isset($match[2]) && $match[2] === 'true';
+            $orderBy = isset($match[3]) ? strtolower($match[3]) : 'id_product';
+            $orderWay = isset($match[4]) ? strtoupper($match[4]) : 'ASC';
+
+            $allowedOrderBy = ['id_product', 'price', 'name', 'date_add', 'position'];
+            $allowedOrderWay = ['ASC', 'DESC'];
+            if (!in_array($orderBy, $allowedOrderBy)) {
+                $orderBy = 'id_product';
+            }
+            if (!in_array($orderWay, $allowedOrderWay)) {
+                $orderWay = 'ASC';
+            }
+
+            $cartIds = array_map(fn($p) => (int) $p['id_product'], $context->cart->getProducts());
+            if (empty($cartIds)) {
+                continue;
+            }
+
+            $cacheId = 'getCrossSellingShortcode_' . md5(json_encode([$cartIds, $limit, $orderBy, $orderWay, $carousel]));
+            if (!EverblockCache::isCacheStored($cacheId)) {
+                $sql = new DbQuery();
+                $sql->select('DISTINCT p.id_product');
+                $sql->from('accessory', 'a');
+                $sql->innerJoin('product', 'p', 'p.id_product = a.id_product_2');
+                $sql->where('a.id_product_1 IN (' . implode(',', $cartIds) . ')');
+                $sql->where('p.active = 1');
+                $sql->orderBy('p.' . pSQL($orderBy) . ' ' . pSQL($orderWay));
+                $sql->limit($limit * 2);
+                $productIds = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+                EverblockCache::cacheStore($cacheId, $productIds);
+            } else {
+                $productIds = EverblockCache::cacheRetrieve($cacheId);
+            }
+
+            $ids = [];
+            foreach ($productIds as $row) {
+                $id = (int) $row['id_product'];
+                if (!in_array($id, $cartIds) && !in_array($id, $ids)) {
+                    $ids[] = $id;
+                }
+                if (count($ids) >= $limit) {
+                    break;
+                }
+            }
+
+            if (empty($ids)) {
+                $shortcode = '[best-sales nb=' . $limit . ' orderby=' . $orderBy . ' orderway=' . $orderWay;
+                if ($carousel) {
+                    $shortcode .= ' carousel=true';
+                }
+                $shortcode .= ']';
+                $replacement = static::getBestSalesShortcode($shortcode, $context, $module);
+                $txt = str_replace($match[0], $replacement, $txt);
+                continue;
+            }
+
+            $everPresentProducts = static::everPresentProducts($ids, $context);
+
+            if (!empty($everPresentProducts)) {
+                $context->smarty->assign([
+                    'everPresentProducts' => $everPresentProducts,
+                    'carousel' => $carousel,
+                ]);
+                $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
+                $replacement = $context->smarty->fetch($templatePath);
+                $txt = str_replace($match[0], $replacement, $txt);
+            }
+        }
+
         return $txt;
     }
 


### PR DESCRIPTION
## Summary
- support `carousel=true` for `[crossselling]` shortcode
- document carousel usage in README
- fix shortcode spelling

## Testing
- `php -l models/EverblockTools.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abb283eb083228cd46cd7cc1e610b