### PR TITLE
Use store-specific PrettyBlocks widget in store locator

### DIFF
--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -80,7 +80,7 @@
           </div>
           {hook h='displayAfterLocatorStore' store=$item}
           {if $has_prettyblocks}
-            {hook h='displayPrettyBlocksStoreLocator' store=$item}
+            {widget name="displayPrettyBlocksStoreLocator" zone_name="displayPrettyBlocksStoreLocator{$item.id}"}
           {/if}
 
           {* Modal horaires *}


### PR DESCRIPTION
## Summary
- switch store locator from hook to PrettyBlocks widget with store-specific zone name

## Testing
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_689b2724dca08322909dd8f227e0324a