### PR TITLE
Limit picture tags to module webp images

### DIFF
--- a/views/templates/hook/displayEverModel.tpl
+++ b/views/templates/hook/displayEverModel.tpl
@@ -4,7 +4,11 @@
         <div class="card-body row">
             <div class="col-12 col-md-6 d-flex align-items-center justify-content-center">
                 <a href="{$ever_model.url}" title="{$ever_model.name|escape:'htmlall'}">
-                    <img class="img-fluid mx-auto" src="{$ever_model.cover.bySize.medium_default.url}" alt="{$ever_model.name|escape:'htmlall'}" />
+                    <picture>
+                      <source srcset="{$ever_model.cover.bySize.medium_default.url}" type="image/webp">
+                      <source srcset="{$ever_model.cover.bySize.medium_default.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                      <img class="img-fluid mx-auto" src="{$ever_model.cover.bySize.medium_default.url|replace:'.webp':'.jpg'}" alt="{$ever_model.name|escape:'htmlall'}" loading="lazy" />
+                    </picture>
                 </a>
             </div>
             <div class="col-12 col-md-6">

--- a/views/templates/hook/ever_img_carousel.tpl
+++ b/views/templates/hook/ever_img_carousel.tpl
@@ -20,7 +20,11 @@
     <div class="carousel-inner">
       {foreach from=$images item=image key=key}
         <div class="carousel-item{if $key == 0} active{/if}">
-          <img src="{$image.src}" class="{$image.class} d-block w-100" width="{$image.width}" height="{$image.height}" alt="{$image.alt}" loading="lazy">
+          <picture>
+            <source srcset="{$image.src}" type="image/webp">
+            <source srcset="{$image.src|replace:'.webp':'.jpg'}" type="image/jpeg">
+            <img src="{$image.src|replace:'.webp':'.jpg'}" class="{$image.class} d-block w-100" width="{$image.width}" height="{$image.height}" alt="{$image.alt}" loading="lazy">
+          </picture>
         </div>
       {/foreach}
     </div>

--- a/views/templates/hook/instagram.tpl
+++ b/views/templates/hook/instagram.tpl
@@ -30,7 +30,11 @@
                            data-media-type="{if $img.is_video}video{else}image{/if}"
                            title="{if $img.is_video}{l s='Click to view full video' mod='everblock'}{else}{l s='Click to view full image' mod='everblock'}{/if}"
                         >
-                            <img {if $img.caption}alt="{$img.caption|escape:'html':'UTF-8'}"{/if} src="{$img.thumbnail|escape:'quotes':'UTF-8'}" loading="lazy" />
+                            <picture>
+                              <source srcset="{$img.thumbnail|escape:'quotes':'UTF-8'}" type="image/webp">
+                              <source srcset="{$img.thumbnail|replace:'.webp':'.jpg'|escape:'quotes':'UTF-8'}" type="image/jpeg">
+                              <img {if $img.caption}alt="{$img.caption|escape:'html':'UTF-8'}"{/if} src="{$img.thumbnail|replace:'.webp':'.jpg'|escape:'quotes':'UTF-8'}" loading="lazy" />
+                            </picture>
                         </span>
                         {if $img.is_video}
                             <video controls style="display: none; padding: 0; width: auto;" id="ever_insta_video_{$key+1|escape:'quotes':'UTF-8'}">

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -40,13 +40,17 @@
           <a href="{$category_link}" title="{$state.name}" class="d-block h-100 w-100 text-decoration-none text-white"{if $state.target_blank} target="_blank"{/if}>
         {/if}
           {if $state.image.url}
-            <img src="{$state.image.url}" 
-                 alt="{$state.name|escape:'htmlall'}"
-                 title="{$state.name|escape:'htmlall'}"
-                 class="img-fluid w-100 h-100 object-fit-cover"
-                 width="{$state.image_width}" 
-                 height="{$state.image_height}" 
-                 loading="lazy">
+            <picture>
+              <source srcset="{$state.image.url}" type="image/webp">
+              <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+              <img src="{$state.image.url|replace:'.webp':'.jpg'}"
+                   alt="{$state.name|escape:'htmlall'}"
+                   title="{$state.name|escape:'htmlall'}"
+                   class="img-fluid w-100 h-100 object-fit-cover"
+                   width="{$state.image_width}"
+                   height="{$state.image_height}"
+                   loading="lazy">
+            </picture>
           {/if}
 
         {if $state.name}

--- a/views/templates/hook/prettyblocks/prettyblock_gallery.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_gallery.tpl
@@ -33,8 +33,12 @@
                 
                 <div class="col-md-3" style="{if isset($state.padding_left) && $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_right) && $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_top) && $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_bottom) && $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_left) && $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_right) && $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_top) && $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_bottom) && $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
                     <div class="card">
-                        <img src="{$state.image.url}" class="img img-fluid card-img-top cursor-pointer lazyload" alt="{$state.name}" title="{$state.name}"
-                        data-toggle="modal" data-target="#imageModal-{$block.id_prettyblocks}" data-bs-toggle="modal" data-bs-target="#imageModal-{$block.id_prettyblocks}" data-src="{$state.image.url}" data-slide-to="{$key}" data-bs-slide-to="{$key}" loading="lazy">
+                        <picture>
+                          <source srcset="{$state.image.url}" type="image/webp">
+                          <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                          <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="img img-fluid card-img-top cursor-pointer lazyload" alt="{$state.name}" title="{$state.name}"
+                          data-toggle="modal" data-target="#imageModal-{$block.id_prettyblocks}" data-bs-toggle="modal" data-bs-target="#imageModal-{$block.id_prettyblocks}" data-src="{$state.image.url}" data-slide-to="{$key}" data-bs-slide-to="{$key}" loading="lazy">
+                        </picture>
                     </div>
                 </div>
                 

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -33,11 +33,15 @@
         {if isset($state.url) && $state.url}
           <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative">
         {/if}
-          <img src="{$state.banner.url}" 
-               {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
-               {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
-               {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
-               class="img img-fluid lazyload" loading="lazy">
+          <picture>
+            <source srcset="{$state.banner.url}" type="image/webp">
+            <source srcset="{$state.banner.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+            <img src="{$state.banner.url|replace:'.webp':'.jpg'}"
+                 {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
+                 {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
+                 {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
+                 class="img img-fluid lazyload" loading="lazy">
+          </picture>
 
           <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
             {if $state.text_highlight_1}

--- a/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
@@ -36,7 +36,11 @@
                   <a href="{$state.link}" title="{$state.name}" {if $state.target_blank}target="_blank"{/if} class="d-block">
                 {/if}
               {/if}
-                  <img src="{$state.image.url}" title="{$state.name}" alt="{$state.name}" class="img img-fluid lazyload" loading="lazy">
+                    <picture>
+                      <source srcset="{$state.image.url}" type="image/webp">
+                      <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                      <img src="{$state.image.url|replace:'.webp':'.jpg'}" title="{$state.name}" alt="{$state.name}" class="img img-fluid lazyload" loading="lazy">
+                    </picture>
               {if $state.link}
                 {if $state.obfuscate}
                   </span>

--- a/views/templates/hook/prettyblocks/prettyblock_layout.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_layout.tpl
@@ -58,13 +58,17 @@
       ">
 
           {if $state.image.url}
-            <img src="{$state.image.url}" 
-                 alt="{$state.name|escape:'htmlall'}"
-                 title="{$state.name|escape:'htmlall'}"
-                 class="img-fluid w-100 h-100 object-fit-cover"
-                 width="{$state.image_width}" 
-                 height="{$state.image_height}" 
-                 loading="lazy">
+            <picture>
+              <source srcset="{$state.image.url}" type="image/webp">
+              <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+              <img src="{$state.image.url|replace:'.webp':'.jpg'}"
+                   alt="{$state.name|escape:'htmlall'}"
+                   title="{$state.name|escape:'htmlall'}"
+                   class="img-fluid w-100 h-100 object-fit-cover"
+                   width="{$state.image_width}"
+                   height="{$state.image_height}"
+                   loading="lazy">
+            </picture>
           {/if}
 
           {if $state.content}

--- a/views/templates/hook/prettyblocks/prettyblock_overlay.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_overlay.tpl
@@ -22,9 +22,13 @@
     {/if}
         <div class="everblock-overlay">
             <div id="overlay-{$block.id_prettyblocks}" class="everblock-overlay">
-                  <div class="image-overlay-container">
-                      <img src="{$block.settings.image.url}" alt="{$block.settings.name}" title="{$block.settings.name}" class="lazyload" loading="lazy">
-                      <div class="overlay">
+                    <div class="image-overlay-container">
+                        <picture>
+                          <source srcset="{$block.settings.image.url}" type="image/webp">
+                          <source srcset="{$block.settings.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                          <img src="{$block.settings.image.url|replace:'.webp':'.jpg'}" alt="{$block.settings.name}" title="{$block.settings.name}" class="lazyload" loading="lazy">
+                        </picture>
+                        <div class="overlay">
                           {$block.settings.content nofilter}
                       </div>
                   </div>

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -33,9 +33,13 @@
         {if $state.text_color}color:{$state.text_color};{/if}
       ">
         {if $icon_url}
-          <div class="mb-2">
-            <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
-          </div>
+            <div class="mb-2">
+              <picture>
+                <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+              </picture>
+            </div>
         {/if}
 
         {if $state.title}

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
@@ -34,7 +34,11 @@
                     <div class="testimonial">
                         <div class="testimonial-author text-center">
                             <p class="author-name">{$state.name}</p>
-                            <img src="{$state.image.url}" alt="{$state.name}" title="{$state.name}" class="rounded-circle img img-fluid lazyload" loading="lazy" width="60">
+                            <picture>
+                              <source srcset="{$state.image.url}" type="image/webp">
+                              <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                              <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="rounded-circle img img-fluid lazyload" loading="lazy" width="60">
+                            </picture>
                         </div>
                         <div class="testimonial-content text-center">
                             <p>{$state.content nofilter}</p>

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -51,18 +51,26 @@
 
             {if $state.order == 'First image, then text'}
                 {if $state.image.url}
-                    <img src="{$state.image.url}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload mb-3"
-                        {if $state.image.width > 0} width="{$state.image.width}"{/if}
-                        {if $state.image.height > 0} height="{$state.image.height}"{/if} loading="lazy">
+                    <picture>
+                      <source srcset="{$state.image.url}" type="image/webp">
+                      <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                      <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload mb-3"
+                          {if $state.image.width > 0} width="{$state.image.width}"{/if}
+                          {if $state.image.height > 0} height="{$state.image.height}"{/if} loading="lazy">
+                    </picture>
                 {/if}
                 <div class="state-content">{$state.content nofilter}</div>
 
             {else}
                 <div class="state-content mb-3">{$state.content nofilter}</div>
                 {if $state.image.url}
-                    <img src="{$state.image.url}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
-                        {if $state.image.width > 0} width="{$state.image.width}"{/if}
-                        {if $state.image.height > 0} height="{$state.image.height}"{/if} loading="lazy">
+                    <picture>
+                      <source srcset="{$state.image.url}" type="image/webp">
+                      <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                      <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                          {if $state.image.width > 0} width="{$state.image.width}"{/if}
+                          {if $state.image.height > 0} height="{$state.image.height}"{/if} loading="lazy">
+                    </picture>
                 {/if}
             {/if}
 


### PR DESCRIPTION
## Summary
- revert picture tags in admin and templates where module does not supply WebP images
- keep `<picture>` blocks on front templates that load WebP through module methods

## Testing
- `grep -n "<picture>" -r views/templates | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684da6d4a178832283facfe51ee12df9