### PR TITLE
feat: add alert shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[cart_quantity]`: Display the number of products currently in the cart.
 - `[shop_logo]`: Display the shop logo.
 - `[newsletter_form]`: Display the PrestaShop newsletter subscription form.
+- `[alert type="success"]Content[/alert]`: Display a Bootstrap alert box. Supports `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light`, and `dark`.
 - `[nativecontact]`: Embed the native PrestaShop contact form (this replaces the obsolete `[evercontact]` shortcode).
 - `[everstore 4]`: Display store information for store ID 4 (several IDs can be separated with commas).
 - `[video https://www.youtube.com/embed/35kwlY_RR08?si=QfwsUt9sEukni0Gj]`: Display a YouTube iframe of the video whose sharing URL is in the parameter (may also works with Vimeo, Dailymotion, and Vidyard).

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -36,6 +36,9 @@ class EverblockTools extends ObjectModel
             'modulefront',
         ];
         $txt = static::getEverShortcodes($txt, $context);
+        if (strpos($txt, '[alert') !== false) {
+            $txt = static::getAlertShortcode($txt);
+        }
         if (strpos($txt, '[everfaq') !== false) {
             $txt = static::getFaqShortcodes($txt, $context, $module);
         }
@@ -1603,6 +1606,27 @@ class EverblockTools extends ObjectModel
         );
 
         return str_replace('[shop_logo]', $imgTag, $txt);
+    }
+
+    public static function getAlertShortcode(string $txt): string
+    {
+        $allowedTypes = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark'];
+
+        return (string) preg_replace_callback(
+            '/\[alert(?:\s+([^\]]+))?\](.*?)\[\/alert\]/is',
+            function ($matches) use ($allowedTypes) {
+                $attrs = static::parseShortcodeAttrs($matches[1] ?? '');
+                $type = strtolower($attrs['type'] ?? 'info');
+
+                if (!in_array($type, $allowedTypes, true)) {
+                    $type = 'info';
+                }
+
+                $content = $matches[2];
+                return '<div class="alert alert-' . $type . '" role="alert">' . $content . '</div>';
+            },
+            $txt
+        );
     }
 
     public static function getNewsletterFormShortcode(string $txt, Context $context, Everblock $module): string


### PR DESCRIPTION
## Summary
- support `[alert]` shortcode for Bootstrap message boxes
- document usage of new alert shortcode

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_689717d644e88322bad65d7a6cdeb365