### PR TITLE
fix: allow category product retrieval from templates

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -816,7 +816,7 @@ class EverblockTools extends ObjectModel
         return $txt;
     }
 
-    protected static function getProductsByCategoryId(int $categoryId, int $limit, string $orderBy = 'id_product', string $orderWay = 'ASC'): array
+    public static function getProductsByCategoryId(int $categoryId, int $limit, string $orderBy = 'id_product', string $orderWay = 'ASC'): array
     {
         $cacheId = 'everblock_getProductsByCategoryId_' . $categoryId . '_' . $limit . '_' . $orderBy . '_' . $orderWay;
 


### PR DESCRIPTION
## Summary
- make `EverblockTools::getProductsByCategoryId` public so templates can access it

## Testing
- `php-cs-fixer fix --allow-risky=yes` *(fails: command not found)*
- `phpstan analyse` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c4223eb88322bb12bff93339a47b