### PR TITLE
Add sold out flag CSS generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ views/backup/css/feature-flags-1.css
 views/backup/js/store-locator-1.js
 views/backup/js/store-locator-1.js
 views/css/feature-flags-1.css
+views/css/outofstock-flag-1.css
 /views/img/svg
 /views/backup


### PR DESCRIPTION
## Summary
- allow customizing sold‑out flag colors
- autogenerate a CSS file for the sold‑out flag
- load this stylesheet on the storefront
- keep generated file out of version control

## Testing
- `php -l everblock.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f82072f08322b7e58ffd2d6ac588