### PR TITLE
Fix mobile store locator map display and bold search label

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -356,7 +356,8 @@
     margin-left: auto;
     margin-right: auto;
   }
-  #pane-map {
+  #pane-map,
+  #pane-list {
     position: static;
   }
 }

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -17,7 +17,7 @@
 *}
 <div id="store-search-block" class="mb-3 text-center">
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-center">
-    <label for="store_search" class="me-md-2 mb-2 mb-md-0">{l s='Find a store' mod='everblock'}</label>
+    <label for="store_search" class="me-md-2 mb-2 mb-md-0 fw-bold">{l s='Find a store' mod='everblock'}</label>
     <input type="text" class="form-control mb-2 mb-md-0 me-md-2 w-100" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
     <button type="button" id="store_search_btn" class="btn btn-primary">{l s='Search' mod='everblock'}</button>
   </div>


### PR DESCRIPTION
## Summary
- ensure store locator map and list panes use static positioning on mobile to fix map rendering and tab navigation
- bold the "Find a store" label

## Testing
- `php vendor/bin/php-cs-fixer fix --dry-run` (fails: Could not open input file: vendor/bin/php-cs-fixer)
- `composer global require friendsofphp/php-cs-fixer:^3 --no-interaction` (fails: CONNECT tunnel failed, response 403)
- `php vendor/bin/phpstan analyse` (fails: Could not open input file: vendor/bin/phpstan)
- `composer global require phpstan/phpstan --no-interaction` (fails: CONNECT tunnel failed, response 403)

------
https://chatgpt.com/codex/tasks/task_e_689b3b06f8b48322b032acf371060be0