### PR TITLE
Add accessories shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[best-sales 10 carousel=true]`: Displays the top ten best-selling products. Optional parameters: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Displays ten random products in a carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Displays products linked to the current product in a Bootstrap carousel.
+- `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Displays accessories of the current product in a Bootstrap carousel.
 - `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Show accessories of products currently in the cart. Falls back to best sellers if none found.
 - `{hook h='displayHome'}`: Displays the `displayHome` hook (hooks are not allowed on modals)
 - `[everinstagram]`: Display your latest Instagram photos.
@@ -305,6 +306,7 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[best-sales 10 carousel=true]` : Affiche les dix meilleures ventes. Paramètres optionnels : `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]` : Affiche dix produits aléatoires en carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]` : Affiche les produits liés au produit courant en carousel Bootstrap.
+- `[accessories nb="8" orderby="date_add" orderway="DESC"]` : Affiche les accessoires du produit courant en carousel Bootstrap.
 - `[crosselling nb=4 orderby="id_product" orderway="asc"]` : Affiche les accessoires des produits du panier. Si aucun résultat, les meilleures ventes sont proposées.
 - `{hook h='displayHome'}` : Affiche le hook `displayHome` (les hooks ne sont pas autorisés dans les modales)
 - `[everinstagram]` : Affiche vos dernières photos Instagram.
@@ -481,6 +483,7 @@ Puedes crear tus propios shortcodes desde la pestaña "Shortcodes" disponible en
 - `[best-sales 10 carousel=true]`: Muestra los diez productos más vendidos. Parámetros opcionales: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Muestra diez productos aleatorios en carrusel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Muestra productos relacionados con el producto actual en un carrusel Bootstrap.
+- `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Muestra los accesorios del producto actual en un carrusel Bootstrap.
 - `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Muestra accesorios de los productos del carrito. Si no hay resultados se proponen los más vendidos.
 - `{hook h='displayHome'}`: Muestra el hook `displayHome` (los hooks no están permitidos en modales)
 - `[everinstagram]`: Muestra tus últimas fotos de Instagram.
@@ -657,6 +660,7 @@ Puoi creare i tuoi shortcode dalla scheda "Shortcodes" nel sottomenu "Ever block
 - `[best-sales 10 carousel=true]`: Mostra i dieci prodotti più venduti. Parametri opzionali: `days`, `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Mostra dieci prodotti casuali in carosello.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Mostra i prodotti collegati a quello attuale in un carosello Bootstrap.
+- `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Mostra gli accessori del prodotto corrente in un carosello Bootstrap.
 - `[crosselling nb=4 orderby="id_product" orderway="asc"]`: Mostra gli accessori dei prodotti presenti nel carrello. Se non ci sono risultati vengono mostrati i più venduti.
 - `{hook h='displayHome'}`: Mostra l'hook `displayHome` (gli hook non sono consentiti nelle modali)
 - `[everinstagram]`: Mostra le ultime foto di Instagram.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -122,6 +122,9 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[random_product') !== false) {
             $txt = static::getRandomProductsShortcode($txt, $context, $module);
         }
+        if (strpos($txt, '[accessories') !== false) {
+            $txt = static::getAccessoriesShortcode($txt, $context, $module);
+        }
         if (strpos($txt, '[linkedproducts') !== false) {
             $txt = static::getLinkedProductsShortcode($txt, $context, $module);
         }
@@ -1265,6 +1268,83 @@ class EverblockTools extends ObjectModel
 
                     $shortcodeParts = ['[linkedproducts'];
                     if (isset($match[1])) { $shortcodeParts[] = 'nb="' . $match[1] . '"'; }
+                    if (isset($match[2])) { $shortcodeParts[] = 'orderby="' . $match[2] . '"'; }
+                    if (isset($match[3])) { $shortcodeParts[] = 'orderway="' . $match[3] . '"'; }
+                    $shortcode = implode(' ', $shortcodeParts) . ']';
+
+                    $txt = str_replace($shortcode, $replacement, $txt);
+                }
+            }
+        }
+
+        return $txt;
+    }
+
+    public static function getAccessoriesShortcode(string $txt, Context $context, Everblock $module): string
+    {
+        if (!Tools::getValue('id_product')) {
+            return $txt;
+        }
+
+        preg_match_all(
+            '/\[accessories\s+nb="?(\d+)"(?:\s+orderby="?(\w+)"?)?(?:\s+orderway="?(ASC|DESC)"?)?\]/i',
+            $txt,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $limit = isset($match[1]) ? (int) $match[1] : 0;
+            if ($limit <= 0) {
+                continue;
+            }
+            $orderBy = isset($match[2]) ? strtolower($match[2]) : 'position';
+            $orderWay = isset($match[3]) ? strtoupper($match[3]) : 'ASC';
+
+            $allowedOrderBy = ['id_product', 'price', 'name', 'date_add', 'position'];
+            $allowedOrderWay = ['ASC', 'DESC'];
+            if (!in_array($orderBy, $allowedOrderBy)) {
+                $orderBy = 'position';
+            }
+            if (!in_array($orderWay, $allowedOrderWay)) {
+                $orderWay = 'ASC';
+            }
+
+            $productId = (int) Tools::getValue('id_product');
+            $cacheId = 'getAccessoriesShortcode_'
+                . (int) $context->shop->id . '_' . $productId . '_' . $limit
+                . '_' . $orderBy . '_' . $orderWay;
+
+            if (!EverblockCache::isCacheStored($cacheId)) {
+                $sql = new DbQuery();
+                $sql->select('p.id_product');
+                $sql->from('product', 'p');
+                $sql->innerJoin('accessory', 'a', 'p.id_product = a.id_product_2');
+                $sql->where('a.id_product_1 = ' . (int) $productId);
+                $sql->where('p.active = 1');
+                $sql->orderBy('p.' . pSQL($orderBy) . ' ' . pSQL($orderWay));
+                $sql->limit($limit);
+
+                $productIds = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+                EverblockCache::cacheStore($cacheId, $productIds);
+            } else {
+                $productIds = EverblockCache::cacheRetrieve($cacheId);
+            }
+
+            if (!empty($productIds)) {
+                $productIdsArray = array_map(fn($row) => (int) $row['id_product'], $productIds);
+                $everPresentProducts = static::everPresentProducts($productIdsArray, $context);
+
+                if (!empty($everPresentProducts)) {
+                    $context->smarty->assign([
+                        'everPresentProducts' => $everPresentProducts,
+                        'carousel_id' => 'accessoriesCarousel-' . uniqid(),
+                    ]);
+
+                    $templatePath = static::getTemplatePath('hook/linkedproducts_carousel.tpl', $module);
+                    $replacement = $context->smarty->fetch($templatePath);
+
+                    $shortcodeParts = ['[accessories', 'nb="' . $match[1] . '"'];
                     if (isset($match[2])) { $shortcodeParts[] = 'orderby="' . $match[2] . '"'; }
                     if (isset($match[3])) { $shortcodeParts[] = 'orderway="' . $match[3] . '"'; }
                     $shortcode = implode(' ', $shortcodeParts) . ']';


### PR DESCRIPTION
## Summary
- support `[accessories]` shortcode for product accessories
- document the new shortcode in README

## Testing
- `php -l models/EverblockTools.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685290ab5cf483229e9fc601c225a79b