### PR TITLE
Ignore vendor directory in lint workflow

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -23,10 +23,11 @@ jobs:
         run: composer global require smarty/smarty:^3
       - name: PHP lint
         run: |
-          find . -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}
+          # Ignore vendor directory to avoid linting third-party code
+          find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}
       - name: Smarty lint
         run: |
-          files=$(find . -name '*.tpl')
+          files=$(find . -path ./vendor -prune -o -name '*.tpl' -print)
           if [ -n "$files" ]; then
             for f in $files; do
               php -r "require '$(composer global config home)/vendor/autoload.php'; \$smarty=new Smarty(); \$smarty->compileCheck=true; try{ \$smarty->fetch('$f'); } catch(Exception \$e){ echo \$e->getMessage(); exit(1);}"

--- a/README.md
+++ b/README.md
@@ -769,4 +769,4 @@ La cartella log si trova in /var/logs/
 
 Cancellare la cache nativa di PrestaShop cancellerà anche quella del modulo, ma quest'ultimo la pulisce automaticamente alla scadenza di un blocco.
 ## Continuous Integration
-A GitHub Actions workflow checks PHP and Smarty template syntax on every push or pull request.
+A GitHub Actions workflow checks PHP and Smarty template syntax on every push or pull request. The `vendor` directory is skipped during these checks to avoid issues with third-party code.


### PR DESCRIPTION
## Summary
- skip vendor directory from lint workflow
- document vendor exclusion in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653818a9ec8322bbd9411856a4d9b9