### PR TITLE
Remove best-sales shortcode usage in cross-selling

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -188,11 +188,21 @@ class EverblockTools extends ObjectModel
             }
 
             if (empty($cartIds)) {
-                $shortcode = '[best-sales nb=' . $limit . ' orderby=' . $orderBy . ' orderway=' . $orderWay . ']';
-                $replacement = static::getBestSalesShortcode($shortcode, $context, $module);
-                if ($replacement === $shortcode) {
+                $bestIds = static::getBestSellingProductIds($limit, $orderBy, $orderWay);
+                $everPresentProducts = static::everPresentProducts($bestIds, $context);
+
+                if (!empty($everPresentProducts)) {
+                    $context->smarty->assign([
+                        'everPresentProducts' => $everPresentProducts,
+                        'carousel' => false,
+                        'shortcodeClass' => 'crosselling',
+                    ]);
+                    $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
+                    $replacement = $context->smarty->fetch($templatePath);
+                } else {
                     $replacement = '';
                 }
+
                 $txt = str_replace($match[0], $replacement, $txt);
                 continue;
             }
@@ -261,11 +271,21 @@ class EverblockTools extends ObjectModel
             }
 
             if (empty($ids)) {
-                $shortcode = '[best-sales nb=' . $limit . ' orderby=' . $orderBy . ' orderway=' . $orderWay . ']';
-                $replacement = static::getBestSalesShortcode($shortcode, $context, $module);
-                if ($replacement === $shortcode) {
+                $bestIds = static::getBestSellingProductIds($limit, $orderBy, $orderWay);
+                $everPresentProducts = static::everPresentProducts($bestIds, $context);
+
+                if (!empty($everPresentProducts)) {
+                    $context->smarty->assign([
+                        'everPresentProducts' => $everPresentProducts,
+                        'carousel' => false,
+                        'shortcodeClass' => 'crosselling',
+                    ]);
+                    $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
+                    $replacement = $context->smarty->fetch($templatePath);
+                } else {
                     $replacement = '';
                 }
+
                 $txt = str_replace($match[0], $replacement, $txt);
                 continue;
             }


### PR DESCRIPTION
## Summary
- use best-selling product IDs directly when cart is empty
- use same fallback when no cross-selling items found

## Testing
- `php -l everblock/models/EverblockTools.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6871212c47e48322a2577c45dedd98ce