### PR TITLE
fix: keep SearchReplaceCommand in module cleanup

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -79,6 +79,7 @@ return [
     'src/Command/ImportFileCommand.php',
     'src/Command/ImportTabCommand.php',
     'src/Command/PrettyBlocksCommand.php',
+    'src/Command/SearchReplaceCommand.php',
     'src/Command/index.php',
     'src/Service/ImportFile.php',
     'src/Service/index.php',


### PR DESCRIPTION
## Summary
- prevent `cleanObsoleteFiles` from removing SearchReplaceCommand

## Testing
- `php -l config/allowed_files.php`
- `php -l src/Command/SearchReplaceCommand.php`


------
https://chatgpt.com/codex/tasks/task_e_6890616289588322b2713d02e24184cb