### PR TITLE
Load product modal via AJAX

### DIFF
--- a/controllers/front/modal.php
+++ b/controllers/front/modal.php
@@ -44,8 +44,9 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
         }
         $blockId = (int) Tools::getValue('id_everblock');
         $cmsId = (int) Tools::getValue('id_cms');
+        $productModalId = (int) Tools::getValue('id_everblock_modal');
 
-        if ($cmsId && !$blockId) {
+        if ($cmsId && !$blockId && !$productModalId) {
             $cms = new CMS($cmsId, $this->context->language->id, $this->context->shop->id);
             if (!Validate::isLoadedObject($cms) || !(bool) $cms->active) {
                 die();
@@ -57,6 +58,35 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
             );
             $this->context->smarty->assign([
                 'everblock_modal' => (object) ['content' => $cmsContent],
+            ]);
+            $response = $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/front/modal.tpl');
+            die($response);
+        }
+        if ($productModalId && !$blockId && !$cmsId) {
+            $modal = new EverblockModal(
+                $productModalId,
+                $this->context->language->id,
+                $this->context->shop->id
+            );
+            if (!Validate::isLoadedObject($modal)) {
+                die();
+            }
+            $content = isset($modal->content[$this->context->language->id])
+                ? $modal->content[$this->context->language->id]
+                : '';
+            $fileUrl = '';
+            if (!empty($modal->file)) {
+                $fileUrl = $this->context->link->getBaseLink() . 'img/cms/' . $modal->file;
+            }
+            $this->context->smarty->assign([
+                'everblock_modal' => (object) [
+                    'content' => EverblockTools::renderShortcodes(
+                        $content,
+                        $this->context,
+                        $this->module
+                    ),
+                    'file' => $fileUrl,
+                ],
             ]);
             $response = $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/front/modal.tpl');
             die($response);

--- a/everblock.php
+++ b/everblock.php
@@ -3720,19 +3720,14 @@ class Everblock extends Module
             (int) $params['product']['id_product'],
             (int) $this->context->shop->id
         );
-        if (!Validate::isLoadedObject($modal)) {
+        if (
+            !Validate::isLoadedObject($modal)
+            || empty($modal->content[$this->context->language->id])
+        ) {
             return;
         }
-        $content = isset($modal->content[$this->context->language->id])
-            ? $modal->content[$this->context->language->id]
-            : '';
-        $fileUrl = '';
-        if (!empty($modal->file)) {
-            $fileUrl = $this->context->link->getBaseLink() . 'img/cms/' . $modal->file;
-        }
         $this->smarty->assign([
-            'modal_content' => $content,
-            'modal_file' => $fileUrl,
+            'everblock_modal_id' => (int) $modal->id_everblock_modal,
         ]);
         return $this->fetch('module:everblock/views/templates/hook/modal.tpl');
     }

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -152,7 +152,8 @@ $(document).ready(function(){
         e.preventDefault();
         let blockId = $(this).data('everclickmodal');
         let cmsId = $(this).data('evercms');
-        if (!blockId && !cmsId) {
+        let productModalId = $(this).data('evermodal');
+        if (!blockId && !cmsId && !productModalId) {
             return;
         }
         let data = { token: everblock_token, force: 1 };
@@ -161,6 +162,9 @@ $(document).ready(function(){
         }
         if (cmsId) {
             data.id_cms = cmsId;
+        }
+        if (productModalId) {
+            data.id_everblock_modal = productModalId;
         }
         $.ajax({
             url: atob(evermodal_link),

--- a/views/templates/front/modal.tpl
+++ b/views/templates/front/modal.tpl
@@ -34,6 +34,9 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
                 {$everblock_modal->content nofilter}
+                {if isset($everblock_modal->file) && $everblock_modal->file}
+                    <p><a href="{$everblock_modal->file|escape:'htmlall':'UTF-8'}" target="_blank">{l s='Download file' mod='everblock'}</a></p>
+                {/if}
             </div>
         </div>
     </div>

--- a/views/templates/hook/modal.tpl
+++ b/views/templates/hook/modal.tpl
@@ -15,18 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
 *}
-<button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#everblock-modal">
+{if isset($everblock_modal_id) && $everblock_modal_id}
+<button type="button" class="btn btn-secondary everblock-modal-button" data-evermodal="{$everblock_modal_id|escape:'htmlall':'UTF-8'}">
     {l s='Show modal' mod='everblock'}
 </button>
-<div class="modal fade" id="everblock-modal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-body">
-                {$modal_content nofilter}
-                {if $modal_file}
-                    <p><a href="{$modal_file|escape:'htmlall':'UTF-8'}" target="_blank">{l s='Download file' mod='everblock'}</a></p>
-                {/if}
-            </div>
-        </div>
-    </div>
-</div>
+{/if}
+


### PR DESCRIPTION
## Summary
- load product-specific modal through front controller
- fetch modal content on click and insert dynamically
- support optional file link in modal output

## Testing
- `php -l controllers/front/modal.php`
- `php -l everblock.php`
- `node --check views/js/everblock.js`


------
https://chatgpt.com/codex/tasks/task_e_689dac6d7ff48322bb36bef380d43d8b