### PR TITLE
Handle non-numeric category IDs

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -816,8 +816,14 @@ class EverblockTools extends ObjectModel
         return $txt;
     }
 
-    public static function getProductsByCategoryId(int $categoryId, int $limit, string $orderBy = 'id_product', string $orderWay = 'ASC'): array
+    public static function getProductsByCategoryId($categoryId, int $limit, string $orderBy = 'id_product', string $orderWay = 'ASC'): array
     {
+        $categoryId = (int) $categoryId;
+
+        if ($categoryId <= 0) {
+            return [];
+        }
+
         $cacheId = 'everblock_getProductsByCategoryId_' . $categoryId . '_' . $limit . '_' . $orderBy . '_' . $orderWay;
 
         if (!EverblockCache::isCacheStored($cacheId)) {


### PR DESCRIPTION
## Summary
- safely handle category IDs passed as strings before fetching products

## Testing
- `php -l models/EverblockTools.php`
- `php vendor/bin/phpstan analyse` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_6894c7a5b9ac8322a4b8590e0157910e