### PR TITLE
Improve mobile store locator UI and marker layout

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3200,7 +3200,7 @@ class EverblockTools extends ObjectModel
 
                 function renderContent(marker) {
                     var phone = marker.phone ? `<div>${marker.phone}</div>` : "";
-                    var directions = `<a href="https://www.google.com/maps/dir/?api=1&destination=${marker.lat},${marker.lng}" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm mt-2">${marker.directions_label}</a>`;
+                    var directions = `<a href="https://www.google.com/maps/dir/?api=1&destination=${marker.lat},${marker.lng}" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">${marker.directions_label}</a>`;
                     return `
                         <div class="everblock-marker-info">
                             <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;margin-bottom:8px;"><br>
@@ -3208,8 +3208,8 @@ class EverblockTools extends ObjectModel
                             ${marker.address}<br>
                             ${phone}
                             <div>${marker.status}</div>
-                            ${directions}
                             <a href="#" data-bs-toggle="modal" data-bs-target="#storeHoursModal${marker.id}">${marker.hours_label}</a>
+                            <div class="mt-2">${directions}</div>
                         </div>
                     `;
                 }
@@ -3331,6 +3331,44 @@ class EverblockTools extends ObjectModel
                         }
                     });
                 }
+
+                document.addEventListener("DOMContentLoaded", function () {
+                    var mapTabBtn = document.getElementById("tab-map");
+                    var listTabBtn = document.getElementById("tab-list");
+                    var mapPane = document.getElementById("pane-map");
+                    var listPane = document.getElementById("pane-list");
+
+                    if (mapTabBtn && listTabBtn && mapPane && listPane) {
+                        function showMapPane() {
+                            mapPane.classList.add("show", "active");
+                            listPane.classList.remove("show", "active");
+                            mapTabBtn.classList.add("active");
+                            listTabBtn.classList.remove("active");
+                            if (typeof google !== "undefined" && map) {
+                                google.maps.event.trigger(map, "resize");
+                            }
+                        }
+
+                        function showListPane() {
+                            listPane.classList.add("show", "active");
+                            mapPane.classList.remove("show", "active");
+                            listTabBtn.classList.add("active");
+                            mapTabBtn.classList.remove("active");
+                        }
+
+                        mapTabBtn.addEventListener("click", function (e) {
+                            e.preventDefault();
+                            showMapPane();
+                        });
+
+                        listTabBtn.addEventListener("click", function (e) {
+                            e.preventDefault();
+                            showListPane();
+                        });
+
+                        showMapPane();
+                    }
+                });
 
                 google.maps.event.addDomListener(window, "load", initAutocomplete);
                 google.maps.event.addDomListener(window, "load", initMap);

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -325,3 +325,18 @@
     opacity: 1;
   }
 }
+
+@media (max-width: 767.98px) {
+  #storeLocatorTabs .nav-item {
+    width: 50%;
+  }
+  #storeLocatorTabs .nav-link {
+    width: 100%;
+    text-align: center;
+  }
+  #store_search {
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -18,7 +18,7 @@
 <div id="store-search-block" class="mb-3 text-center">
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-center">
     <label for="store_search" class="me-md-2 mb-2 mb-md-0">{l s='Find a store' mod='everblock'}</label>
-    <input type="text" class="form-control mb-2 mb-md-0 me-md-2 w-100" style="max-width:375px;" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
+    <input type="text" class="form-control mb-2 mb-md-0 me-md-2 w-100" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
     <button type="button" id="store_search_btn" class="btn btn-primary">{l s='Search' mod='everblock'}</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Move marker "Get directions" button under the "See hours" link
- Ensure map/list tabs work correctly on mobile and default to the map
- Tweak mobile styling: 50% width tabs and 400px max width search field

## Testing
- `php -l models/EverblockTools.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689b3150c9388322b63c5782c0308315