### PR TITLE
feat: add title to link list block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2340,6 +2340,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $linkListTemplate,
                 ],
+                'config' => [
+                    'fields' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Block title'),
+                            'default' => $module->l('Links'),
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Link',
                     'nameFrom' => 'name',

--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -21,6 +21,9 @@
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
+  {if isset($block.settings.title) && $block.settings.title}
+    <span class="h2 pb-link-list-title">{$block.settings.title|escape:'htmlall'}</span>
+  {/if}
   {if isset($block.states) && $block.states}
     <ul class="list-unstyled">
       {foreach from=$block.states item=state key=key}


### PR DESCRIPTION
## Summary
- allow setting a title for link list blocks
- render link list titles in the template

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l views/templates/hook/prettyblocks/prettyblock_link_list.tpl`
- `composer validate --no-check-all --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68907ce793e88322a31d6039b4541bcf