### PR TITLE
Add shop logo shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[evercart]`: Display dropdown cart.
 - `[cart_total]`: Display the total value of the current cart.
 - `[cart_quantity]`: Display the number of products currently in the cart.
+- `[shop_logo]`: Display the shop logo.
 - `[newsletter_form]`: Display the PrestaShop newsletter subscription form.
 - `[nativecontact]`: Embed the native PrestaShop contact form (this replaces the obsolete `[evercontact]` shortcode).
 - `[everstore 4]`: Display store information for store ID 4 (several IDs can be separated with commas).

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -123,6 +123,9 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[cart_quantity]') !== false) {
             $txt = static::getCartQuantityShortcode($txt, $context);
         }
+        if (strpos($txt, '[shop_logo]') !== false) {
+            $txt = static::getShopLogoShortcode($txt, $context);
+        }
         if (strpos($txt, '[newsletter_form]') !== false) {
             $txt = static::getNewsletterFormShortcode($txt, $context, $module);
         }
@@ -1274,6 +1277,29 @@ class EverblockTools extends ObjectModel
         }
         $txt = str_replace('[cart_quantity]', (string) $quantity, $txt);
         return $txt;
+    }
+
+    public static function getShopLogoShortcode(string $txt, Context $context): string
+    {
+        $logoName = Configuration::get('PS_LOGO', null, null, (int) $context->shop->id);
+        $filePath = _PS_IMG_DIR_ . $logoName;
+        if (!$logoName || !file_exists($filePath)) {
+            return str_replace('[shop_logo]', '', $txt);
+        }
+
+        [$width, $height] = getimagesize($filePath);
+        $url = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'img/' . $logoName;
+        $alt = htmlspecialchars($context->shop->name, ENT_QUOTES);
+
+        $imgTag = sprintf(
+            '<img src="%s" alt="%s" width="%d" height="%d" />',
+            htmlspecialchars($url, ENT_QUOTES),
+            $alt,
+            (int) $width,
+            (int) $height
+        );
+
+        return str_replace('[shop_logo]', $imgTag, $txt);
     }
 
     public static function getNewsletterFormShortcode(string $txt, Context $context, Everblock $module): string


### PR DESCRIPTION
## Summary
- support `[shop_logo]` shortcode to render the shop's logo with alt, width and height attributes
- document the new shortcode

## Testing
- `php -l models/EverblockTools.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_6890d5cbf4748322949645361c991201