### PR TITLE
Fix product highlight hook and repeater

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3100,7 +3100,7 @@ class Everblock extends Module
         }
     }
 
-    public function hookbeforeRenderingEverblockProductHighlight($params)
+    public function hookBeforeRenderingEverblockProductHighlight($params)
     {
         $product = false;
         $settings = $params['block']['settings'];

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2296,8 +2296,10 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $productHighlightTemplate,
                 ],
-                'config' => [
-                    'fields' => [
+                'repeater' => [
+                    'name' => 'Product',
+                    'nameFrom' => 'id_product',
+                    'groups' => [
                         'id_product' => [
                             'type' => 'text',
                             'label' => $module->l('Product ID'),


### PR DESCRIPTION
## Summary
- fix typo in `hookBeforeRenderingEverblockProductHighlight`
- allow multiple product highlight entries by using a repeater

## Testing
- `php -l everblock.php` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854044b4d10832285885878fc2a041d