### PR TITLE
feat: add search button to store locator

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3270,12 +3270,12 @@ class EverblockTools extends ObjectModel
                 }
 
                 function applySearch(userLocation) {
+                    map.panTo(userLocation);
+                    map.setZoom(15);
                     var closestMarker = findClosestMarker(userLocation);
                     filterStores(userLocation);
                     if (closestMarker) {
                         var markerObj = markerMap[closestMarker.id];
-                        map.panTo({ lat: closestMarker.lat, lng: closestMarker.lng });
-                        map.setZoom(15);
                         infoWindow.setContent(renderContent(closestMarker));
                         infoWindow.open(map, markerObj);
                     }

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -18,7 +18,10 @@
 <div id="store-search-block" class="mb-3 text-center">
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-center">
     <label for="store_search" class="me-md-2 mb-2 mb-md-0 fw-bold">{l s='Find a store' mod='everblock'}</label>
-    <input type="text" class="form-control mb-2 mb-md-0 w-100" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
+    <div class="input-group mb-2 mb-md-0 w-100">
+      <input type="text" class="form-control" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
+      <button type="button" class="btn btn-primary" id="store_search_btn">{l s='Search' mod='everblock'}</button>
+    </div>
   </div>
 </div>
 {hook h='displayBeforeStoreLocator'}


### PR DESCRIPTION
## Summary
- add a search button next to the store locator input field
- allow manual address search to locate nearest store
- center map on manually entered address before displaying closest store

## Testing
- `php -d memory_limit=-1 vendor/bin/php-cs-fixer fix --diff --dry-run` *(fails: Could not open input file: vendor/bin/php-cs-fixer)*
- `php -d memory_limit=-1 vendor/bin/phpstan analyse` *(fails: Could not open input file: vendor/bin/phpstan)*

------
https://chatgpt.com/codex/tasks/task_e_689b6286e6c88322a68092e84d16ed20