### PR TITLE
Refactor product highlight block

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3112,15 +3112,13 @@ class Everblock extends Module
     public function hookBeforeRenderingEverblockProductHighlight($params)
     {
         $product = false;
-        foreach ($params['block']['states'] as $state) {
-            if (!empty($state['id_product'])) {
-                $presented = EverblockTools::everPresentProducts(
-                    [(int) $state['id_product']],
-                    $this->context
-                );
-                if (!empty($presented)) {
-                    $product = reset($presented);
-                }
+        if (!empty($params['block']['settings']['id_product'])) {
+            $presented = EverblockTools::everPresentProducts(
+                [(int) $params['block']['settings']['id_product']],
+                $this->context
+            );
+            if (!empty($presented)) {
+                $product = reset($presented);
             }
         }
 

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2296,14 +2296,17 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $productHighlightTemplate,
                 ],
-                'repeater' => [
-                    'name' => 'Product',
-                    'nameFrom' => 'id_product',
-                    'groups' => [
+                'config' => [
+                    'fields' => [
                         'id_product' => [
                             'type' => 'text',
                             'label' => $module->l('Product ID'),
                             'default' => '',
+                        ],
+                        'badge_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Badge text'),
+                            'default' => $module->l('Our current favorite!'),
                         ],
                         'custom_text' => [
                             'type' => 'editor',

--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -16,10 +16,10 @@
              loading="lazy">
       </div>
 
-      <div class="col-12 col-md-7 text-center text-md-start">
+      <div class="col-12 col-md-7 text-start">
 
         <div class="d-inline-block px-3 py-1 mb-4 rounded-pill bg-light fw-bold text-dark" style="font-size: 1rem;">
-          ❤️ {l s='Our current favorite!' mod='everblock'}
+          ❤️ {$block.settings.badge_text|escape:'htmlall':'UTF-8'}
         </div>
 
         <div class="h5 fw-bold mb-2">{$product.name}</div>


### PR DESCRIPTION
## Summary
- convert product highlight pretty block from repeater to standard config fields
- expose badge text setting
- adjust helper hook to read new fields
- left align the button and make badge text editable

## Testing
- `php -l models/EverblockPrettyBlocks.php` *(fails: command not found)*
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a928a4abc8322a85c182dc871e661