### PR TITLE
Add Bootstrap card PrettyBlock

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -65,6 +65,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $linkListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_link_list.tpl';
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
+            $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -2494,6 +2495,111 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'bg-light' => 'bg-light',
                                 'bg-dark' => 'bg-dark',
                             ],
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Bootstrap cards'),
+                'description' => $module->l('Display content cards'),
+                'code' => 'everblock_card',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $cardTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Card',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Card title'),
+                            'default' => '',
+                        ],
+                        'content' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Card content'),
+                            'default' => '',
+                        ],
+                        'button_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button text'),
+                            'default' => $module->l('Read more'),
+                        ],
+                        'button_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button link'),
+                            'default' => '#',
+                        ],
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => 'Image',
+                            'path' => '$/modules/' . $module->name . '/views/img/prettyblocks/',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'alt' => [
+                            'type' => 'text',
+                            'label' => $module->l('Image alt text'),
+                            'default' => '',
+                        ],
+                        'image_width' => [
+                            'type' => 'text',
+                            'label' => $module->l('Image width'),
+                            'default' => '',
+                        ],
+                        'image_height' => [
+                            'type' => 'text',
+                            'label' => $module->l('Image height'),
+                            'default' => '',
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -1,0 +1,55 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}w-100 px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+    {if isset($block.states) && $block.states}
+      {foreach from=$block.states item=state key=key}
+        <div class="col-md-4 mb-3 {if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}">
+          <div class="card h-100">
+            {if isset($state.image.url) && $state.image.url}
+              <picture>
+                <source srcset="{$state.image.url}" type="image/webp">
+                <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="card-img-top img img-fluid lazyload"
+                     loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if}
+                     alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
+              </picture>
+            {/if}
+            <div class="card-body">
+              {if $state.title}<h5 class="card-title">{$state.title|escape:'htmlall'}</h5>{/if}
+              {if $state.content}<div class="card-text">{$state.content nofilter}</div>{/if}
+            </div>
+            {if $state.button_link && $state.button_text}
+              <div class="card-footer bg-transparent border-0">
+                <a href="{$state.button_link|escape:'htmlall'}" class="btn btn-primary" title="{$state.title|escape:'htmlall'}">
+                  {$state.button_text|escape:'htmlall'}
+                </a>
+              </div>
+            {/if}
+          </div>
+        </div>
+      {/foreach}
+    {/if}
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add Bootstrap card prettyblock template
- register new card template in configuration
- provide repeater fields with title, content, button link/text, image upload and display options

## Testing
- `composer validate --no-check-all --strict`
- `php -l models/EverblockPrettyBlocks.php`
- `php -l views/templates/hook/prettyblocks/prettyblock_card.tpl`


------
https://chatgpt.com/codex/tasks/task_e_6870d5aff2708322ad4bd16f23d69f48