### PR TITLE
fix: exclude vendor from cleanObsoleteFiles

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3678,7 +3678,7 @@ class EverblockTools extends ObjectModel
         }
         $allowed = array_flip(array_map('trim', $allowedFiles));
 
-        $ignorePatterns = ['views/img/*'];
+        $ignorePatterns = ['views/img/*', 'vendor/*'];
         $gitignore = $moduleDir . '.gitignore';
         if (file_exists($gitignore)) {
             $lines = file($gitignore, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);


### PR DESCRIPTION
## Summary
- prevent `cleanObsoleteFiles` from removing files in `vendor`

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_68906404278883229eb68b29d471699b