### PR TITLE
Add testimonial slider PrettyBlock

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -125,6 +125,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $dividerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_divider.tpl';
             $galleryTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_gallery.tpl';
             $testimonialTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl';
+            $testimonialSliderTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl';
             $parallaxTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_parallax.tpl';
             $overlayTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_overlay.tpl';
             $tartifletteTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_tartiflette.tpl';
@@ -1841,6 +1842,81 @@ class EverblockPrettyBlocks extends ObjectModel
                 ],
                 'repeater' => [
                     'name' => 'Tab',
+                    'nameFrom' => 'name',
+                    'groups' => [
+                        'name' => [
+                            'type' => 'text',
+                            'label' => 'testimonial title',
+                            'default' => Configuration::get('PS_SHOP_NAME'),
+                        ],
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => 'Image',
+                            'path' => '$/modules/' . $module->name . '/views/img/prettyblocks/',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'content' => [
+                            'type' => 'editor',
+                            'label' => 'Tab content',
+                            'default' => '[llorem]',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Testimonials slider'),
+                'description' => $module->l('Display testimonials in a carousel'),
+                'code' => 'everblock_testimonial_slider',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $testimonialSliderTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Slide',
                     'nameFrom' => 'name',
                     'groups' => [
                         'name' => [

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
@@ -1,0 +1,74 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<!-- Module Ever Block -->
+<div class="mt-2{if $block.settings.default.container} container{/if}"  style="
+    {if $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}
+    {if $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    {if $block.settings.default.container}
+        <div class="row">
+    {/if}
+    {if isset($block.states) && $block.states}
+    <div id="testimonialCarousel-{$block.id_prettyblocks}" class="carousel slide everblock-testimonial" data-ride="carousel" data-bs-ride="carousel">
+        <div class="carousel-inner">
+            {foreach from=$block.states item=state key=key}
+                <div class="carousel-item {if $key == 0}active{/if}" style="
+                    {if $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}
+                    {if $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+                    <div class="testimonial text-center">
+                        <p class="author-name h3 mb-2">{$state.name}</p>
+                        <picture>
+                          <source srcset="{$state.image.url}" type="image/webp">
+                          <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                          <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="rounded-circle img img-fluid lazyload" loading="lazy" width="80">
+                        </picture>
+                        <div class="testimonial-content mt-3">
+                            <p>{$state.content nofilter}</p>
+                        </div>
+                    </div>
+                </div>
+            {/foreach}
+        </div>
+        <a class="carousel-control-prev" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="prev" data-bs-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="sr-only visually-hidden">Previous</span>
+        </a>
+        <a class="carousel-control-next" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="next" data-bs-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="sr-only visually-hidden">Next</span>
+        </a>
+    </div>
+    {/if}
+    {if $block.settings.default.container}
+        </div>
+    {/if}
+</div>
+<!-- /Module Ever Block -->


### PR DESCRIPTION
## Summary
- add new template for testimonial slider using Bootstrap carousel
- register new `everblock_testimonial_slider` block with repeater fields

## Testing
- `php -l models/EverblockPrettyBlocks.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ff438815483228f2cfad0491fd369