### PR TITLE
feat: enhance store locator search

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1740,8 +1740,10 @@ class Everblock extends Module
                     'title' => $store['name'],
                     'address' => $address,
                     'phone' => $store['phone'],
-                    'img' => $context->link->getMediaLink('img/st/' . $storeId . '.jpg'),
+                    'img' => $context->link->getBaseLink(null, null) . 'img/st/' . $storeId . '.jpg',
                     'status' => $status,
+                    'directions_label' => $this->l('Get directions'),
+                    'hours_label' => $this->l('See hours'),
                 ];
                 $markers[] = $marker;
             }

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -639,3 +639,7 @@ $_MODULE['<{everblock}prestashop>everblock_21f59a9a3e796f0e797ad7736028089c'] = 
 $_MODULE['<{everblock}prestashop>everblock_a97e8578c3942df9fc98bb501d385883'] = 'Heure d\'ouverture de %s le %s';
 $_MODULE['<{everblock}prestashop>everblock_5ce749b4b55e9ed91bda1aba920e1ffd'] = 'Heure de fermeture de %s le %s';
 $_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Activer le slider';
+$_MODULE['<{everblock}prestashop>storelocator_1d66769fe7f641de0c633976e5f46cb5'] = 'Trouver un magasin';
+$_MODULE['<{everblock}prestashop>storelocator_13348442cc6a27032d2b4aa28b75a5d3'] = 'Rechercher';
+$_MODULE['<{everblock}prestashop>storelocator_46f3ea056caa3126b91f3f70beea068c'] = 'Carte';
+$_MODULE['<{everblock}prestashop>storelocator_821b8ee6937cec96c30fdafbfe836d68'] = 'Magasins';

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -16,15 +16,29 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 <div id="store-search-block" class="mb-3">
-  <div class="input-group">
-    <input type="text" class="form-control" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
+  <div class="d-flex flex-column flex-md-row align-items-md-center">
+    <label for="store_search" class="me-md-2 mb-2 mb-md-0">{l s='Find a store' mod='everblock'}</label>
+    <input type="text" class="form-control mb-2 mb-md-0 me-md-2" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
+    <button type="button" id="store_search_btn" class="btn btn-primary">{l s='Search' mod='everblock'}</button>
   </div>
 </div>
 {hook h='displayBeforeStoreLocator'}
-<div id="everblock-storelocator-wrapper" class="row">
-  <div class="col-12 col-md-4">
-    <div id="everblock-storelist" class="row g-4">
-      {foreach from=$everblock_stores item=item name=store_loop}
+<div id="everblock-storelocator-wrapper" class="mb-3">
+  <ul class="nav nav-tabs" id="storeLocatorTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="tab-map" data-bs-toggle="tab" data-bs-target="#pane-map" type="button" role="tab" aria-controls="pane-map" aria-selected="true">{l s='Map' mod='everblock'}</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="tab-list" data-bs-toggle="tab" data-bs-target="#pane-list" type="button" role="tab" aria-controls="pane-list" aria-selected="false">{l s='Stores' mod='everblock'}</button>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane fade show active" id="pane-map" role="tabpanel" aria-labelledby="tab-map">
+      <div id="everblock-storelocator" class="everblock-storelocator w-100 h-100"></div>
+    </div>
+    <div class="tab-pane fade" id="pane-list" role="tabpanel" aria-labelledby="tab-list">
+      <div id="everblock-storelist" class="row g-4">
+        {foreach from=$everblock_stores item=item name=store_loop}
         {assign var="hasCoordinates" value=(isset($item.latitude) && isset($item.longitude) && $item.latitude != '' && $item.longitude != '')}
         <div class="col-12 everblock-store-item" data-lat="{$item.latitude}" data-lng="{$item.longitude}">
           <div class="d-flex align-items-start">
@@ -43,14 +57,14 @@
                   {$item.name|escape:'htmlall':'UTF-8'}
                 {/if}
               </h6>
-              <p class="mb-0 small text-muted">
+              <p class="mb-0 small">
                 {$item.address1|escape:'htmlall':'UTF-8'}<br>
                 {if $item.address2}{$item.address2|escape:'htmlall':'UTF-8'}<br>{/if}
                 {$item.postcode} {$item.city}
               </p>
               {if $item.phone}
                 <p class="mb-1 small">
-                  <span class="text-muted">{l s='Tel:' mod='everblock'}</span>
+                  <span>{l s='Tel:' mod='everblock'}</span>
                   <a href="tel:{$item.phone|replace:' ':''|escape:'htmlall':'UTF-8'}" class="text-dark text-decoration-none">+{$item.phone|escape:'htmlall':'UTF-8'}</a>
                 </p>
               {/if}
@@ -80,7 +94,7 @@
           </div>
           {hook h='displayAfterLocatorStore' store=$item}
           {if $has_prettyblocks}
-            {widget name="displayPrettyBlocksStoreLocator" zone_name="displayPrettyBlocksStoreLocator{$item.id}"}
+            {prettyblocks_zone zone_name="displayPrettyBlocksStoreLocator{$item.id}"}
           {/if}
 
           {* Modal horaires *}
@@ -117,10 +131,8 @@
           </div>
         </div>
       {/foreach}
+      </div>
     </div>
-  </div>
-  <div class="col-12 col-md-8">
-    <div id="everblock-storelocator" class="everblock-storelocator w-100 h-100"></div>
   </div>
 </div>
 {hook h='displayAfterStoreLocator'}


### PR DESCRIPTION
## Summary
- add translatable label and search button to store locator
- show store map and list inside tabs
- reset map and store list when search is cleared
- fix PrettyBlocks integration and improve marker info

## Testing
- `php -l models/EverblockTools.php`
- `php -l everblock.php`
- `php -l translations/fr.php`


------
https://chatgpt.com/codex/tasks/task_e_689b2813a0e483229c1a17ad992b8d06