### PR TITLE
feat: adjust store locator layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -344,7 +344,14 @@
   margin-bottom: 1rem;
 }
 
+#everblock-storelocator {
+  width: 100%;
+}
+
 @media (min-width: 768px) {
+  #everblock-storelocator {
+    width: 50%;
+  }
   #everblock-storelocator-wrapper #pane-list {
     opacity: 1;
   }

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -18,8 +18,7 @@
 <div id="store-search-block" class="mb-3 text-center">
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-center">
     <label for="store_search" class="me-md-2 mb-2 mb-md-0 fw-bold">{l s='Find a store' mod='everblock'}</label>
-    <input type="text" class="form-control mb-2 mb-md-0 me-md-2 w-100" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
-    <button type="button" id="store_search_btn" class="btn btn-primary">{l s='Search' mod='everblock'}</button>
+    <input type="text" class="form-control mb-2 mb-md-0 w-100" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
   </div>
 </div>
 {hook h='displayBeforeStoreLocator'}


### PR DESCRIPTION
## Summary
- remove unused search button from store locator
- make store locator map full width on mobile and half width on desktop

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689b4d2230148322884ad52d4e685912