### PR TITLE
Fix empty log file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The module uses its own cache system in addition to the PrestaShop one.
 The cache directory is located in /var/cache/dev?prod/everblock/
 
 The logs directory is located in /var/logs/
+Log files are created only when there is content to log.
 
 Clearing the native PrestaShop cache will also clear the module cache, but the module will clear its own cache on a block expiry automatically.
 
@@ -406,6 +407,7 @@ Le module utilise son propre système de cache en plus de celui de PrestaShop.
 Le dossier du cache se situe dans /var/cache/dev?prod/everblock/
 
 Le dossier des logs se situe dans /var/logs/
+Les fichiers de log ne sont créés que s'il y a un message à enregistrer.
 
 Vider le cache natif de PrestaShop videra également le cache du module, mais ce dernier vide automatiquement son cache lorsqu'un bloc expire.
 
@@ -590,6 +592,7 @@ El módulo utiliza su propio sistema de caché además del de PrestaShop.
 El directorio de caché está en /var/cache/dev?prod/everblock/
 
 El directorio de logs está en /var/logs/
+Los archivos de registro solo se crean si contienen información.
 
 Borrar la caché nativa de PrestaShop también limpiará la del módulo, pero este limpia automáticamente su caché cuando expira un bloque.
 
@@ -774,6 +777,7 @@ Il modulo utilizza un proprio sistema di cache oltre a quello di PrestaShop.
 La cartella cache si trova in /var/cache/dev?prod/everblock/
 
 La cartella log si trova in /var/logs/
+I file di log vengono creati solo se contengono dei messaggi.
 
 Cancellare la cache nativa di PrestaShop cancellerà anche quella del modulo, ma quest'ultimo la pulisce automaticamente alla scadenza di un blocco.
 ## Continuous Integration

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3993,6 +3993,13 @@ class EverblockTools extends ObjectModel
     public static function setLog(string $logKey, string $logValue)
     {
         $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
+        $logValue = trim($logValue);
+        if ($logValue === '') {
+            if (file_exists($logFilePath)) {
+                unlink($logFilePath);
+            }
+            return;
+        }
         file_put_contents($logFilePath, $logValue);
     }
 

--- a/src/Command/ExportFileCommand.php
+++ b/src/Command/ExportFileCommand.php
@@ -298,6 +298,11 @@ class ExportFileCommand extends Command
 
     protected function logCommand($msg)
     {
+        $msg = trim($msg);
+        if ($msg === '') {
+            return;
+        }
+
         $log  = 'Msg: ' . $msg . PHP_EOL .
                 date('j.n.Y') . PHP_EOL .
                 '-------------------------' . PHP_EOL;

--- a/src/Command/ImportFileCommand.php
+++ b/src/Command/ImportFileCommand.php
@@ -425,6 +425,11 @@ class ImportFileCommand extends Command
 
     protected function logCommand($msg)
     {
+        $msg = trim($msg);
+        if ($msg === '') {
+            return;
+        }
+
         $log  = 'Msg: '
         . $msg
         . PHP_EOL

--- a/src/Command/ImportTabCommand.php
+++ b/src/Command/ImportTabCommand.php
@@ -150,6 +150,11 @@ class ImportTabCommand extends Command
 
     protected function logCommand($msg)
     {
+        $msg = trim($msg);
+        if ($msg === '') {
+            return;
+        }
+
         $log  = 'Msg: ' . $msg . PHP_EOL .
                 date('j.n.Y') . PHP_EOL .
                 '-------------------------' . PHP_EOL;


### PR DESCRIPTION
## Summary
- prevent creation of empty log files
- update commands to avoid logging blank messages
- document new logging behaviour in README

## Testing
- `find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 -I{} php -l {}`
- ❌ `composer global require smarty/smarty:^3` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68720b8701088322bbabbfc78cd71a25