### PR TITLE
Add store details to Google Maps store locator

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1670,10 +1670,17 @@ class Everblock extends Module
             if (Tools::getValue('EVERBLOCK_GMAP_KEY')) {
                 $markers = [];
                 foreach ($stores as $store) {
+                    $address = $store['address1'];
+                    if (!empty($store['address2'])) {
+                        $address .= ' ' . $store['address2'];
+                    }
+                    $address .= ', ' . $store['postcode'] . ' ' . $store['city'];
                     $marker = [
                         'lat' => $store['latitude'],
                         'lng' => $store['longitude'],
                         'title' => $store['name'],
+                        'address' => $address,
+                        'phone' => $store['phone'],
                     ];
                     $markers[] = $marker;
                 }
@@ -1686,10 +1693,17 @@ class Everblock extends Module
             } else {
                 $markers = [];
                 foreach ($stores as $store) {
+                    $address = $store['address1'];
+                    if (!empty($store['address2'])) {
+                        $address .= ' ' . $store['address2'];
+                    }
+                    $address .= ', ' . $store['postcode'] . ' ' . $store['city'];
                     $marker = [
                         'lat' => $store['latitude'],
                         'lng' => $store['longitude'],
                         'title' => $store['name'],
+                        'address' => $address,
+                        'phone' => $store['phone'],
                     ];
                     $markers[] = $marker;
                 }

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -2595,6 +2595,7 @@ class EverblockTools extends ObjectModel
         $googleMapCode = '
             (function() {
                 var map;
+                var infoWindow;
                 var markers = ' . json_encode($markers) . '; // Initialisez la variable markers avec vos données JSON
 
                 // Fonction pour trouver le marqueur le plus proche
@@ -2620,12 +2621,25 @@ class EverblockTools extends ObjectModel
                         center: { lat: ' . $markers[0]['lat'] . ', lng: ' . $markers[0]['lng'] . ' },
                         zoom: 13
                     });
+                    infoWindow = new google.maps.InfoWindow();
 
                     markers.forEach(function(marker) {
-                        new google.maps.Marker({
+                        var markerObj = new google.maps.Marker({
                             position: { lat: marker.lat, lng: marker.lng },
                             map: map,
                             title: marker.title
+                        });
+
+                        markerObj.addListener("click", function() {
+                            var link = `https://www.google.com/maps?q=${marker.lat},${marker.lng}`;
+                            var content = `
+                                <strong>${marker.title}</strong><br>
+                                ${marker.address}<br>
+                                ${marker.phone ? "Tel: " + marker.phone + "<br>" : ""}
+                                <a href="${link}" target="_blank">Ouvrir dans Google Maps</a>
+                            `;
+                            infoWindow.setContent(content);
+                            infoWindow.open(map, markerObj);
                         });
                     });
 


### PR DESCRIPTION
## Summary
- include store address and phone in generated map markers
- show info windows with details and Google Maps link on marker click

## Testing
- `php -l everblock.php models/EverblockTools.php`
- `composer global require friendsofphp/php-cs-fixer phpstan/phpstan` *(fails: CONNECT tunnel failed, response 403)*
- `~/.composer/vendor/bin/php-cs-fixer --version` *(command not found)*
- `~/.composer/vendor/bin/phpstan --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6eb938588322b7ed88e2ddcca533