### PR TITLE
Fix undefined variables in qcdacf shortcode handler

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -1798,6 +1798,7 @@ class EverblockTools extends ObjectModel
             return $txt;
         }
         $objectId = 0;
+        $objectType = '';
         if (Tools::getValue('id_product')) {
             $objectId = (int) Tools::getValue('id_product');
             $objectType = 'product';
@@ -1820,7 +1821,7 @@ class EverblockTools extends ObjectModel
         }
         Module::getInstanceByName('qcdacf');
         $pattern = '/\[qcdacf\s+(\w+)\s+(\w+)\s+(\w+)\]/i';
-        $modifiedTxt = preg_replace_callback($pattern, function ($matches) {
+        $modifiedTxt = preg_replace_callback($pattern, function ($matches) use ($objectType, $objectId, $context) {
             $name = $matches[1];
             $value = qcdacf::getVar($name, $objectType, $objectId, $context->language->id);
             if ($value) {


### PR DESCRIPTION
## Summary
- avoid undefined variables in `getQcdAcfCode`

## Testing
- `php -l models/EverblockTools.php`
- `find models -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6870db0e71a483228241a569c2c0ad79