### PR TITLE
feat: centralize prettyblocks media

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -23,6 +23,8 @@ if (!defined('_PS_VERSION_')) {
 
 class EverblockPrettyBlocks extends ObjectModel
 {
+    private const MEDIA_PATH = '$/img/cms/prettyblocks/';
+
     public function registerBlockToZone($zone_name, $code, $id_lang, $id_shop)
     {
         return PrettyBlocksModel::registerBlockToZone($zone_name, $code, $id_lang, $id_shop);
@@ -3059,9 +3061,39 @@ class EverblockPrettyBlocks extends ObjectModel
                     ],
                 ],
             ];
+            $blocks = self::applyFileUploadPath($blocks);
             EverblockCache::cacheStore($cacheId, $blocks);
             return $blocks;
         }
         return EverblockCache::cacheRetrieve($cacheId);
+    }
+
+    private static function applyFileUploadPath(array $blocks): array
+    {
+        foreach ($blocks as &$block) {
+            if (isset($block['config']['fields'])) {
+                $block['config']['fields'] = self::setPathRecursive($block['config']['fields']);
+            }
+            if (isset($block['repeater']['groups'])) {
+                $block['repeater']['groups'] = self::setPathRecursive($block['repeater']['groups']);
+            }
+        }
+
+        return $blocks;
+    }
+
+    private static function setPathRecursive(array $fields): array
+    {
+        foreach ($fields as &$field) {
+            if (is_array($field)) {
+                if (($field['type'] ?? null) === 'fileupload') {
+                    $field['path'] = self::MEDIA_PATH;
+                } else {
+                    $field = self::setPathRecursive($field);
+                }
+            }
+        }
+
+        return $fields;
     }
 }

--- a/src/Command/PrettyBlocksCommand.php
+++ b/src/Command/PrettyBlocksCommand.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Module;
 use Validate;
 use Db;
+use EverblockTools;
 
 class PrettyBlocksCommand extends Command
 {
@@ -42,6 +43,7 @@ class PrettyBlocksCommand extends Command
 
     private $allowedActions = [
         'duplicate',
+        'migrate-media',
     ];
 
     public function __construct(KernelInterface $kernel)
@@ -81,6 +83,12 @@ class PrettyBlocksCommand extends Command
                 return self::INVALID;
             }
             $this->duplicatePrettyblocks($fromLang, $toLang, $output);
+            return self::SUCCESS;
+        }
+
+        if ($action === 'migrate-media') {
+            $count = EverblockTools::moveAllPrettyblocksMediasToCms();
+            $output->writeln('<success>' . $count . ' block(s) updated</success>');
             return self::SUCCESS;
         }
 


### PR DESCRIPTION
## Summary
- direct all PrettyBlocks file uploads to `/img/cms/prettyblocks`
- add migration utility to move existing PrettyBlocks media into the CMS folder
- expose `migrate-media` console action to trigger the migration

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l models/EverblockTools.php`
- `php -l src/Command/PrettyBlocksCommand.php`


------
https://chatgpt.com/codex/tasks/task_e_689d9f11b8f483228acb250bcd1a0bbb