### PR TITLE
Add feature best sales shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[best-sales 10 carousel=true]`: Displays the top ten best-selling products. Optional parameters: `days`, `orderby`, `orderway`.
 - `[categorybestsales id="8" nb="10"]`: Displays the best-selling products from category ID 8. Optional parameters: `orderby`, `orderway`.
 - `[brandbestsales id="3" nb="10"]`: Displays the best-selling products from brand ID 3. Optional parameters: `orderby`, `orderway`.
+- `[featurebestsales id="2" nb="10"]`: Displays the best-selling products with feature ID 2. Optional parameters: `orderby`, `orderway`.
+- `[featurevaluebestsales id="5" nb="10"]`: Displays the best-selling products with feature value ID 5. Optional parameters: `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Displays ten random products in a carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Displays products linked to the current product in a Bootstrap carousel.
 - `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Displays accessories of the current product in a Bootstrap carousel.
@@ -304,6 +306,8 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[best-sales 10 carousel=true]` : Affiche les dix meilleures ventes. Paramètres optionnels : `days`, `orderby`, `orderway`.
 - `[categorybestsales id="8" nb="10"]` : Affiche les meilleures ventes de la catégorie 8. Paramètres optionnels : `orderby`, `orderway`.
 - `[brandbestsales id="3" nb="10"]` : Affiche les meilleures ventes de la marque 3. Paramètres optionnels : `orderby`, `orderway`.
+- `[featurebestsales id="2" nb="10"]` : Affiche les meilleures ventes associées à la caractéristique 2. Paramètres optionnels : `orderby`, `orderway`.
+- `[featurevaluebestsales id="5" nb="10"]` : Affiche les meilleures ventes pour la valeur de caractéristique 5. Paramètres optionnels : `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]` : Affiche dix produits aléatoires en carousel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]` : Affiche les produits liés au produit courant en carousel Bootstrap.
 - `[accessories nb="8" orderby="date_add" orderway="DESC"]` : Affiche les accessoires du produit courant en carousel Bootstrap.
@@ -488,6 +492,8 @@ Puedes crear tus propios shortcodes desde la pestaña "Shortcodes" disponible en
 - `[best-sales 10 carousel=true]`: Muestra los diez productos más vendidos. Parámetros opcionales: `days`, `orderby`, `orderway`.
 - `[categorybestsales id="8" nb="10"]`: Muestra los productos más vendidos de la categoría 8. Parámetros opcionales: `orderby`, `orderway`.
 - `[brandbestsales id="3" nb="10"]`: Muestra los productos más vendidos de la marca 3. Parámetros opcionales: `orderby`, `orderway`.
+- `[featurebestsales id="2" nb="10"]`: Muestra los productos más vendidos con la característica 2. Parámetros opcionales: `orderby`, `orderway`.
+- `[featurevaluebestsales id="5" nb="10"]`: Muestra los productos más vendidos con el valor de característica 5. Parámetros opcionales: `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Muestra diez productos aleatorios en carrusel.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Muestra productos relacionados con el producto actual en un carrusel Bootstrap.
 - `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Muestra los accesorios del producto actual en un carrusel Bootstrap.
@@ -672,6 +678,8 @@ Puoi creare i tuoi shortcode dalla scheda "Shortcodes" nel sottomenu "Ever block
 - `[best-sales 10 carousel=true]`: Mostra i dieci prodotti più venduti. Parametri opzionali: `days`, `orderby`, `orderway`.
 - `[categorybestsales id="8" nb="10"]`: Mostra i prodotti più venduti della categoria 8. Parametri opzionali: `orderby`, `orderway`.
 - `[brandbestsales id="3" nb="10"]`: Mostra i prodotti più venduti del marchio 3. Parametri opzionali: `orderby`, `orderway`.
+- `[featurebestsales id="2" nb="10"]`: Mostra i prodotti più venduti con la caratteristica 2. Parametri opzionali: `orderby`, `orderway`.
+- `[featurevaluebestsales id="5" nb="10"]`: Mostra i prodotti più venduti con il valore caratteristica 5. Parametri opzionali: `orderby`, `orderway`.
 - `[random_product nb="10" carousel=true]`: Mostra dieci prodotti casuali in carosello.
 - `[linkedproducts nb="8" orderby="date_add" orderway="DESC"]`: Mostra i prodotti collegati a quello attuale in un carosello Bootstrap.
 - `[accessories nb="8" orderby="date_add" orderway="DESC"]`: Mostra gli accessori del prodotto corrente in un carosello Bootstrap.


### PR DESCRIPTION
## Summary
- add `[featurebestsales]` and `[featurevaluebestsales]` shortcodes
- support fetching best sellers by feature or feature value
- document new shortcodes in README

## Testing
- `composer validate --no-check-all --strict`
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_688274aa54e88322a14e2d8ace2180ee