### PR TITLE
Add slick theme CSS for Instagram slider dots

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3053,6 +3053,11 @@ class Everblock extends Module
                 'modules/' . $this->name . '/views/css/slick-min.css',
                 ['media' => 'all', 'priority' => 200]
             );
+            $this->context->controller->registerStylesheet(
+                'module-slick-theme-min-css',
+                'modules/' . $this->name . '/views/css/slick-theme-min.css',
+                ['media' => 'all', 'priority' => 200]
+            );
             $this->context->controller->registerJavascript(
                 'module-slick-min-js',
                 'modules/' . $this->name . '/views/js/slick-min.js',


### PR DESCRIPTION
## Summary
- ensure slick theme CSS is loaded when slick is enabled

## Testing
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_687f362cd7b083229c26ddd1c9b1a5c5