### PR TITLE
Fix store locator popup spacing and mobile map tab

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1722,11 +1722,6 @@ class Everblock extends Module
             $markers = [];
             $context = Context::getContext();
             foreach ($stores as $store) {
-                $address = $store['address1'];
-                if (!empty($store['address2'])) {
-                    $address .= ' ' . $store['address2'];
-                }
-                $address .= ', ' . $store['postcode'] . ' ' . $store['city'];
                 $storeId = isset($store['id']) ? (int) $store['id'] : (int) $store['id_store'];
                 if (!empty($store['is_open'])) {
                     $status = sprintf($this->l('Open today until %s'), $store['open_until']);
@@ -1740,7 +1735,10 @@ class Everblock extends Module
                     'lat' => $store['latitude'],
                     'lng' => $store['longitude'],
                     'title' => $store['name'],
-                    'address' => $address,
+                    'address1' => $store['address1'],
+                    'address2' => $store['address2'],
+                    'postcode' => $store['postcode'],
+                    'city' => $store['city'],
                     'phone' => $store['phone'],
                     'img' => $context->link->getBaseLink(null, null) . 'img/st/' . $storeId . '.jpg',
                     'status' => $status,

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3200,16 +3200,23 @@ class EverblockTools extends ObjectModel
 
                 function renderContent(marker) {
                     var phone = marker.phone ? `<div>${marker.phone}</div>` : "";
+                    var address2 = marker.address2 ? marker.address2 + "<br>" : "";
                     var directions = `<a href="https://www.google.com/maps/dir/?api=1&destination=${marker.lat},${marker.lng}" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-sm">${marker.directions_label}</a>`;
                     return `
-                        <div class="everblock-marker-info">
-                            <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;margin-bottom:8px;"><br>
-                            <strong>${marker.title}</strong><br>
-                            ${marker.address}<br>
-                            ${phone}
-                            <div>${marker.status}</div>
-                            <a href="#" data-bs-toggle="modal" data-bs-target="#storeHoursModal${marker.id}">${marker.hours_label}</a>
-                            <div class="mt-2">${directions}</div>
+                        <div class="everblock-marker-info row g-2">
+                            <div class="col-4">
+                                <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;" class="rounded w-100">
+                            </div>
+                            <div class="col-8">
+                                <strong>${marker.title}</strong><br>
+                                ${marker.address1}<br>
+                                ${address2}
+                                ${marker.postcode} ${marker.city}<br>
+                                ${phone}
+                                <div>${marker.status}</div>
+                                <a href="#" data-bs-toggle="modal" data-bs-target="#storeHoursModal${marker.id}"><u>${marker.hours_label}</u> &gt;</a>
+                                <div class="mt-2">${directions}</div>
+                            </div>
                         </div>
                     `;
                 }
@@ -3334,39 +3341,12 @@ class EverblockTools extends ObjectModel
 
                 document.addEventListener("DOMContentLoaded", function () {
                     var mapTabBtn = document.getElementById("tab-map");
-                    var listTabBtn = document.getElementById("tab-list");
-                    var mapPane = document.getElementById("pane-map");
-                    var listPane = document.getElementById("pane-list");
-
-                    if (mapTabBtn && listTabBtn && mapPane && listPane) {
-                        function showMapPane() {
-                            mapPane.classList.add("show", "active");
-                            listPane.classList.remove("show", "active");
-                            mapTabBtn.classList.add("active");
-                            listTabBtn.classList.remove("active");
+                    if (mapTabBtn) {
+                        mapTabBtn.addEventListener("shown.bs.tab", function () {
                             if (typeof google !== "undefined" && map) {
                                 google.maps.event.trigger(map, "resize");
                             }
-                        }
-
-                        function showListPane() {
-                            listPane.classList.add("show", "active");
-                            mapPane.classList.remove("show", "active");
-                            listTabBtn.classList.add("active");
-                            mapTabBtn.classList.remove("active");
-                        }
-
-                        mapTabBtn.addEventListener("click", function (e) {
-                            e.preventDefault();
-                            showMapPane();
                         });
-
-                        listTabBtn.addEventListener("click", function (e) {
-                            e.preventDefault();
-                            showListPane();
-                        });
-
-                        showMapPane();
                     }
                 });
 

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -320,6 +320,20 @@
 }
 
 /* Store locator adjustments */
+#store_search {
+  max-width: 400px;
+  background-color: #fff;
+}
+
+.gm-style .gm-style-iw-c {
+  padding-top: 0 !important;
+}
+
+.gm-style-iw button.gm-ui-hover-effect {
+  top: 0 !important;
+  right: 0 !important;
+}
+
 @media (min-width: 768px) {
   #everblock-storelocator-wrapper #pane-list {
     opacity: 1;
@@ -335,8 +349,10 @@
     text-align: center;
   }
   #store_search {
-    max-width: 400px;
     margin-left: auto;
     margin-right: auto;
+  }
+  #pane-map {
+    position: static;
   }
 }

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -48,7 +48,7 @@
                    style="width: 80px; height: 80px; object-fit: cover;">
             </div>
             <div class="flex-grow-1">
-              <h6 class="fw-bold mb-1">
+              <h6 class="fw-bold mb-1 mt-0">
                 {if $item.cms_link}
                   <a href="{$item.cms_link|escape:'htmlall':'UTF-8'}" class="text-dark text-decoration-none">
                     {$item.name|escape:'htmlall':'UTF-8'}
@@ -86,8 +86,7 @@
               {* Voir les horaires (ouvre une modal Bootstrap) *}
               <p class="mb-0 small">
                 <a href="#" class="text-decoration-none" data-bs-toggle="modal" data-bs-target="#storeHoursModal{$item.id}">
-                  <u>{l s='See hours' mod='everblock'}</u>
-                  <i class="ms-1 bi bi-chevron-right" style="font-size: 0.75rem;"></i>
+                  <u>{l s='See hours' mod='everblock'}</u> &gt;
                 </a>
               </p>
             </div>


### PR DESCRIPTION
## Summary
- include detailed address fields for Google Maps markers
- structure info window with image left and store details right
- underline "See hours" with trailing > and align list titles with thumbnails
- add white background to store search input and ensure Google Map displays on mobile

## Testing
- `php -l everblock.php`
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_689b3422e7908322b6f53083bfd64b0c