### PR TITLE
Add cover PrettyBlocks block with background image and buttons

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -171,6 +171,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_card.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl',
     'views/templates/hook/prettyblocks/prettyblock_contact.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_cover.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cta.tpl',
     'views/templates/hook/prettyblocks/prettyblock_divider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_everblock.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -67,6 +67,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
+            $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -2740,6 +2741,91 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'text',
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Cover block'),
+                'description' => $module->l('Background image with title, text and two buttons'),
+                'code' => 'everblock_cover',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $coverTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Cover',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Title'),
+                            'default' => '',
+                        ],
+                        'content' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Content'),
+                            'default' => '',
+                        ],
+                        'background_image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Background image'),
+                            'path' => '$/modules/' . $module->name . '/views/img/prettyblocks/',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'btn1_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button 1 text'),
+                            'default' => '',
+                        ],
+                        'btn1_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button 1 link'),
+                            'default' => '',
+                        ],
+                        'btn1_type' => [
+                            'type' => 'radio_group',
+                            'label' => $module->l('Button 1 type'),
+                            'default' => 'primary',
+                            'choices' => [
+                                'primary' => 'primary',
+                                'secondary' => 'secondary',
+                                'success' => 'success',
+                                'danger' => 'danger',
+                                'warning' => 'warning',
+                                'info' => 'info',
+                                'light' => 'light',
+                                'dark' => 'dark',
+                            ],
+                        ],
+                        'btn2_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button 2 text'),
+                            'default' => '',
+                        ],
+                        'btn2_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button 2 link'),
+                            'default' => '',
+                        ],
+                        'btn2_type' => [
+                            'type' => 'radio_group',
+                            'label' => $module->l('Button 2 type'),
+                            'default' => 'primary',
+                            'choices' => [
+                                'primary' => 'primary',
+                                'secondary' => 'secondary',
+                                'success' => 'success',
+                                'danger' => 'danger',
+                                'warning' => 'warning',
+                                'info' => 'info',
+                                'light' => 'light',
+                                'dark' => 'dark',
+                            ],
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -1,0 +1,43 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="prettyblock-cover">
+  {if isset($block.states) && $block.states}
+    {foreach from=$block.states item=state key=key}
+      <div id="block-{$block.id_prettyblocks}-{$key}"
+           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if} text-center"
+           style="{if isset($state.background_image.url) && $state.background_image.url}background-image: url('{$state.background_image.url|escape:'htmlall'}'); background-size: cover; background-position: center;{/if}">
+        {if $state.title}
+          <h2>{$state.title|escape:'htmlall'}</h2>
+        {/if}
+        {if $state.content}
+          {$state.content nofilter}
+        {/if}
+        {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
+          <div class="mt-3 d-flex justify-content-center gap-2">
+            {if $state.btn1_text && $state.btn1_link}
+              <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
+            {/if}
+            {if $state.btn2_text && $state.btn2_link}
+              <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/foreach}
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add new PrettyBlocks cover block with background image, text and two configurable buttons
- center cover block content and display buttons side by side
- register cover block template in allowed files

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`


------
https://chatgpt.com/codex/tasks/task_e_689083b8c00c8322940ac6eb20867af3