### PR TITLE
Add evertpl shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[prettyblocks name="myzone"]`: Render a PrettyBlocks zone if the module is installed.
 - `[everblock 3]`: Insert the content of block ID 3.
 - `[cms id="1"]` or `[evercms id="1"]`: Display the content of CMS page ID 1.
+- `[evertpl name="my_template.tpl"]`: Render the specified template from the active theme.
 ### Contact form shortcodes
 A contact form must start with the shortcode `[evercontactform_open]` and end with the shortcode `[evercontactform_close]`
 
@@ -325,6 +326,7 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[prettyblocks name="myzone"]` : Affiche une zone PrettyBlocks si le module est installé.
 - `[everblock 3]` : Insère le contenu du bloc ayant l'ID 3.
 - `[cms id="1"]` or `[evercms id="1"]` : Affiche le contenu de la page CMS ayant l'ID 1.
+- `[evertpl name="mon_template.tpl"]` : Affiche le template indiqué depuis le thème actif.
 
 ### Shortcodes de formulaire de contact
 Un formulaire de contact doit commencer par `[evercontactform_open]` et se terminer par `[evercontactform_close]`
@@ -507,6 +509,7 @@ Puedes crear tus propios shortcodes desde la pestaña "Shortcodes" disponible en
 - `[prettyblocks name="myzone"]`: Muestra una zona PrettyBlocks si el módulo está instalado.
 - `[everblock 3]`: Inserta el contenido del bloque con ID 3.
 - `[cms id="1"]` or `[evercms id="1"]`: Muestra el contenido de la página CMS con ID 1.
+- `[evertpl name="mi_template.tpl"]`: Muestra el template indicado desde el tema activo.
 
 ### Shortcodes para formularios de contacto
 Un formulario de contacto debe comenzar con `[evercontactform_open]` y finalizar con `[evercontactform_close]`
@@ -689,6 +692,7 @@ Puoi creare i tuoi shortcode dalla scheda "Shortcodes" nel sottomenu "Ever block
 - `[prettyblocks name="myzone"]`: Mostra una zona PrettyBlocks se il modulo è installato.
 - `[everblock 3]`: Inserisce il contenuto del blocco con ID 3.
 - `[cms id="1"]` or `[evercms id="1"]`: Mostra il contenuto della pagina CMS con ID 1.
+- `[evertpl name="mio_template.tpl"]`: Mostra il template indicato dal tema attivo.
 
 ### Shortcode per moduli di contatto
 Un modulo di contatto deve iniziare con `[evercontactform_open]` e terminare con `[evercontactform_close]`

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -143,6 +143,9 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[cms') !== false) {
             $txt = static::getCmsShortcode($txt, $context);
         }
+        if (strpos($txt, '[evertpl') !== false) {
+            $txt = static::getThemeTplShortcode($txt, $context);
+        }
         if (in_array($context->controller->controller_type, $controllerTypes)) {
             $txt = static::getCustomerShortcodes($txt, $context);
             $txt = static::obfuscateTextByClass($txt);
@@ -419,6 +422,28 @@ class EverblockTools extends ObjectModel
                 // Si CMS non trouvé ou inactif, on retire le shortcode
                 $txt = str_replace($match[0], '', $txt);
             }
+        }
+
+        return $txt;
+    }
+
+    public static function getThemeTplShortcode(string $txt, Context $context): string
+    {
+        preg_match_all('/\[evertpl\s+name="([^"]+)"\]/i', $txt, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $tplName = trim($match[1]);
+            $themeDir = rtrim(_PS_THEME_DIR_, '/') . '/';
+            $relativePath = ltrim($tplName, '/');
+            $filePath = realpath($themeDir . $relativePath);
+
+            if ($filePath && strpos($filePath, $themeDir) === 0 && is_file($filePath)) {
+                $replacement = $context->smarty->fetch($filePath);
+            } else {
+                $replacement = '';
+            }
+
+            $txt = str_replace($match[0], $replacement, $txt);
         }
 
         return $txt;


### PR DESCRIPTION
## Summary
- add `[evertpl]` shortcode to render a template from the active theme
- document the shortcode in every language section of the README

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}` *(fails: `php` not found)*
- `files=$(find . -name '*.tpl'); if [ -n "$files" ]; then for f in $files; do php -r "require '$(composer global config home)/vendor/autoload.php'; \$smarty=new Smarty(); \$smarty->compileCheck=true; try{ \$smarty->fetch('$f'); } catch(Exception \$e){ echo \$e->getMessage(); exit(1);}"; done; fi` *(fails: `composer` and `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adba764a48322939826100b1a03f5