### PR TITLE
Rename shortcode rendering hooks

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -132,18 +132,18 @@ class Everblock extends Module
             $hook->description = 'This hook triggers after every block shortcode is rendered';
             $hook->save();
         }
-        // Hook BeforeRenderingShortcodes
-        if (!Hook::getIdByName('BeforeRenderingShortcodes')) {
+        // Hook displayBeforeRenderingShortcodes
+        if (!Hook::getIdByName('displayBeforeRenderingShortcodes')) {
             $hook = new Hook();
-            $hook->name = 'BeforeRenderingShortcodes';
+            $hook->name = 'displayBeforeRenderingShortcodes';
             $hook->title = 'Before rendering shortcodes';
             $hook->description = 'This hook triggers before shortcodes are rendered';
             $hook->save();
         }
-        // Hook AfterRenderingShortcodes
-        if (!Hook::getIdByName('AfterRenderingShortcodes')) {
+        // Hook displayAfterRenderingShortcodes
+        if (!Hook::getIdByName('displayAfterRenderingShortcodes')) {
             $hook = new Hook();
-            $hook->name = 'AfterRenderingShortcodes';
+            $hook->name = 'displayAfterRenderingShortcodes';
             $hook->title = 'After rendering shortcodes';
             $hook->description = 'This hook triggers after shortcodes are rendered';
             $hook->save();
@@ -231,16 +231,16 @@ class Everblock extends Module
             $hook->description = 'This hook triggers after every block shortcode is rendered';
             $hook->save();
         }
-        if (!Hook::getIdByName('BeforeRenderingShortcodes')) {
+        if (!Hook::getIdByName('displayBeforeRenderingShortcodes')) {
             $hook = new Hook();
-            $hook->name = 'BeforeRenderingShortcodes';
+            $hook->name = 'displayBeforeRenderingShortcodes';
             $hook->title = 'Before rendering shortcodes';
             $hook->description = 'This hook triggers before shortcodes are rendered';
             $hook->save();
         }
-        if (!Hook::getIdByName('AfterRenderingShortcodes')) {
+        if (!Hook::getIdByName('displayAfterRenderingShortcodes')) {
             $hook = new Hook();
-            $hook->name = 'AfterRenderingShortcodes';
+            $hook->name = 'displayAfterRenderingShortcodes';
             $hook->title = 'After rendering shortcodes';
             $hook->description = 'This hook triggers after shortcodes are rendered';
             $hook->save();

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -29,7 +29,7 @@ class EverblockTools extends ObjectModel
 {
     public static function renderShortcodes(string $txt, Context $context, Everblock $module): string
     {
-        Hook::exec('BeforeRenderingShortcodes', ['html' => &$txt]);
+        Hook::exec('displayBeforeRenderingShortcodes', ['html' => &$txt]);
         $controllerTypes = [
             'front',
             'modulefront',
@@ -148,7 +148,7 @@ class EverblockTools extends ObjectModel
             $txt = static::obfuscateTextByClass($txt);
         }
         $txt = static::renderSmartyVars($txt, $context);
-        Hook::exec('AfterRenderingShortcodes', ['html' => &$txt]);
+        Hook::exec('displayAfterRenderingShortcodes', ['html' => &$txt]);
         return $txt;
     }
 


### PR DESCRIPTION
## Summary
- rename `BeforeRenderingShortcodes` hook to `displayBeforeRenderingShortcodes`
- rename `AfterRenderingShortcodes` hook to `displayAfterRenderingShortcodes`

## Testing
- `composer validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b2d53ab483228730bfff60ac36e3