### PR TITLE
Update block size order

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -326,8 +326,16 @@ class AdminEverBlockController extends ModuleAdminController
         ];
         $bootstrapSizes = [
             [
-                'id_bootstrap' => 6,
-                'size' => $this->l('1/6')
+                'id_bootstrap' => 0,
+                'size' => $this->l('None')
+            ],
+            [
+                'id_bootstrap' => 1,
+                'size' => $this->l('100%')
+            ],
+            [
+                'id_bootstrap' => 2,
+                'size' => $this->l('1/2')
             ],
             [
                 'id_bootstrap' => 4,
@@ -338,16 +346,8 @@ class AdminEverBlockController extends ModuleAdminController
                 'size' => $this->l('1/4')
             ],
             [
-                'id_bootstrap' => 2,
-                'size' => $this->l('1/2')
-            ],
-            [
-                'id_bootstrap' => 1,
-                'size' => $this->l('100%')
-            ],
-            [
-                'id_bootstrap' => 0,
-                'size' => $this->l('None')
+                'id_bootstrap' => 6,
+                'size' => $this->l('1/6')
             ],
         ];
         $everblock_obj = $this->loadObject(true);


### PR DESCRIPTION
## Summary
- reorder bootstrap size options so 'None' and '100%' appear first

## Testing
- `php -l controllers/admin/AdminEverBlockController.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685252ddf84c83229cae7cf1a709f8e7