### PR TITLE
feat: configure holiday hours per store

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -2472,8 +2472,6 @@ class EverblockTools extends ObjectModel
             $currentTime = $now->format('H:i');
             $todayDate = $now->format('Y-m-d');
             $frenchHolidays = self::getFrenchHolidays((int) $now->format('Y'));
-            $holidayHours = self::getHolidayHoursConfig($id_shop);
-            $todayHolidaySlot = $holidayHours[$todayDate] ?? null;
             $isHoliday = in_array($todayDate, $frenchHolidays);
 
             foreach ($stores as &$store) {
@@ -2481,7 +2479,7 @@ class EverblockTools extends ObjectModel
                 $cms_id = (int) Configuration::get('QCD_ASSOCIATED_CMS_PAGE_ID_STORE_' . $id_store, null, null, $id_shop);
                 $cms_link = null;
                 $storeHolidayHours = self::getStoreHolidayHoursConfig($id_store);
-                $todayStoreHolidaySlot = $storeHolidayHours[$todayDate] ?? $todayHolidaySlot;
+                $todayStoreHolidaySlot = $storeHolidayHours[$todayDate] ?? null;
 
                 if ($cms_id > 0) {
                     $cms = new CMS($cms_id, $id_lang, $id_shop);
@@ -2610,31 +2608,6 @@ class EverblockTools extends ObjectModel
         ];
 
         return $holidays;
-    }
-
-    protected static function getHolidayHoursConfig(?int $idShop = null): array
-    {
-        if (!$idShop) {
-            $idShop = (int) Context::getContext()->shop->id;
-        }
-        $config = Configuration::get('EVERBLOCK_HOLIDAY_HOURS', null, null, (int) $idShop);
-        $result = [];
-        if ($config) {
-            $lines = preg_split('/[\r\n]+/', $config);
-            foreach ($lines as $line) {
-                $line = trim($line);
-                if (!$line) {
-                    continue;
-                }
-                if (strpos($line, '=') !== false) {
-                    [$date, $hours] = array_map('trim', explode('=', $line, 2));
-                    if (Validate::isDate($date) && $hours !== '') {
-                        $result[$date] = $hours;
-                    }
-                }
-            }
-        }
-        return $result;
     }
 
     protected static function getStoreHolidayHoursConfig(int $storeId): array


### PR DESCRIPTION
## Summary
- allow configuring holiday opening hours per store
- load and save holiday hours per store in module configuration
- display store-specific holiday hours on store locator when day is a holiday

## Testing
- `php -l everblock.php`
- `php -l models/EverblockTools.php`
- `vendor/bin/phpstan analyse` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895a0289268832280cb18983783ca9a