### PR TITLE
feat: add product limit for category tabs

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3542,9 +3542,13 @@ class Everblock extends Module
                 if (empty($state['id_category'])) {
                     continue;
                 }
+                $limit = isset($state['nb_products']) ? (int) $state['nb_products'] : 0;
+                if ($limit <= 0) {
+                    $limit = (int) Configuration::get('PS_PRODUCTS_PER_PAGE');
+                }
                 $rawProducts = EverblockTools::getProductsByCategoryId(
                     (int) $state['id_category'],
-                    0
+                    $limit
                 );
                 $presented = EverblockTools::everPresentProducts(
                     array_column($rawProducts, 'id_product'),

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2616,6 +2616,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Category ID'),
                             'default' => '',
                         ],
+                        'nb_products' => [
+                            'type' => 'text',
+                            'label' => $module->l('Number of products to display (0 for default)'),
+                            'default' => 0,
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),


### PR DESCRIPTION
## Summary
- add `nb_products` option to category tabs PrettyBlocks configuration
- respect configured product count or PrestaShop default in hook

## Testing
- `php -l everblock.php`
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_689708dc0a00832291199e170098dc58