### PR TITLE
Add product highlight block

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3047,4 +3047,23 @@ class Everblock extends Module
             );
         }
     }
+
+    public function hookbeforeRenderingEverblockProductHighlight($params)
+    {
+        $product = false;
+        $settings = $params['block']['settings'];
+
+        if (isset($settings['id_product']) && (int) $settings['id_product'] > 0) {
+            $presented = EverblockTools::everPresentProducts([
+                (int) $settings['id_product'],
+            ], $this->context);
+            if (!empty($presented)) {
+                $product = reset($presented);
+            }
+        }
+
+        return [
+            'product' => $product,
+        ];
+    }
 }

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -134,6 +134,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $ctaTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cta.tpl';
             $sharerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_sharer.tpl';
             $linkListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_link_list.tpl';
+            $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -2237,6 +2238,75 @@ class EverblockPrettyBlocks extends ObjectModel
                 ],
                 'config' => [
                     'fields' => [
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            $blocks[] = [
+                'name' => $module->l('Product highlight'),
+                'description' => $module->l('Highlight one product with custom text'),
+                'code' => 'everblock_product_highlight',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $productHighlightTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'id_product' => [
+                            'type' => 'text',
+                            'label' => $module->l('Product ID'),
+                            'default' => '',
+                        ],
+                        'custom_text' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Custom text'),
+                            'default' => '',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -1,0 +1,19 @@
+{*
+ * Product highlight block
+*}
+{if $block.extra.product}
+  {assign var="product" value=$block.extra.product}
+  <div class="{if $block.settings.default.container}container{/if}">
+    {if $block.settings.default.container}<div class="row align-items-center">{/if}
+      <div class="col-12 col-md-6 mb-3 mb-md-0 text-center">
+        <img src="{$product.cover.bySize.large_default.url|replace:'.webp':'.jpg'}" alt="{$product.name|escape:'htmlall'}" class="img-fluid w-100" loading="lazy">
+      </div>
+      <div class="col-12 col-md-6 text-center text-md-start">
+        <div class="mb-2 text-danger"><i class="fa fa-heart me-2"></i>{l s='Coup de coeur du moment' mod='everblock'}</div>
+        <h3 class="h4">{$product.name}</h3>
+        {$block.settings.custom_text nofilter}
+        <a href="{$product.url}" class="btn btn-primary mt-3">{l s='Voir le produit' mod='everblock'}</a>
+      </div>
+    {if $block.settings.default.container}</div>{/if}
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- add template for prettyblock_product_highlight
- register new template path and block configuration
- load product data in hookbeforeRenderingEverblockProductHighlight

## Testing
- `php -l models/EverblockPrettyBlocks.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685101f8c1cc8322b7fc8fd386eb327d