### PR TITLE
Implement AJAX-based shortcode reload

### DIFF
--- a/controllers/front/shortcode.php
+++ b/controllers/front/shortcode.php
@@ -1,0 +1,32 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverblockshortcodeModuleFrontController extends ModuleFrontController
+{
+    public function initContent()
+    {
+        $this->ajax = true;
+        parent::initContent();
+        $this->processShortcodes();
+    }
+
+    protected function processShortcodes()
+    {
+        $validToken = Tools::getToken();
+        $token = Tools::getValue('token');
+        if (!$token || $token !== $validToken) {
+            die('');
+        }
+
+        $html = Tools::getValue('html');
+        if (!$html) {
+            die('');
+        }
+
+        $html = html_entity_decode($html);
+        $html = EverblockTools::renderShortcodes($html, $this->context, $this->module);
+        die($html);
+    }
+}

--- a/everblock.php
+++ b/everblock.php
@@ -2853,9 +2853,16 @@ class Everblock extends Module
                 'modal'
             )
         );
+        $shortcodeLink = base64_encode(
+            $this->context->link->getModuleLink(
+                $this->name,
+                'shortcode'
+            )
+        );
         Media::addJsDef([
             'evercontact_link' => $contactLink,
             'evermodal_link' => $modalLink,
+            'evershortcode_link' => $shortcodeLink,
             'everblock_token' => Tools::getToken(),
         ]);
         $filePath = _PS_MODULE_DIR_ . $this->name . '/views/js/header-scripts-' . $this->context->shop->id . '.js';

--- a/views/js/everblock-obfuscation.js
+++ b/views/js/everblock-obfuscation.js
@@ -131,3 +131,4 @@ function clickAndMousedownActions(selector) {
         }
       });
 }
+

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -180,4 +180,43 @@ $(document).ready(function(){
         backdrop: true,
         show: false
     });
+
+    reloadShortcodes('body');
+
+    prestashop.on('updateProductList', function() {
+        reloadShortcodes('#js-product-list');
+    });
+
+    prestashop.on('updatedProduct', function() {
+        reloadShortcodes('.product-actions.js-product-actions');
+    });
+
+    prestashop.on('updatedCart', function() {
+        reloadShortcodes('body');
+    });
+    prestashop.on('updateShoppingCart', function() {
+        reloadShortcodes('.blockcart');
+    });
 });
+
+function reloadShortcodes(selector) {
+    let target = 'body';
+    if (typeof selector !== 'undefined') {
+        target = selector;
+    }
+    let content = $(target).html();
+    $.ajax({
+        url: atob(evershortcode_link),
+        type: 'POST',
+        data: { html: content, token: everblock_token },
+        success: function(res) {
+            $(target).html(res);
+            if (typeof clickAndMousedownActions === 'function') {
+                clickAndMousedownActions(target);
+            }
+        },
+        error: function(xhr) {
+            console.log(xhr.responseText);
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- add a new front controller to process shortcodes via AJAX
- expose new `evershortcode_link` JS variable
- trigger shortcode reload in `everblock.js`
- keep obfuscation script focused on obfuscation

## Testing
- `php -l controllers/front/shortcode.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685910bb3ad48322a42b3c349bf0419a