### PR TITLE
fix: show store list and center search

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -318,3 +318,10 @@
 .ever-cover-carousel .slick-next {
     right: 10px;
 }
+
+/* Store locator adjustments */
+@media (min-width: 768px) {
+  #everblock-storelocator-wrapper #pane-list {
+    opacity: 1;
+  }
+}

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -15,8 +15,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="store-search-block" class="mb-3">
-  <div class="d-flex flex-column flex-md-row align-items-md-center">
+<div id="store-search-block" class="mb-3 text-center">
+  <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-center">
     <label for="store_search" class="me-md-2 mb-2 mb-md-0">{l s='Find a store' mod='everblock'}</label>
     <input type="text" class="form-control mb-2 mb-md-0 me-md-2 w-100" style="max-width:375px;" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
     <button type="button" id="store_search_btn" class="btn btn-primary">{l s='Search' mod='everblock'}</button>
@@ -33,10 +33,10 @@
     </li>
   </ul>
   <div class="tab-content row">
-    <div class="tab-pane fade show active col-12 col-md-8 d-md-block" id="pane-map" role="tabpanel" aria-labelledby="tab-map">
+    <div class="tab-pane fade show active col-12 col-md-8 d-md-block order-md-2" id="pane-map" role="tabpanel" aria-labelledby="tab-map">
       <div id="everblock-storelocator" class="everblock-storelocator w-100 h-100"></div>
     </div>
-    <div class="tab-pane fade col-12 col-md-4 d-md-block" id="pane-list" role="tabpanel" aria-labelledby="tab-list">
+    <div class="tab-pane fade col-12 col-md-4 d-md-block order-md-1" id="pane-list" role="tabpanel" aria-labelledby="tab-list">
       <div id="everblock-storelist" class="row g-4" style="max-height:500px; overflow-y:auto;">
         {foreach from=$everblock_stores item=item name=store_loop}
         {assign var="hasCoordinates" value=(isset($item.latitude) && isset($item.longitude) && $item.latitude != '' && $item.longitude != '')}


### PR DESCRIPTION
## Summary
- ensure store list is visible on desktop and sits left of map
- center the "Find a store" search bar above the locator

## Testing
- `php -l everblock.php`
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_689b2f18b364832285a6c0af98e02ce4