### PR TITLE
Add heading for cross-selling shortcode

### DIFF
--- a/translations/fr.php
+++ b/translations/fr.php
@@ -617,3 +617,4 @@ $_MODULE['<{everblock}prestashop>prettyblock_shopping_cart_96b0141273eabab320119
 $_MODULE['<{everblock}prestashop>prettyblock_shopping_cart_59fc69e031ecb0f82efe467fd6692383'] = 'Voir le panier';
 $_MODULE['<{everblock}prestashop>prettyblock_silo_78f6f209024537ab3369e54b172c94b6'] = 'Retrouvez ce produit dans nos univers';
 $_MODULE['<{everblock}prestashop>prettyblock_silo_5becdb6da34b0a9ce1de8b8e1066baae'] = 'Retrouvez cette catégorie dans nos univers';
+$_MODULE['<{everblock}prestashop>ever_presented_products_124117dd22bc1dce2b0687b65f35f091'] = 'Vous pourriez aussi aimer';

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -16,6 +16,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($everPresentProducts) && $everPresentProducts}
+  <h2 class="h4 my-3 text-center">{l s='You may also like' mod='everblock'}</h2>
   <section class="ever-featured-products featured-products clearfix mt-3">
     <div class="products row {if isset($carousel) && $carousel}ever-slick-carousel{/if}">
       {foreach $everPresentProducts item=product}


### PR DESCRIPTION
## Summary
- add a translatable heading above the cross-selling product list
- provide a French translation for this new string

## Testing
- `composer validate` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852a57300448322ab2ca7ef82783d26