### PR TITLE
Add GitHub workflow for syntax checking

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -1,0 +1,34 @@
+name: PHP Syntax Check
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - '**.tpl'
+  pull_request:
+    paths:
+      - '**.php'
+      - '**.tpl'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - name: Install Smarty
+        run: composer global require smarty/smarty:^3
+      - name: PHP lint
+        run: |
+          find . -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}
+      - name: Smarty lint
+        run: |
+          files=$(find . -name '*.tpl')
+          if [ -n "$files" ]; then
+            for f in $files; do
+              php -r "require '$(composer global config home)/vendor/autoload.php'; \$smarty=new Smarty(); \$smarty->compileCheck=true; try{ \$smarty->fetch('$f'); } catch(Exception \$e){ echo \$e->getMessage(); exit(1);}"
+            done
+          fi

--- a/README.md
+++ b/README.md
@@ -746,3 +746,5 @@ La cartella cache si trova in /var/cache/dev?prod/everblock/
 La cartella log si trova in /var/logs/
 
 Cancellare la cache nativa di PrestaShop cancellerà anche quella del modulo, ma quest'ultimo la pulisce automaticamente alla scadenza di un blocco.
+## Continuous Integration
+A GitHub Actions workflow checks PHP and Smarty template syntax on every push or pull request.


### PR DESCRIPTION
## Summary
- ensure PHP and Smarty templates compile cleanly using a GitHub Action
- document syntax checking in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f6668ce4832294181529ccce09a8