### PR TITLE
Make French holidays getter public

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -2588,7 +2588,7 @@ class EverblockTools extends ObjectModel
     }
 
 
-    protected static function getFrenchHolidays($year)
+    public static function getFrenchHolidays($year)
     {
         $easterDate = easter_date($year);
         $holidays = [


### PR DESCRIPTION
## Summary
- expose `EverblockTools::getFrenchHolidays` as public so it can be accessed from `Everblock`

## Testing
- `php -l models/EverblockTools.php`
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_6894ca91398483229e44fc96c0d497a1