### PR TITLE
Add hooks around product miniature

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -266,6 +266,20 @@ class Everblock extends Module
             $hook->description = 'This hook triggers after store content on store locator';
             $hook->save();
         }
+        if (!Hook::getIdByName('displayBeforeProductMiniature')) {
+            $hook = new Hook();
+            $hook->name = 'displayBeforeProductMiniature';
+            $hook->title = 'display before product miniature';
+            $hook->description = 'This hook triggers before product miniature is rendered';
+            $hook->save();
+        }
+        if (!Hook::getIdByName('displayAfterProductMiniature')) {
+            $hook = new Hook();
+            $hook->name = 'displayAfterProductMiniature';
+            $hook->title = 'display after product miniature';
+            $hook->description = 'This hook triggers after product miniature is rendered';
+            $hook->save();
+        }
         // Vérifier si l'onglet "AdminEverBlockParent" existe déjà
         $id_tab = Tab::getIdFromClassName('AdminEverBlockParent');
         if (!$id_tab) {

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -16,12 +16,13 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($everPresentProducts) && $everPresentProducts}
-  <h2 class="h4 my-3 text-center">{l s='You may also like' mod='everblock'}</h2>
   <section class="ever-featured-products featured-products clearfix mt-3{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
     <div class="products row {if isset($carousel) && $carousel}ever-slick-carousel{/if}">
+      {hook h='displayBeforeProductMiniature'}
       {foreach $everPresentProducts item=product}
         {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
       {/foreach}
+      {hook h='displayAfterProductMiniature'}
     </div>
   </section>
 {/if}


### PR DESCRIPTION
## Summary
- remove unused header
- register hooks for product miniature
- move hook calls outside the product loop

## Testing
- `php -l everblock.php` *(fails: `php` not installed)*
- `composer validate --no-check-publish` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853980f22448322b61fd6ad494691e9