### PR TITLE
Add hooks around shortcodes replacement

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -132,6 +132,22 @@ class Everblock extends Module
             $hook->description = 'This hook triggers after every block shortcode is rendered';
             $hook->save();
         }
+        // Hook BeforeRenderingShortcodes
+        if (!Hook::getIdByName('BeforeRenderingShortcodes')) {
+            $hook = new Hook();
+            $hook->name = 'BeforeRenderingShortcodes';
+            $hook->title = 'Before rendering shortcodes';
+            $hook->description = 'This hook triggers before shortcodes are rendered';
+            $hook->save();
+        }
+        // Hook AfterRenderingShortcodes
+        if (!Hook::getIdByName('AfterRenderingShortcodes')) {
+            $hook = new Hook();
+            $hook->name = 'AfterRenderingShortcodes';
+            $hook->title = 'After rendering shortcodes';
+            $hook->description = 'This hook triggers after shortcodes are rendered';
+            $hook->save();
+        }
         return (parent::install()
             && $this->registerHook('displayHeader')
             && $this->registerHook('actionAdminControllerSetMedia')
@@ -213,6 +229,20 @@ class Everblock extends Module
             $hook->name = 'actionEverBlockChangeShortcodeAfter';
             $hook->title = 'After block shortcodes are rendered';
             $hook->description = 'This hook triggers after every block shortcode is rendered';
+            $hook->save();
+        }
+        if (!Hook::getIdByName('BeforeRenderingShortcodes')) {
+            $hook = new Hook();
+            $hook->name = 'BeforeRenderingShortcodes';
+            $hook->title = 'Before rendering shortcodes';
+            $hook->description = 'This hook triggers before shortcodes are rendered';
+            $hook->save();
+        }
+        if (!Hook::getIdByName('AfterRenderingShortcodes')) {
+            $hook = new Hook();
+            $hook->name = 'AfterRenderingShortcodes';
+            $hook->title = 'After rendering shortcodes';
+            $hook->description = 'This hook triggers after shortcodes are rendered';
             $hook->save();
         }
         if (!Hook::getIdByName('displayBeforeStoreLocator')) {

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -29,6 +29,7 @@ class EverblockTools extends ObjectModel
 {
     public static function renderShortcodes(string $txt, Context $context, Everblock $module): string
     {
+        Hook::exec('BeforeRenderingShortcodes', ['html' => &$txt]);
         $controllerTypes = [
             'front',
             'modulefront',
@@ -144,6 +145,7 @@ class EverblockTools extends ObjectModel
             $txt = static::obfuscateTextByClass($txt);
         }
         $txt = static::renderSmartyVars($txt, $context);
+        Hook::exec('AfterRenderingShortcodes', ['html' => &$txt]);
         return $txt;
     }
 


### PR DESCRIPTION
## Summary
- move BeforeRenderingShortcodes/AfterRenderingShortcodes triggers next to `renderShortcodes`

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685102593cc08322a2b1ce014c8c4817