### PR TITLE
Improve cross selling shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[best-sales 10 carousel=true]`: Displays the top ten best-selling products. Optional parameters: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Displays ten random products in a carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Displays products linked to the current product in a Bootstrap carousel.
-- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Show accessories of products currently in the cart. Falls back to best sellers if none found.
+- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Show accessories of products currently in the cart. If needed, completes with items from the same categories before falling back to best sellers.
 - `{hook h='displayHome'}`: Displays the `displayHome` hook (hooks are not allowed on modals)
 - `[everinstagram]`: Display your latest Instagram photos.
 - `[nativecontact]`: Embed the native PrestaShop contact form.
@@ -305,7 +305,7 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[best-sales 10 carousel=true]` : Affiche les dix meilleures ventes. Paramètres optionnels : `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]` : Affiche dix produits aléatoires en carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]` : Affiche les produits liés au produit courant en carousel Bootstrap.
-- `[crosselling nb=4 orderby="id_product" orderway="asc"]` : Affiche les accessoires des produits du panier. Si aucun résultat, les meilleures ventes sont proposées.
+- `[crosselling nb=4 orderby="id_product" orderway="asc"]` : Affiche les accessoires des produits du panier. Si nécessaire, complète avec les articles des mêmes catégories puis affiche les meilleures ventes en dernier recours.
 - `{hook h='displayHome'}` : Affiche le hook `displayHome` (les hooks ne sont pas autorisés dans les modales)
 - `[everinstagram]` : Affiche vos dernières photos Instagram.
 - `[nativecontact]` : Intègre le formulaire de contact natif PrestaShop.
@@ -481,7 +481,7 @@ Puedes crear tus propios shortcodes desde la pestaña "Shortcodes" disponible en
 - `[best-sales 10 carousel=true]`: Muestra los diez productos más vendidos. Parámetros opcionales: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Muestra diez productos aleatorios en carrusel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Muestra productos relacionados con el producto actual en un carrusel Bootstrap.
-- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Muestra accesorios de los productos del carrito. Si no hay resultados se proponen los más vendidos.
+- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Muestra accesorios de los productos del carrito. Si es necesario, se completa con artículos de las mismas categorías y finalmente se muestran los más vendidos.
 - `{hook h='displayHome'}`: Muestra el hook `displayHome` (los hooks no están permitidos en modales)
 - `[everinstagram]`: Muestra tus últimas fotos de Instagram.
 - `[nativecontact]`: Inserta el formulario de contacto nativo de PrestaShop.
@@ -657,7 +657,7 @@ Puoi creare i tuoi shortcode dalla scheda "Shortcodes" nel sottomenu "Ever block
 - `[best-sales 10 carousel=true]`: Mostra i dieci prodotti più venduti. Parametri opzionali: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Mostra dieci prodotti casuali in carosello.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Mostra i prodotti collegati a quello attuale in un carosello Bootstrap.
-- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Mostra gli accessori dei prodotti presenti nel carrello. Se non ci sono risultati vengono mostrati i più venduti.
+- `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Mostra gli accessori dei prodotti presenti nel carrello. Se necessario, completa con articoli delle stesse categorie e infine mostra i più venduti.
 - `{hook h='displayHome'}`: Mostra l'hook `displayHome` (gli hook non sono consentiti nelle modali)
 - `[everinstagram]`: Mostra le ultime foto di Instagram.
 - `[nativecontact]`: Inserisce il modulo di contatto nativo di PrestaShop.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -151,9 +151,6 @@ class EverblockTools extends ObjectModel
 
     public static function getCrossSellingShortcode(string $txt, Context $context, Everblock $module): string
     {
-        if (!$context->cart || !$context->cart->id) {
-            return $txt;
-        }
 
         preg_match_all(
             '/\[crosselling(?:\s+nb=(\d+))?(?:\s+orderby=(\w+))?(?:\s+orderway=(ASC|DESC))?\]/i',
@@ -176,8 +173,15 @@ class EverblockTools extends ObjectModel
                 $orderWay = 'ASC';
             }
 
-            $cartIds = array_map(fn($p) => (int) $p['id_product'], $context->cart->getProducts());
+            $cartIds = [];
+            if ($context->cart && $context->cart->id) {
+                $cartIds = array_map(fn($p) => (int) $p['id_product'], $context->cart->getProducts());
+            }
+
             if (empty($cartIds)) {
+                $shortcode = '[best-sales nb=' . $limit . ' orderby=' . $orderBy . ' orderway=' . $orderWay . ']';
+                $replacement = static::getBestSalesShortcode($shortcode, $context, $module);
+                $txt = str_replace($match[0], $replacement, $txt);
                 continue;
             }
 
@@ -205,6 +209,30 @@ class EverblockTools extends ObjectModel
                 }
                 if (count($ids) >= $limit) {
                     break;
+                }
+            }
+
+            if (count($ids) < $limit) {
+                $categoryIds = [];
+                foreach ($cartIds as $cartId) {
+                    foreach (Product::getProductCategories($cartId) as $cid) {
+                        $categoryIds[(int) $cid] = true;
+                    }
+                }
+                foreach (array_keys($categoryIds) as $cid) {
+                    if (count($ids) >= $limit) {
+                        break;
+                    }
+                    $categoryProducts = static::getProductsByCategoryId($cid, $limit * 2, $orderBy, $orderWay);
+                    foreach ($categoryProducts as $cproduct) {
+                        $pid = (int) $cproduct['id_product'];
+                        if (!in_array($pid, $cartIds) && !in_array($pid, $ids)) {
+                            $ids[] = $pid;
+                        }
+                        if (count($ids) >= $limit) {
+                            break 2;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- enhance cross selling logic
- document category-based fallback in README

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not found)*
- `php -v` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852900c5c008322abf430216c5be35f