### PR TITLE
chore: always run static checks

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -2,15 +2,7 @@ name: PHP CS Fixer
 
 on:
   push:
-    paths:
-      - '**/*.php'
-    paths-ignore:
-      - 'vendor/**'
   pull_request:
-    paths:
-      - '**/*.php'
-    paths-ignore:
-      - 'vendor/**'
 
 jobs:
   php-cs-fixer:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,15 +2,7 @@ name: PHPStan
 
 on:
   push:
-    paths:
-      - '**/*.php'
-    paths-ignore:
-      - 'vendor/**'
   pull_request:
-    paths:
-      - '**/*.php'
-    paths-ignore:
-      - 'vendor/**'
 
 jobs:
   phpstan:


### PR DESCRIPTION
## Summary
- ensure php-cs-fixer workflow runs on all pushes and pull requests
- ensure phpstan workflow runs on all pushes and pull requests

## Testing
- `curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/latest/download/php-cs-fixer.phar -o php-cs-fixer.phar && php php-cs-fixer.phar --version` *(fails: CONNECT tunnel failed, response 403)*
- `curl -LsS https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar -o phpstan.phar && php phpstan.phar --version` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68908ff3f5f483228d60bcdc264d7cda