### PR TITLE
Display prettyblock cards as slider

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -16,40 +16,44 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}w-100 px-0 mx-0{elseif $block.settings.default.container}container{/if}">
-  {if $block.settings.default.force_full_width}
-    <div class="row gx-0 no-gutters">
-  {elseif $block.settings.default.container}
-    <div class="row">
-  {/if}
-    {if isset($block.states) && $block.states}
-      {foreach from=$block.states item=state key=key}
-        <div class="col-md-4 mb-3 {if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}">
-          <div class="card h-100">
-            {if isset($state.image.url) && $state.image.url}
-              <picture>
-                <source srcset="{$state.image.url}" type="image/webp">
-                <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="card-img-top img img-fluid lazyload"
-                     loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if}
-                     alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
-              </picture>
-            {/if}
-            <div class="card-body">
-              {if $state.title}<h5 class="card-title">{$state.title|escape:'htmlall'}</h5>{/if}
-              {if $state.content}<div class="card-text">{$state.content nofilter}</div>{/if}
-            </div>
-            {if $state.button_link && $state.button_text}
-              <div class="card-footer bg-transparent border-0">
-                <a href="{$state.button_link|escape:'htmlall'}" class="btn btn-primary" title="{$state.title|escape:'htmlall'}">
-                  {$state.button_text|escape:'htmlall'}
-                </a>
+  {if isset($block.states) && $block.states}
+    <div id="cardCarousel-{$block.id_prettyblocks}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
+      <div class="carousel-inner">
+        {foreach from=$block.states item=state key=key}
+          <div class="carousel-item{if $key == 0} active{/if}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}">
+            <div class="card h-100 mb-3">
+              {if isset($state.image.url) && $state.image.url}
+                <picture>
+                  <source srcset="{$state.image.url}" type="image/webp">
+                  <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                  <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="card-img-top img img-fluid lazyload"
+                       loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if}
+                       alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
+                </picture>
+              {/if}
+              <div class="card-body">
+                {if $state.title}<span class="card-title h5">{$state.title|escape:'htmlall'}</span>{/if}
+                {if $state.content}<div class="card-text">{$state.content nofilter}</div>{/if}
               </div>
-            {/if}
+              {if $state.button_link && $state.button_text}
+                <div class="card-footer bg-transparent border-0">
+                  <a href="{$state.button_link|escape:'htmlall'}" class="btn btn-primary" title="{$state.title|escape:'htmlall'}">
+                    {$state.button_text|escape:'htmlall'}
+                  </a>
+                </div>
+              {/if}
+            </div>
           </div>
-        </div>
-      {/foreach}
-    {/if}
-  {if $block.settings.default.force_full_width || $block.settings.default.container}
+        {/foreach}
+      </div>
+      <a class="carousel-control-prev" href="#cardCarousel-{$block.id_prettyblocks}" role="button" data-slide="prev" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only visually-hidden">Previous</span>
+      </a>
+      <a class="carousel-control-next" href="#cardCarousel-{$block.id_prettyblocks}" role="button" data-slide="next" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only visually-hidden">Next</span>
+      </a>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- Replace static grid with Bootstrap carousel to display prettyblock cards as a slider
- Use span with `h5` class for card titles instead of `<h5>` tag

## Testing
- `composer validate`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `composer require --dev phpstan/phpstan` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68907f9697fc8322a5f0e883bb91b891