### PR TITLE
Fix syntax-check workflow paths configuration

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -5,14 +5,12 @@ on:
     paths:
       - '**/*.php'
       - '**/*.tpl'
-    paths-ignore:
-      - 'vendor/**'
+      - '!vendor/**'
   pull_request:
     paths:
       - '**/*.php'
       - '**/*.tpl'
-    paths-ignore:
-      - 'vendor/**'
+      - '!vendor/**'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- fix syntax-check workflow paths configuration, removing paths-ignore and excluding vendor

## Testing
- `composer validate`
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_6890ace780bc8322bc4c29794d26877f