### PR TITLE
Fix CI vendor ignore

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -5,10 +5,14 @@ on:
     paths:
       - '**.php'
       - '**.tpl'
+    paths-ignore:
+      - 'vendor/**'
   pull_request:
     paths:
       - '**.php'
       - '**.tpl'
+    paths-ignore:
+      - 'vendor/**'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- ignore `vendor` directory to avoid linting third-party code when triggering CI

## Testing
- `composer validate --no-check-all --ansi`


------
https://chatgpt.com/codex/tasks/task_e_6871f240ccb08322858f7dc7a167700e