### PR TITLE
Disable store locator without Google Maps key

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[category id="8" nb="8"]`: Display 8 products from category with ID 8.
 - `[manufacturer id="2" nb="8"]`: Display 8 products from manufacturer with ID 2.
 - `[brands nb="8"]`: Display 8 brand names with their associated logos. Optional `carousel=true`.
-- `[storelocator]`: Show a store locator on any CMS page.
+- `[storelocator]`: Show a store locator on any CMS page when a Google Maps API key is configured.
 - `[evermap]`: Display a Google Map centered on the shop address when a Google Maps API key is configured.
 - `[subcategories id="2" nb="8"]`: Display 8 subcategories (name, image and link) of category 2.
 - `[last-products 4]`: Display the last 4 products listed in the store. Supports `carousel=true`.

--- a/everblock.php
+++ b/everblock.php
@@ -1716,6 +1716,8 @@ class Everblock extends Module
             $this->emptyAllCache();
         }
         $stores = EverblockTools::getStoreLocatorData();
+        $filename = 'store-locator-' . $idShop . '.js';
+        $filePath = _PS_MODULE_DIR_ . $this->name . '/views/js/' . $filename;
         if (!empty($stores) && Tools::getValue('EVERBLOCK_GMAP_KEY')) {
             $markers = [];
             $context = Context::getContext();
@@ -1749,10 +1751,10 @@ class Everblock extends Module
             }
             $gmapScript = EverblockTools::generateGoogleMapScript($markers);
             if ($gmapScript) {
-                $filename = 'store-locator-' . $idShop . '.js';
-                $filePath = _PS_MODULE_DIR_ . $this->name . '/views/js/' . $filename;
                 file_put_contents($filePath, $gmapScript);
             }
+        } elseif (file_exists($filePath)) {
+            unlink($filePath);
         }
         $this->generateFeatureFlagsCssFile();
         $this->generateSoldOutFlagCssFile();
@@ -3170,17 +3172,15 @@ class Everblock extends Module
         }
         // Do not show GMAP api KEY on Everblock cache
         $apiKey = Configuration::get('EVERBLOCK_GMAP_KEY');
-        if (Tools::getValue('controller') == 'cms') {
+        if ($apiKey && Tools::getValue('controller') == 'cms') {
             $filename = 'store-locator-' . $idShop . '.js';
             $filePath = _PS_MODULE_DIR_ . $this->name . '/views/js/' . $filename;
             if (file_exists($filePath) && filesize($filePath) > 0) {
-                if ($apiKey) {
-                    $this->context->controller->registerJavascript(
-                        'module-' . $this->name . '-custom-gmap-js',
-                        'https://maps.googleapis.com/maps/api/js?key=' . $apiKey . '&libraries=places,geometry',
-                        ['server' => 'remote', 'position' => 'bottom', 'priority' => 300, 'attributes' => 'defer']
-                    );
-                }
+                $this->context->controller->registerJavascript(
+                    'module-' . $this->name . '-custom-gmap-js',
+                    'https://maps.googleapis.com/maps/api/js?key=' . $apiKey . '&libraries=places,geometry',
+                    ['server' => 'remote', 'position' => 'bottom', 'priority' => 300, 'attributes' => 'defer']
+                );
                 $this->context->controller->registerJavascript(
                     'module-' . $this->name . '-shop-map-js',
                     'modules/' . $this->name . '/views/js/' . $filename,

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3156,6 +3156,10 @@ class EverblockTools extends ObjectModel
 
     public static function generateGoogleMap(string $txt, Context $context, Everblock $module): string
     {
+        $apiKey = Configuration::get('EVERBLOCK_GMAP_KEY');
+        if (!$apiKey) {
+            return str_replace('[storelocator]', '', $txt);
+        }
         $stores = static::getStoreLocatorData();
         if (!empty($stores)) {
             $smarty = $context->smarty;


### PR DESCRIPTION
## Summary
- Ensure `[storelocator]` renders only when a Google Maps API key is configured
- Register and generate store locator scripts only with an API key, removing stale files otherwise
- Document the API key requirement for the store locator shortcode

## Testing
- `php -l models/EverblockTools.php`
- `php -l everblock.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689b2b08bca08322b3a6421d260678e7