### PR TITLE
Export configuration with block backup

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -491,7 +491,8 @@ class Everblock extends Module
 
         if ((bool) Tools::isSubmit('submitBackupBlocks') === true) {
             $backuped = EverblockTools::exportModuleTablesSQL();
-            if ((bool) $backuped === true) {
+            $configBackuped = EverblockTools::exportConfigurationSQL();
+            if ((bool) $backuped === true && (bool) $configBackuped === true) {
                 $this->postSuccess[] = $this->l('Backup done');
             } else {
                 $this->postErrors[] = $this->l('Backup failed');

--- a/src/Command/ExecuteAction.php
+++ b/src/Command/ExecuteAction.php
@@ -155,7 +155,8 @@ class ExecuteAction extends Command
         }
         if ($action === 'saveblocks') {
             $backuped = EverblockTools::exportModuleTablesSQL();
-            if ((bool) $backuped === true) {
+            $configBackuped = EverblockTools::exportConfigurationSQL();
+            if ((bool) $backuped === true && (bool) $configBackuped === true) {
                 try {
                     $modulePath = _PS_MODULE_DIR_ . 'everblock/';
                     $this->copyDirectory($modulePath . 'views/css', $modulePath . 'views/backup/css');


### PR DESCRIPTION
## Summary
- add new `exportConfigurationSQL` utility to dump configuration table
- include configuration dump when backing up blocks from admin or CLI

## Testing
- `php-cs-fixer fix --dry-run -v` *(fails: command not found)*
- `phpstan analyse --no-progress --configuration=phpstan.neon` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837b8018108322b30519e50a1a358c