### PR TITLE
Add shortcode class for product listings

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -270,6 +270,7 @@ class EverblockTools extends ObjectModel
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
                     'carousel' => false,
+                    'shortcodeClass' => 'crosselling',
                 ]);
                 $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
                 $replacement = $context->smarty->fetch($templatePath);
@@ -468,7 +469,8 @@ class EverblockTools extends ObjectModel
                 // Assign products and carousel flag to the template
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
-                    'carousel' => $carousel
+                    'carousel' => $carousel,
+                    'shortcodeClass' => 'product'
                 ]);
                 $renderedContent = $context->smarty->fetch($templatePath);
                 
@@ -517,7 +519,8 @@ class EverblockTools extends ObjectModel
             if (!empty($featureProducts)) {
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
-                    'carousel' => $carousel
+                    'carousel' => $carousel,
+                    'shortcodeClass' => 'productfeature'
                 ]);
                 $renderedContent = $context->smarty->fetch($templatePath);
                 $txt = str_replace($match[0], $renderedContent, $txt);
@@ -573,7 +576,8 @@ class EverblockTools extends ObjectModel
                 // Assigner les produits et le flag carousel au template
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
-                    'carousel' => $carousel
+                    'carousel' => $carousel,
+                    'shortcodeClass' => 'productfeaturevalue'
                 ]);
                 $renderedContent = $context->smarty->fetch($templatePath);
 
@@ -638,6 +642,7 @@ class EverblockTools extends ObjectModel
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
                     'carousel' => $carousel,
+                    'shortcodeClass' => 'category',
                 ]);
                 $renderedHtml = $context->smarty->fetch($templatePath);
                 $txt = str_replace($match[0], $renderedHtml, $txt);
@@ -710,7 +715,8 @@ class EverblockTools extends ObjectModel
 
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
-                    'carousel' => $carousel
+                    'carousel' => $carousel,
+                    'shortcodeClass' => 'manufacturer'
                 ]);
                 $renderedHtml = $context->smarty->fetch($templatePath);
                 $message = str_replace($match[0], $renderedHtml, $message);
@@ -1106,7 +1112,8 @@ class EverblockTools extends ObjectModel
                     // Assign products and carousel flag to the template
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => $carousel
+                        'carousel' => $carousel,
+                        'shortcodeClass' => 'random_product'
                     ]);
 
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
@@ -1149,7 +1156,8 @@ class EverblockTools extends ObjectModel
                     // Assign products and carousel flag to the template
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => $carousel
+                        'carousel' => $carousel,
+                        'shortcodeClass' => 'last-products'
                     ]);
 
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
@@ -1193,7 +1201,8 @@ class EverblockTools extends ObjectModel
                     // Assign products and carousel flag to the template
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => $carousel
+                        'carousel' => $carousel,
+                        'shortcodeClass' => 'promo-products'
                     ]);
 
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
@@ -1265,7 +1274,8 @@ class EverblockTools extends ObjectModel
                 if (!empty($everPresentProducts)) {
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => $carousel
+                        'carousel' => $carousel,
+                        'shortcodeClass' => 'best-sales'
                     ]);
 
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -17,7 +17,7 @@
 *}
 {if isset($everPresentProducts) && $everPresentProducts}
   <h2 class="h4 my-3 text-center">{l s='You may also like' mod='everblock'}</h2>
-  <section class="ever-featured-products featured-products clearfix mt-3">
+  <section class="ever-featured-products featured-products clearfix mt-3{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
     <div class="products row {if isset($carousel) && $carousel}ever-slick-carousel{/if}">
       {foreach $everPresentProducts item=product}
         {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}


### PR DESCRIPTION
## Summary
- inject shortcode name as CSS class in `ever_presented_products.tpl`
- pass `shortcodeClass` from product-related shortcodes in `EverblockTools`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852f9a93ec08322af3ec3c41135e389