### PR TITLE
Allow Enter key to trigger store locator search

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3318,20 +3318,29 @@ class EverblockTools extends ObjectModel
                         }
                     });
 
-                    if (searchBtn) {
-                        searchBtn.addEventListener("click", function () {
-                            var address = searchInput.value;
-                            if (!address.trim()) {
-                                resetDisplay();
-                                return;
+                    function performSearch() {
+                        var address = searchInput.value;
+                        if (!address.trim()) {
+                            resetDisplay();
+                            return;
+                        }
+                        geocoder.geocode({ address: address }, function (results, status) {
+                            if (status === "OK" && results[0].geometry && results[0].geometry.location) {
+                                applySearch(results[0].geometry.location);
                             }
-                            geocoder.geocode({ address: address }, function (results, status) {
-                                if (status === "OK" && results[0].geometry && results[0].geometry.location) {
-                                    applySearch(results[0].geometry.location);
-                                }
-                            });
                         });
                     }
+
+                    if (searchBtn) {
+                        searchBtn.addEventListener("click", performSearch);
+                    }
+
+                    searchInput.addEventListener("keydown", function (e) {
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            performSearch();
+                        }
+                    });
 
                     searchInput.addEventListener("input", function () {
                         if (!this.value) {


### PR DESCRIPTION
## Summary
- handle `Enter` key in store locator search input to trigger geocoding

## Testing
- `php -l models/EverblockTools.php`
- `php-cs-fixer --version` *(fails: command not found)*
- `composer global require friendsofphp/php-cs-fixer phpstan/phpstan` *(fails: curl error 56, CONNECT tunnel failed: 403)*
- `phpstan --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6a3a4964832291ec24e62c54f46e