### PR TITLE
Fix default active tab for category tabs block

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -23,17 +23,17 @@
     <div class="mt-2 col-12 d-flex justify-content-center text-center">
         <div class="tab-container">
             <ul class="nav nav-tabs justify-content-center" role="tablist">
-                {foreach from=$block.states item=state key=key}
+                {foreach from=$block.states item=state key=key name=categorytabs}
                     <li class="nav-item">
-                        <a class="nav-link {if $key == 0}active{/if}" data-toggle="tab" data-bs-toggle="tab" href="#tab-{$block.id_prettyblocks}-{$key}" role="tab" aria-controls="tab-{$block.id_prettyblocks}-{$key}" aria-selected="{if $key == 0}true{else}false{/if}">
+                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" data-toggle="tab" data-bs-toggle="tab" href="#tab-{$block.id_prettyblocks}-{$key}" role="tab" aria-controls="tab-{$block.id_prettyblocks}-{$key}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}">
                             {$state.name}
                         </a>
                     </li>
                 {/foreach}
             </ul>
             <div class="tab-content">
-                {foreach from=$block.states item=state key=key}
-                    <div class="tab-pane {if $key == 0}show active{/if}" id="tab-{$block.id_prettyblocks}-{$key}" role="tabpanel" aria-labelledby="tab-{$block.id_prettyblocks}-{$key}-tab">
+                {foreach from=$block.states item=state key=key name=categorytabs}
+                    <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}" id="tab-{$block.id_prettyblocks}-{$key}" role="tabpanel" aria-labelledby="tab-{$block.id_prettyblocks}-{$key}-tab">
                         {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                         <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
                             <div class="products row">


### PR DESCRIPTION
## Summary
- ensure Category Tabs block automatically marks and shows the first tab on page load

## Testing
- `vendor/bin/php-cs-fixer --version` (fails: No such file or directory)
- `vendor/bin/phpstan --version` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_6897199aa5048322b1158f27f489c6ab