### PR TITLE
Add low stock product shortcode

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -115,6 +115,7 @@ class Everblock extends Module
             true
         );
         Configuration::updateValue('EVERBLOCK_SOLDOUT_FLAG', 0);
+        Configuration::updateValue('EVERBLOCK_LOW_STOCK_THRESHOLD', 5);
         // Install SQL
         $sql = [];
         include dirname(__FILE__) . '/sql/install.php';
@@ -196,6 +197,7 @@ class Everblock extends Module
         Configuration::deleteByName('EVER_SOLDOUT_TEXTCOLOR');
         Configuration::deleteByName('EVERBLOCK_SOLDOUT_FLAG');
         Configuration::deleteByName('EVERINSTA_SHOW_CAPTION');
+        Configuration::deleteByName('EVERBLOCK_LOW_STOCK_THRESHOLD');
         return (parent::uninstall()
             && $this->uninstallModuleTab('AdminEverBlockParent')
             && $this->uninstallModuleTab('AdminEverBlock')

--- a/views/templates/hook/low_stock.tpl
+++ b/views/templates/hook/low_stock.tpl
@@ -1,0 +1,10 @@
+{if $products|@count}
+  <div class="eb-low-stock cols-{$cols|default:4}">
+    {foreach $products as $product}
+      {include file='catalog/_partials/miniatures/product.tpl' product=$product}
+    {/foreach}
+  </div>
+{else}
+  <div class="eb-low-stock--empty">{l s='No low stock products.' mod='everblock'}</div>
+{/if}
+


### PR DESCRIPTION
## Summary
- support `[low_stock]` shortcode to display products nearing stock depletion with configurable filters
- parse shortcode attributes with pipe-separated values
- store default low stock threshold in configuration and provide Smarty template for rendering

## Testing
- `php -l models/EverblockTools.php`
- `php -l everblock.php`
- `composer validate`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68972afe89a883228c3f9be4f7ea07c9