### PR TITLE
Set store locator to absolute position

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3302,6 +3302,7 @@ class EverblockTools extends ObjectModel
                     });
 
                     document.getElementById("everblock-storelocator").style.height = "500px";
+                    document.getElementById("everblock-storelocator").style.position = "absolute";
                 }
 
                 function initAutocomplete() {


### PR DESCRIPTION
## Summary
- ensure `#everblock-storelocator` uses absolute positioning to display Google Maps correctly on mobile

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_689b479eabf88322b59c837bad4ebd72