### PR TITLE
Adjust PrettyBlocks progress bars

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -260,3 +260,9 @@
 @media (max-width: 576px) {
     .everblock-masonry-gallery { column-count: 1; }
 }
+
+/* PrettyBlocks progress bars */
+.everblock-progress {
+    height: 1.5rem;
+    margin-bottom: 0.25rem;
+}

--- a/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl
@@ -21,7 +21,7 @@
     {/if}
     {foreach from=$block.states item=state key=key}
         <div id="block-{$block.id_prettyblocks}-{$key}" class="{if isset($state.css_class) && $state.css_class}{$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
-            <div class="progress">
+            <div class="progress everblock-progress">
                 <div class="progress-bar {$state.style}" role="progressbar" aria-valuenow="{$state.value}" aria-valuemin="0" aria-valuemax="100" style="width: {$state.value}%">
                     {$state.text}
                 </div>


### PR DESCRIPTION
## Summary
- enlarge PrettyBlocks progress bars and give them spacing

## Testing
- `find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}`
- `files=$(find . -path ./vendor -prune -o -name '*.tpl' -print); if [ -n "$files" ]; then for f in $files; do php -r "require '$(composer global config home)/vendor/autoload.php'; \$smarty=new Smarty(); \$smarty->compileCheck=true; try{ \$smarty->fetch('$f'); } catch(Exception \$e){ echo \$e->getMessage(); exit(1); }"; done; fi`

------
https://chatgpt.com/codex/tasks/task_e_6870d89c79008322af90750990d0c416