### PR TITLE
Fix modal category filtering for products

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -2813,6 +2813,7 @@ class Everblock extends Module
                 // Only category management
                 if ((bool) $block['only_category'] === true
                     && Tools::getValue('controller') != 'category'
+                    && (bool) $block['only_category_product'] === false
                 ) {
                     continue;
                 }
@@ -2883,7 +2884,6 @@ class Everblock extends Module
                 // Only products pages with specific category
                 if (Tools::getValue('id_product')
                     && Tools::getValue('controller') === 'product'
-                    && (bool) $block['only_category'] === true
                     && (bool) $block['only_category_product'] === true
                 ) {
                     $product = new Product(


### PR DESCRIPTION
## Summary
- ensure blocks with product-category restrictions aren't shown outside their categories

## Testing
- `php -l everblock.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_6890c6e25bc88322b3061aa04ebf7091