### PR TITLE
Fix store locator popup close button positioning

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -332,6 +332,7 @@
 
 .gm-style-iw button.gm-ui-hover-effect {
   /* Position close cross flush with image and store name */
+  position: absolute;
   top: 0 !important;
   right: 0 !important;
   transform: translate(0, 0) !important;


### PR DESCRIPTION
## Summary
- ensure store locator popup close button uses absolute positioning for predictable placement

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689b482890188322a26c7862a87b0c76