### PR TITLE
Ensure first carousel slide is active

### DIFF
--- a/views/templates/hook/ever_img_carousel.tpl
+++ b/views/templates/hook/ever_img_carousel.tpl
@@ -18,8 +18,8 @@
 {if isset($images) && $images}
   <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
     <div class="carousel-inner">
-      {foreach from=$images item=image key=key}
-        <div class="carousel-item{if $key == 0} active{/if}">
+      {foreach from=$images item=image}
+        <div class="carousel-item{if $image@first} active{/if}">
           <picture>
             <source srcset="{$image.src}" type="image/webp">
             <source srcset="{$image.src|replace:'.webp':'.jpg'}" type="image/jpeg">

--- a/views/templates/hook/linkedproducts_carousel.tpl
+++ b/views/templates/hook/linkedproducts_carousel.tpl
@@ -19,15 +19,15 @@
   <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
     <div class="carousel-inner">
       {assign var="numProductsPerSlide" value=4}
-      {foreach from=$everPresentProducts item=product key=key}
-        {if $key % $numProductsPerSlide == 0}
-          <div class="carousel-item{if $key == 0} active{/if}">
+      {foreach from=$everPresentProducts item=product name=products}
+        {if $product@index % $numProductsPerSlide == 0}
+          <div class="carousel-item{if $product@first} active{/if}">
             <div class="row">
         {/if}
         <div class="col-md-3">
           {include file="catalog/_partials/miniatures/product.tpl" product=$product}
         </div>
-        {if ($key + 1) % $numProductsPerSlide == 0 || $key == count($everPresentProducts) - 1}
+        {if ($product@index + 1) % $numProductsPerSlide == 0 || $product@last}
             </div>
           </div>
         {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -19,8 +19,8 @@
   {if isset($block.states) && $block.states}
     <div id="cardCarousel-{$block.id_prettyblocks}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
       <div class="carousel-inner">
-        {foreach from=$block.states item=state key=key}
-          <div class="carousel-item{if $key == 0} active{/if}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}">
+        {foreach from=$block.states item=state}
+          <div class="carousel-item{if $state@first} active{/if}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}">
             <div class="card h-100 mb-3">
               {if isset($state.image.url) && $state.image.url}
                 {assign var="imgExt" value=$state.image.url|lower|substr:-4}

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
@@ -32,8 +32,8 @@
     {if isset($block.states) && $block.states}
     <div id="testimonialCarousel-{$block.id_prettyblocks}" class="carousel slide everblock-testimonial" data-ride="carousel" data-bs-ride="carousel">
         <div class="carousel-inner">
-            {foreach from=$block.states item=state key=key}
-                <div class="carousel-item {if $key == 0}active{/if}" style="
+            {foreach from=$block.states item=state}
+                <div class="carousel-item{if $state@first} active{/if}" style="
                     {if isset($state.padding_left) && $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}
                     {if isset($state.padding_right) && $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}
                     {if isset($state.padding_top) && $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}


### PR DESCRIPTION
## Summary
- Ensure carousel templates mark the first item as active using iteration state
- Use iteration indexes for product carousels to avoid missing active class

## Testing
- `php -l views/templates/hook/prettyblocks/prettyblock_card.tpl`
- `php -l views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl`
- `php -l views/templates/hook/ever_img_carousel.tpl`
- `php -l views/templates/hook/linkedproducts_carousel.tpl`


------
https://chatgpt.com/codex/tasks/task_e_6896f825ba888322a7def899ed4d2e6f