### PR TITLE
style: hide overflow in store locator info window

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -339,6 +339,11 @@
   margin: 0 !important;
 }
 
+.gm-style .gm-style-iw-d {
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
 @media (min-width: 768px) {
   #everblock-storelocator-wrapper #pane-list {
     opacity: 1;


### PR DESCRIPTION
## Summary
- hide overflow and add spacing under Google Maps info windows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689b48ed8d1c832299d033baf8e8a0db