### PR TITLE
feat: add slider option to cover block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2878,6 +2878,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $coverTemplate,
                 ],
+                'config' => [
+                    'fields' => [
+                        'slider' => [
+                            'type' => 'switch',
+                            'label' => $module->l('Enable slider'),
+                            'default' => 0,
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Cover',
                     'nameFrom' => 'title',

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -638,3 +638,4 @@ $_MODULE['<{everblock}prestashop>everblock_2c0923ac78b194c2e9946bd32a650d0b'] = 
 $_MODULE['<{everblock}prestashop>everblock_21f59a9a3e796f0e797ad7736028089c'] = 'Une date et une plage horaire par ligne (YYYY-MM-DD=09h00-12h00)';
 $_MODULE['<{everblock}prestashop>everblock_a97e8578c3942df9fc98bb501d385883'] = 'Heure d\'ouverture de %s le %s';
 $_MODULE['<{everblock}prestashop>everblock_5ce749b4b55e9ed91bda1aba920e1ffd'] = 'Heure de fermeture de %s le %s';
+$_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Activer le slider';

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -292,3 +292,29 @@
     height: auto;
     display: block;
 }
+
+/* Cover block slider */
+.ever-cover-carousel .slick-slide {
+    opacity: 0.5;
+    transition: opacity 0.3s;
+}
+.ever-cover-carousel .slick-center {
+    opacity: 1;
+    position: relative;
+}
+.ever-cover-carousel .slick-prev,
+.ever-cover-carousel .slick-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: 0;
+    color: #fff;
+    font-size: 2rem;
+}
+.ever-cover-carousel .slick-prev {
+    left: 10px;
+}
+.ever-cover-carousel .slick-next {
+    right: 10px;
+}

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -50,6 +50,32 @@ $(document).ready(function(){
         $('.ever-slick-carousel').on('setPosition', function(event, slick) {
             $(slick.$slider).find('.slick-track').addClass('row');
         });
+        $('.ever-cover-carousel:not(.slick-initialised)').each(function(){
+            var $carousel = $(this);
+            $carousel.on('init', function(event, slick){
+                var $center = $(slick.$slides[slick.currentSlide]);
+                $(slick.$prevArrow).appendTo($center);
+                $(slick.$nextArrow).appendTo($center);
+            });
+            $carousel.on('afterChange', function(event, slick, currentSlide){
+                var $center = $(slick.$slides[currentSlide]);
+                $(slick.$prevArrow).appendTo($center);
+                $(slick.$nextArrow).appendTo($center);
+            });
+            $carousel.slick({
+                slidesToShow: 3,
+                centerMode: true,
+                arrows: true,
+                dots: false,
+                autoplay: false,
+                responsive: [{
+                    breakpoint: 768,
+                    settings: {
+                        slidesToShow: 1
+                    }
+                }]
+            });
+        });
     }
     $('.ever_instagram img').on('click', function() {
         // Mettre à jour le src de l'image dans la modal

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -16,7 +16,34 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 <div id="block-{$block.id_prettyblocks}" class="prettyblock-cover">
-  {if isset($block.states) && $block.states}
+{if isset($block.states) && $block.states}
+  {assign var='use_slider' value=(isset($block.settings.slider) && $block.settings.slider && $block.states|@count > 1)}
+  {if $use_slider}
+    <div class="ever-cover-carousel">
+      {foreach from=$block.states item=state key=key}
+        <div id="block-{$block.id_prettyblocks}-{$key}"
+             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if} text-center"
+             style="{if isset($state.background_image.url) && $state.background_image.url}background-image: url('{$state.background_image.url|escape:'htmlall'}'); background-size: cover; background-position: center;{/if}">
+          {if $state.title}
+            <h2>{$state.title|escape:'htmlall'}</h2>
+          {/if}
+          {if $state.content}
+            {$state.content nofilter}
+          {/if}
+          {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
+            <div class="mt-3 d-flex justify-content-center gap-2">
+              {if $state.btn1_text && $state.btn1_link}
+                <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
+              {/if}
+              {if $state.btn2_text && $state.btn2_link}
+                <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/foreach}
+    </div>
+  {else}
     {foreach from=$block.states item=state key=key}
       <div id="block-{$block.id_prettyblocks}-{$key}"
            class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if} text-center"
@@ -40,4 +67,5 @@
       </div>
     {/foreach}
   {/if}
+{/if}
 </div>


### PR DESCRIPTION
## Summary
- add configurable slider option to cover block
- render cover states in centered slick slider with navigation arrows
- style slider with faded side items and centered controls

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l translations/fr.php`


------
https://chatgpt.com/codex/tasks/task_e_6890c403d8188322b0f30788460496f3