### PR TITLE
Add Excel block import

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3238,6 +3238,33 @@ class Everblock extends Module
         if (isset($line['groups']) && Validate::isString($line['groups'])) {
             $block->groups = json_encode(explode(',', $line['groups']));
         }
+        if (isset($line['only_manufacturer']) && Validate::isBool($line['only_manufacturer'])) {
+            $block->only_manufacturer = $line['only_manufacturer'];
+        }
+        if (isset($line['only_supplier']) && Validate::isBool($line['only_supplier'])) {
+            $block->only_supplier = $line['only_supplier'];
+        }
+        if (isset($line['only_cms_category']) && Validate::isBool($line['only_cms_category'])) {
+            $block->only_cms_category = $line['only_cms_category'];
+        }
+        if (isset($line['manufacturers']) && Validate::isString($line['manufacturers'])) {
+            $block->manufacturers = json_encode(explode(',', $line['manufacturers']));
+        }
+        if (isset($line['suppliers']) && Validate::isString($line['suppliers'])) {
+            $block->suppliers = json_encode(explode(',', $line['suppliers']));
+        }
+        if (isset($line['cms_categories']) && Validate::isString($line['cms_categories'])) {
+            $block->cms_categories = json_encode(explode(',', $line['cms_categories']));
+        }
+        if (isset($line['obfuscate_link']) && Validate::isBool($line['obfuscate_link'])) {
+            $block->obfuscate_link = $line['obfuscate_link'];
+        }
+        if (isset($line['add_container']) && Validate::isBool($line['add_container'])) {
+            $block->add_container = $line['add_container'];
+        }
+        if (isset($line['lazyload']) && Validate::isBool($line['lazyload'])) {
+            $block->lazyload = $line['lazyload'];
+        }
         if (isset($line['background']) && Validate::isColor($line['background'])) {
             $block->background = $line['background'];
         }
@@ -3249,6 +3276,15 @@ class Everblock extends Module
         }
         if (isset($line['bootstrap_class']) && Validate::isString($line['bootstrap_class'])) {
             $block->bootstrap_class = $line['bootstrap_class'];
+        }
+        if (isset($line['modal']) && Validate::isBool($line['modal'])) {
+            $block->modal = $line['modal'];
+        }
+        if (isset($line['delay']) && Validate::isUnsignedInt($line['delay'])) {
+            $block->delay = $line['delay'];
+        }
+        if (isset($line['timeout']) && Validate::isUnsignedInt($line['timeout'])) {
+            $block->timeout = $line['timeout'];
         }
         if (isset($line['date_start']) && Validate::isDateFormat($line['date_start'])) {
             $block->date_start = $line['date_start'];

--- a/src/Command/ExportFileCommand.php
+++ b/src/Command/ExportFileCommand.php
@@ -32,6 +32,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use Hook;
 use Validate;
 
 class ExportFileCommand extends Command
@@ -122,180 +124,99 @@ class ExportFileCommand extends Command
                                          ->setDescription($title)
                                          ->setCategory($title);
             $spreadsheet->setActiveSheetIndex(0);
-            $r = 2;
+            $row = 2;
+            $headers = [
+                'id_everblock',
+                'id_shop',
+                'id_lang',
+                'name',
+                'hook',
+                'only_home',
+                'only_category',
+                'only_category_product',
+                'only_manufacturer',
+                'only_supplier',
+                'only_cms_category',
+                'obfuscate_link',
+                'add_container',
+                'lazyload',
+                'device',
+                'categories',
+                'manufacturers',
+                'suppliers',
+                'cms_categories',
+                'groups',
+                'background',
+                'css_class',
+                'data_attribute',
+                'bootstrap_class',
+                'position',
+                'modal',
+                'delay',
+                'timeout',
+                'date_start',
+                'date_end',
+                'active',
+                'content',
+                'custom_code',
+            ];
             foreach ($dataSet as $block) {
-                if ($block['categories']
-                    && $block['categories'] != 'false'
-                    && Validate::isJson($block['categories'])
-                ) {
-                    $categories = implode(',', json_decode($block['categories']));
-                } else {
-                    $categories = '';
+                $values = [
+                    $block['id_everblock'],
+                    $block['id_shop'],
+                    $block['id_lang'],
+                    $block['name'],
+                    Hook::getNameById((int) $block['id_hook']),
+                    $block['only_home'],
+                    $block['only_category'],
+                    $block['only_category_product'],
+                    $block['only_manufacturer'],
+                    $block['only_supplier'],
+                    $block['only_cms_category'],
+                    $block['obfuscate_link'],
+                    $block['add_container'],
+                    $block['lazyload'],
+                    $block['device'],
+                    $this->decodeField($block['categories']),
+                    $this->decodeField($block['manufacturers']),
+                    $this->decodeField($block['suppliers']),
+                    $this->decodeField($block['cms_categories']),
+                    $this->decodeField($block['groups']),
+                    $block['background'],
+                    $block['css_class'],
+                    $block['data_attribute'],
+                    $block['bootstrap_class'],
+                    $block['position'],
+                    $block['modal'],
+                    $block['delay'],
+                    $block['timeout'],
+                    $block['date_start'],
+                    $block['date_end'],
+                    $block['active'],
+                    $block['content'],
+                    $block['custom_code'],
+                ];
+                foreach ($values as $i => $value) {
+                    $col = $i + 1;
+                    $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow($col, $row, $value);
+                    $letter = Coordinate::stringFromColumnIndex($col);
+                    $spreadsheet->getActiveSheet()->getStyle($letter . $row)->getFont()->setBold(true)->setName('Arial')->setSize(9);
+                    $spreadsheet->getActiveSheet()->getColumnDimension($letter)->setAutoSize(true);
                 }
-                if ($block['groups']
-                    && $block['groups'] != 'false'
-                    && Validate::isJson($block['groups'])
-                ) {
-                    $groups = implode(',', json_decode($block['groups']));
-                } else {
-                    $groups = '';
-                }
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(1, $r, $block['id_everblock']);
-                $spreadsheet->getActiveSheet()->getStyle("A" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("A" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("A" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("A")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(2, $r, $block['id_shop']);
-                $spreadsheet->getActiveSheet()->getStyle("B" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("B" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("B" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("B")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(3, $r, $block['id_lang']);
-                $spreadsheet->getActiveSheet()->getStyle("C" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("C" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("C" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("C")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(4, $r, $block['id_hook']);
-                $spreadsheet->getActiveSheet()->getStyle("D" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("D" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("D" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("D")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(5, $r, $block['name']);
-                $spreadsheet->getActiveSheet()->getStyle("E" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("E" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("E" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("E")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(6, $r, $block['only_home']);
-                $spreadsheet->getActiveSheet()->getStyle("F" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("F" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("F" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("F")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(7, $r, $block['only_category']);
-                $spreadsheet->getActiveSheet()->getStyle("G" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("G" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("G" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("G")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(8, $r, $block['only_category_product']);
-                $spreadsheet->getActiveSheet()->getStyle("H" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("H" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("H" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("H")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(9, $r, $block['device']);
-                $spreadsheet->getActiveSheet()->getStyle("I" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("I" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("I" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("I")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(10, $r, $categories);
-                $spreadsheet->getActiveSheet()->getStyle("J" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("J" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("J" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("J")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(11, $r, $groups);
-                $spreadsheet->getActiveSheet()->getStyle("K" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("K" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("K" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("K")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(12, $r, $block['background']);
-                $spreadsheet->getActiveSheet()->getStyle("L" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("L" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("L" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("L")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(13, $r, $block['css_class']);
-                $spreadsheet->getActiveSheet()->getStyle("M" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("M" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("M" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("M")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(14, $r, $block['data_attribute']);
-                $spreadsheet->getActiveSheet()->getStyle("N" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("N" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("N" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("N")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(15, $r, $block['bootstrap_class']);
-                $spreadsheet->getActiveSheet()->getStyle("O" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("O" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("O" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("O")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(16, $r, $block['position']);
-                $spreadsheet->getActiveSheet()->getStyle("P" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("P" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("P" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("P")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(17, $r, $block['date_start']);
-                $spreadsheet->getActiveSheet()->getStyle("Q" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("Q" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("Q" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("Q")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(18, $r, $block['date_end']);
-                $spreadsheet->getActiveSheet()->getStyle("R" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("R" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("R" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("R")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(19, $r, $block['active']);
-                $spreadsheet->getActiveSheet()->getStyle("S" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("S" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("S" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("S")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(20, $r, $block['content']);
-                $spreadsheet->getActiveSheet()->getStyle("T" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("T" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("T" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("T")->setAutoSize(true);
-
-                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow(21, $r, $block['custom_code']);
-                $spreadsheet->getActiveSheet()->getStyle("U" . $r)->getFont()->setBold(true);
-                $spreadsheet->getActiveSheet()->getStyle("U" . $r)->getFont()->setName('Arial');
-                $spreadsheet->getActiveSheet()->getStyle("U" . $r)->getFont()->setSize(9);
-                $spreadsheet->getActiveSheet()->getColumnDimension("U")->setAutoSize(true);
-
-                $r++;
+                $row++;
             }
-            $spreadsheet->setActiveSheetIndex(0)
-            ->setCellValue('A1', 'id_everblock')
-            ->setCellValue('B1', 'id_shop')
-            ->setCellValue('C1', 'id_lang')
-            ->setCellValue('D1', 'name')
-            ->setCellValue('E1', 'id_hook')
-            ->setCellValue('F1', 'only_home')
-            ->setCellValue('G1', 'only_category')
-            ->setCellValue('H1', 'only_category_product')
-            ->setCellValue('I1', 'device')
-            ->setCellValue('J1', 'categories')
-            ->setCellValue('K1', 'groups')
-            ->setCellValue('L1', 'background')
-            ->setCellValue('M1', 'css_class')
-            ->setCellValue('N1', 'data_attribute')
-            ->setCellValue('O1', 'bootstrap_class')
-            ->setCellValue('P1', 'position')
-            ->setCellValue('Q1', 'date_start')
-            ->setCellValue('R1', 'date_end')
-            ->setCellValue('S1', 'active')
-            ->setCellValue('T1', 'content')
-            ->setCellValue('U1', 'custom_code');
-            $spreadsheet->getActiveSheet()->setAutoFilter('A1:U1');
+            $spreadsheet->setActiveSheetIndex(0);
+            foreach ($headers as $i => $header) {
+                $col = $i + 1;
+                $spreadsheet->getActiveSheet()->setCellValueByColumnAndRow($col, 1, $header);
+            }
+            $lastColumn = Coordinate::stringFromColumnIndex(count($headers));
+            $spreadsheet->getActiveSheet()->setAutoFilter('A1:' . $lastColumn . '1');
             // Rename sheet
             $spreadsheet->getActiveSheet()->setTitle(\Tools::substr($reportName, 0, 31));
 
             //Text bold in first row
-            $spreadsheet->getActiveSheet()->getStyle('A1:U1')->getFont()->setBold(true);
+            $spreadsheet->getActiveSheet()->getStyle('A1:' . $lastColumn . '1')->getFont()->setBold(true);
 
             //Freeze first row
             $spreadsheet->getActiveSheet()->freezePane('A2');
@@ -326,7 +247,7 @@ class ExportFileCommand extends Command
                 ],
             ];
 
-            $spreadsheet->getActiveSheet()->getStyle('A1:U1')->applyFromArray($styleArray);
+            $spreadsheet->getActiveSheet()->getStyle('A1:' . $lastColumn . '1')->applyFromArray($styleArray);
 
             // Set active sheet index to the first sheet, so Excel opens this as the first sheet
             $spreadsheet->setActiveSheetIndex(0);
@@ -359,6 +280,18 @@ class ExportFileCommand extends Command
         $sql->where('ebl.id_lang = ' . (int) $idLang);
         $allBlocks = \Db::getInstance()->executeS($sql);
         return $allBlocks;
+    }
+
+    protected function decodeField($json)
+    {
+        if ($json && $json != 'false' && Validate::isJson($json)) {
+            $items = json_decode($json);
+            if (is_array($items)) {
+                return implode(',', $items);
+            }
+        }
+
+        return '';
     }
 
 

--- a/src/Command/ImportFileCommand.php
+++ b/src/Command/ImportFileCommand.php
@@ -30,6 +30,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Validate;
+use Hook;
+use PrestaShopLogger;
 
 class ImportFileCommand extends Command
 {
@@ -48,7 +50,7 @@ class ImportFileCommand extends Command
     protected function configure()
     {
         $this->setName('everblock:tools:import');
-        $this->setDescription('Update SEO datas for categories & products');
+        $this->setDescription('Import HTML blocks from xlsx file');
         $this->filename = _PS_MODULE_DIR_ . 'everblock/input/everblock.xlsx';
         $this->logFile = _PS_ROOT_DIR_ . '/var/logs/log-everblock-import-' . date('Y-m-d') . '.log';
         $help = sprintf(
@@ -92,14 +94,6 @@ class ImportFileCommand extends Command
 
     protected function updateEverblocks($line, $output)
     {
-        if (!isset($line['id_everblock'])
-            || !Validate::isInt($line['id_everblock'])
-        ) {
-            $output->writeln(
-               '<error>Missing id_everblock column</error>'
-            );
-            return;
-        }
         if (!isset($line['id_lang'])
             || !Validate::isInt($line['id_lang'])
         ) {
@@ -116,11 +110,40 @@ class ImportFileCommand extends Command
             );
             return;
         }
-        $block = new \Everblock(
-            (int) $line['id_everblock'],
-            (int) $line['id_lang'],
-            (int) $line['id_shop']
-        );
+        $create = false;
+        if (isset($line['id_everblock']) && Validate::isUnsignedInt($line['id_everblock']) && (int)$line['id_everblock'] > 0) {
+            $block = new \Everblock(
+                (int) $line['id_everblock'],
+                (int) $line['id_lang'],
+                (int) $line['id_shop']
+            );
+            if (!Validate::isLoadedObject($block)) {
+                $block = new \Everblock();
+                $create = true;
+            }
+        } else {
+            $block = new \Everblock();
+            $create = true;
+        }
+        if ($create) {
+            $block->id_shop = (int) $line['id_shop'];
+            if (!isset($line['name']) || !Validate::isString($line['name'])) {
+                $output->writeln('<error>name column is required for creation</error>');
+                return;
+            }
+            if (!isset($line['hook']) || !Validate::isHookName($line['hook'])) {
+                $output->writeln('<error>hook column is required for creation</error>');
+                return;
+            }
+            $idHook = (int) Hook::getIdByName($line['hook']);
+            if (!$idHook) {
+                $output->writeln('<error>Hook not found: ' . $line['hook'] . '</error>');
+                PrestaShopLogger::addLog('Everblock import - Hook not found: ' . $line['hook']);
+                return;
+            }
+            $block->name = pSQL($line['name']);
+            $block->id_hook = $idHook;
+        }
         if (isset($line['name'])) {
             if (!Validate::isString($line['name'])) {
                 $output->writeln(
@@ -194,13 +217,19 @@ class ImportFileCommand extends Command
                 $block->only_category_product = $line['only_category_product'];
             }
         }
-        if (isset($line['id_hook'])) {
-            if (!Validate::isBool($line['id_hook'])) {
+        if (isset($line['hook'])) {
+            if (!Validate::isHookName($line['hook'])) {
                 $output->writeln(
-                   '<error>id_hook column is not valid : ' . $line['id_hook'] . '</error>'
+                   '<error>hook column is not valid : ' . $line['hook'] . '</error>'
                 );
             } else {
-                $block->id_hook = $line['id_hook'];
+                $idHook = (int) Hook::getIdByName($line['hook']);
+                if (!$idHook) {
+                    $output->writeln('<error>Hook not found: ' . $line['hook'] . '</error>');
+                    PrestaShopLogger::addLog('Everblock import - Hook not found: ' . $line['hook']);
+                } else {
+                    $block->id_hook = $idHook;
+                }
             }
         }
         if (isset($line['device'])) {

--- a/src/Command/ImportFileCommand.php
+++ b/src/Command/ImportFileCommand.php
@@ -306,6 +306,114 @@ class ImportFileCommand extends Command
                 $block->categories = json_encode($categories);
             }
         }
+        if (isset($line['only_manufacturer'])) {
+            if (!Validate::isBool($line['only_manufacturer'])) {
+                $output->writeln(
+                   '<error>only_manufacturer column is not valid : ' . $line['only_manufacturer'] . '</error>'
+                );
+            } else {
+                $block->only_manufacturer = $line['only_manufacturer'];
+            }
+        }
+        if (isset($line['only_supplier'])) {
+            if (!Validate::isBool($line['only_supplier'])) {
+                $output->writeln(
+                   '<error>only_supplier column is not valid : ' . $line['only_supplier'] . '</error>'
+                );
+            } else {
+                $block->only_supplier = $line['only_supplier'];
+            }
+        }
+        if (isset($line['only_cms_category'])) {
+            if (!Validate::isBool($line['only_cms_category'])) {
+                $output->writeln(
+                   '<error>only_cms_category column is not valid : ' . $line['only_cms_category'] . '</error>'
+                );
+            } else {
+                $block->only_cms_category = $line['only_cms_category'];
+            }
+        }
+        if (isset($line['manufacturers'])) {
+            if (!Validate::isString($line['manufacturers'])) {
+                $output->writeln(
+                   '<error>manufacturers column is not valid : ' . $line['manufacturers'] . '</error>'
+                );
+            } else {
+                $block->manufacturers = json_encode(explode(',', $line['manufacturers']));
+            }
+        }
+        if (isset($line['suppliers'])) {
+            if (!Validate::isString($line['suppliers'])) {
+                $output->writeln(
+                   '<error>suppliers column is not valid : ' . $line['suppliers'] . '</error>'
+                );
+            } else {
+                $block->suppliers = json_encode(explode(',', $line['suppliers']));
+            }
+        }
+        if (isset($line['cms_categories'])) {
+            if (!Validate::isString($line['cms_categories'])) {
+                $output->writeln(
+                   '<error>cms_categories column is not valid : ' . $line['cms_categories'] . '</error>'
+                );
+            } else {
+                $block->cms_categories = json_encode(explode(',', $line['cms_categories']));
+            }
+        }
+        if (isset($line['obfuscate_link'])) {
+            if (!Validate::isBool($line['obfuscate_link'])) {
+                $output->writeln(
+                   '<error>obfuscate_link column is not valid : ' . $line['obfuscate_link'] . '</error>'
+                );
+            } else {
+                $block->obfuscate_link = $line['obfuscate_link'];
+            }
+        }
+        if (isset($line['add_container'])) {
+            if (!Validate::isBool($line['add_container'])) {
+                $output->writeln(
+                   '<error>add_container column is not valid : ' . $line['add_container'] . '</error>'
+                );
+            } else {
+                $block->add_container = $line['add_container'];
+            }
+        }
+        if (isset($line['lazyload'])) {
+            if (!Validate::isBool($line['lazyload'])) {
+                $output->writeln(
+                   '<error>lazyload column is not valid : ' . $line['lazyload'] . '</error>'
+                );
+            } else {
+                $block->lazyload = $line['lazyload'];
+            }
+        }
+        if (isset($line['modal'])) {
+            if (!Validate::isBool($line['modal'])) {
+                $output->writeln(
+                   '<error>modal column is not valid : ' . $line['modal'] . '</error>'
+                );
+            } else {
+                $block->modal = $line['modal'];
+            }
+        }
+        if (isset($line['delay'])) {
+            if (!Validate::isUnsignedInt($line['delay'])) {
+                $output->writeln(
+                   '<error>delay column is not valid : ' . $line['delay'] . '</error>'
+                );
+            } else {
+                $block->delay = $line['delay'];
+            }
+        }
+        if (isset($line['timeout'])) {
+            if (!Validate::isUnsignedInt($line['timeout'])) {
+                $output->writeln(
+                   '<error>timeout column is not valid : ' . $line['timeout'] . '</error>'
+                );
+            } else {
+                $block->timeout = $line['timeout'];
+            }
+        }
         try {
             $block->save();
         } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- allow uploading an Excel file with block data from module configuration
- parse file to create HTML blocks with all options
- update Symfony command to create blocks when needed
- resolve review: use hook name instead of id

## Testing
- `composer validate --no-check-all` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c041890c48322bfe2fe755325ab7d