### PR TITLE
Align marker popup close button

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -326,12 +326,16 @@
 }
 
 .gm-style .gm-style-iw-c {
-  padding-top: 0 !important;
+  /* Remove default padding so the close button aligns with the popup content */
+  padding: 0 !important;
 }
 
 .gm-style-iw button.gm-ui-hover-effect {
+  /* Position close cross flush with image and store name */
   top: 0 !important;
   right: 0 !important;
+  transform: translate(0, 0) !important;
+  margin: 0 !important;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- align Google Maps marker popup close cross with image and store name

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689b399a2790832285a7eed19a1d7203