### PR TITLE
Add table of contents Prettyblock

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -203,6 +203,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_testimonial.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_toc.tpl',
     'views/templates/hook/prettyblocks/prettyblocks.tpl',
     'views/templates/hook/prettyblocks/row.tpl',
     'views/templates/hook/store.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -73,6 +73,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
             $headingTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heading.tpl';
+            $tocTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_toc.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -3057,6 +3058,47 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'light' => 'light',
                                 'dark' => 'dark',
                             ],
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Table of contents'),
+                'description' => $module->l('Display a summary with anchored sections'),
+                'code' => 'everblock_toc',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $tocTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Summary title'),
+                            'default' => $module->l('Summary'),
+                        ],
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Section',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'anchor' => [
+                            'type' => 'text',
+                            'label' => $module->l('Anchor ID'),
+                            'default' => 'section-1',
+                        ],
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Title'),
+                            'default' => $module->l('Section 1'),
+                        ],
+                        'content' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Content'),
+                            'default' => '[llorem]',
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_toc.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_toc.tpl
@@ -1,0 +1,48 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}w-100 px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  {if isset($block.states) && $block.states}
+    <div class="col-12 col-lg-4 pb-toc-summary">
+      {if isset($block.settings.title) && $block.settings.title}
+        <span class="h2 pb-toc-title">{$block.settings.title|escape:'htmlall'}</span>
+      {/if}
+      <ul class="list-unstyled">
+        {foreach from=$block.states item=state}
+          <li><a href="#{$state.anchor|escape:'htmlall'}">{$state.title|escape:'htmlall'}</a></li>
+        {/foreach}
+      </ul>
+    </div>
+    <div class="col-12 col-lg-8 pb-toc-content">
+      {foreach from=$block.states item=state}
+        <div id="{$state.anchor|escape:'htmlall'}" class="pb-toc-section">
+          {$state.content nofilter}
+        </div>
+      {/foreach}
+    </div>
+  {/if}
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+<!-- /Module Ever Block -->
+


### PR DESCRIPTION
## Summary
- add new Prettyblock `everblock_toc` with repeater for anchored sections
- render responsive summary and content columns via new template
- allow Prettyblock TOC template in allowed files list

## Testing
- `php -l config/allowed_files.php`
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_689db6f2a77c83228cd47f5425e989bd