### PR TITLE
Fix shortcodes reload on page refresh

### DIFF
--- a/controllers/front/shortcode.php
+++ b/controllers/front/shortcode.php
@@ -37,7 +37,7 @@ class EverblockshortcodeModuleFrontController extends ModuleFrontController
             die('');
         }
 
-        $html = Tools::getValue('html');
+        $html = Tools::getValue('html', '', true);
         if (!$html) {
             die('');
         }


### PR DESCRIPTION
## Summary
- ensure page HTML is not stripped when processing shortcodes

## Testing
- `php -l controllers/front/shortcode.php`

------
https://chatgpt.com/codex/tasks/task_e_68778636b8148322bfcd490ae9252b3e