### PR TITLE
Add Google Map shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[manufacturer id="2" nb="8"]`: Display 8 products from manufacturer with ID 2.
 - `[brands nb="8"]`: Display 8 brand names with their associated logos. Optional `carousel=true`.
 - `[storelocator]`: Show a store locator on any CMS page.
+- `[evermap]`: Display a Google Map centered on the shop address when a Google Maps API key is configured.
 - `[subcategories id="2" nb="8"]`: Display 8 subcategories (name, image and link) of category 2.
 - `[last-products 4]`: Display the last 4 products listed in the store. Supports `carousel=true`.
 - `[best-sales 4]`: Display the 4 best-selling products in your store. Supports `carousel=true`.
@@ -317,6 +318,7 @@ Vous pouvez créer vos propres shortcodes depuis l'onglet "Shortcodes" accessibl
 - `[nativecontact]` : Intègre le formulaire de contact natif PrestaShop.
 - `[everimg name="image.jpg" class="img-fluid"]` : Affiche une ou plusieurs images CMS.
 - `[displayQcdSvg name="icon" class="myclass" inline=true]` : Affiche une icône SVG QCD. Module disponible chez [410 Gone](https://www.410-gone.fr/).
+- `[evermap]` : Affiche une carte Google centrée sur l'adresse de la boutique si la clé Google Maps est renseignée.
 - `[qcdacf field objectType objectId]` : Affiche une valeur provenant des champs QCD ACF. Module disponible chez [410 Gone](https://www.410-gone.fr/).
 - `[widget moduleName="mymodule" hookName="displayHome"]` : Affiche le widget d'un autre module.
 - `[prettyblocks name="myzone"]` : Affiche une zone PrettyBlocks si le module est installé.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -63,6 +63,9 @@ class EverblockTools extends ObjectModel
         if (strpos($txt, '[storelocator]') !== false) {
             $txt = static::generateGoogleMap($txt, $context, $module);
         }
+        if (strpos($txt, '[evermap]') !== false) {
+            $txt = static::getEverMapShortcode($txt, $context, $module);
+        }
         if (strpos($txt, '{hook h=') !== false) {
             $txt = static::replaceHook($txt);
         }
@@ -2675,6 +2678,55 @@ class EverblockTools extends ObjectModel
             })();
         ';
         return $googleMapCode;
+    }
+
+    public static function getEverMapShortcode(string $txt, Context $context, Everblock $module): string
+    {
+        $apiKey = Configuration::get('EVERBLOCK_GMAP_KEY');
+        if (!$apiKey) {
+            $message = $module->l('Please set a Google Maps API key in the module configuration.', 'EverblockTools');
+            return str_replace('[evermap]', $message, $txt);
+        }
+
+        $address1 = Configuration::get('PS_SHOP_ADDR1');
+        $postcode = Configuration::get('PS_SHOP_CODE');
+        $city = Configuration::get('PS_SHOP_CITY');
+        $idCountry = (int) Configuration::get('PS_SHOP_COUNTRY_ID');
+        $country = $idCountry ? new Country($idCountry, (int) $context->language->id) : null;
+        $countryName = $country ? $country->name : '';
+
+        if (!$address1 || !$postcode || !$city || !$countryName) {
+            $message = $module->l('Please fill the postal address of the shop.', 'EverblockTools');
+            return str_replace('[evermap]', $message, $txt);
+        }
+
+        $address2 = Configuration::get('PS_SHOP_ADDR2');
+        $fullAddress = trim($address1 . ' ' . $address2 . ' ' . $postcode . ' ' . $city . ' ' . $countryName);
+
+        $coords = static::getCoordinatesFromAddress($fullAddress, $apiKey);
+        if (!$coords) {
+            $message = $module->l('Unable to geocode the store address.', 'EverblockTools');
+            return str_replace('[evermap]', $message, $txt);
+        }
+
+        $mapHtml = '<div id="everblock-gmap" style="width:100%;height:300px;"></div>';
+        $mapHtml .= '<script>function initEverblockGmap(){var c={lat:' . $coords['lat'] . ',lng:' . $coords['lng'] . '};var m=new google.maps.Map(document.getElementById("everblock-gmap"),{zoom:15,center:c});new google.maps.Marker({position:c,map:m});}</script>';
+        $mapHtml .= '<script src="https://maps.googleapis.com/maps/api/js?key=' . $apiKey . '&callback=initEverblockGmap" async defer></script>';
+
+        return str_replace('[evermap]', $mapHtml, $txt);
+    }
+
+    public static function getCoordinatesFromAddress(string $address, string $apiKey)
+    {
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . urlencode($address) . '&key=' . $apiKey;
+        $response = Tools::file_get_contents($url);
+        if ($response) {
+            $data = json_decode($response, true);
+            if (isset($data['results'][0]['geometry']['location'])) {
+                return $data['results'][0]['geometry']['location'];
+            }
+        }
+        return false;
     }
 
     public static function getAllProducts(int $shopId, int $langId, $start = null, $limit = null, $orderBy = null, $orderWay = null): array

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -623,6 +623,9 @@ $_MODULE['<{everblock}prestashop>storelocator_047a1dd66c6e4d29b5f45cd776a42992']
 $_MODULE['<{everblock}prestashop>storelocator_0987be375bb6cdd954eb90e2b023ced4'] = 'Horaires à %s';
 $_MODULE['<{everblock}prestashop>storelocator_d3d2e617335f08df83599665eef8a418'] = 'Fermer';
 $_MODULE['<{everblock}prestashop>storelocator_a9407a9201ef1b64f0c567ed291574ba'] = 'S\'y rendre';
+$_MODULE['<{everblock}prestashop>everblocktools_465bdb56b331fa5d1b1e3bab14bc6c41'] = 'Veuillez renseigner la clé Google Maps dans la configuration du module.';
+$_MODULE['<{everblock}prestashop>everblocktools_d6f69704e815d4fa6fd548878c6f9d1e'] = 'Veuillez renseigner l\'adresse postale de la boutique.';
+$_MODULE['<{everblock}prestashop>everblocktools_8a46c2c7448b0db1b1ddc0d5e44629da'] = 'Impossible de géocoder l\'adresse de la boutique.';
 $_MODULE['<{everblock}prestashop>prettyblock_login_ce8ae9da5b7cd6c3df2929543a9af92d'] = 'Email';
 $_MODULE['<{everblock}prestashop>prettyblock_login_4d2c105ff95dbd829718674aadd3254d'] = 'Mot de passe';
 $_MODULE['<{everblock}prestashop>prettyblock_login_57478054ae00730105f1bfe535b2225e'] = 'Récupérez votre mot de passe oublié';


### PR DESCRIPTION
## Summary
- add [evermap] shortcode to display a map centered on the shop address
- provide translations and docs for new shortcode

## Testing
- `php -l models/EverblockTools.php`
- `php -l translations/fr.php`
- `vendor/bin/phpstan analyse models/EverblockTools.php --no-progress` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890cec234488322816c32f68c562e22