### PR TITLE
feat: add customization options to cover block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2997,6 +2997,19 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Title'),
                             'default' => '',
                         ],
+                        'title_tag' => [
+                            'type' => 'select',
+                            'label' => $module->l('Heading level'),
+                            'choices' => [
+                                'h1' => 'H1',
+                                'h2' => 'H2',
+                                'h3' => 'H3',
+                                'h4' => 'H4',
+                                'h5' => 'H5',
+                                'h6' => 'H6',
+                            ],
+                            'default' => 'h2',
+                        ],
                         'content' => [
                             'type' => 'editor',
                             'label' => $module->l('Content'),
@@ -3058,6 +3071,11 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'light' => 'light',
                                 'dark' => 'dark',
                             ],
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -25,10 +25,12 @@
              class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if} text-center"
              style="{if isset($state.background_image.url) && $state.background_image.url}background-image: url('{$state.background_image.url|escape:'htmlall'}'); background-size: cover; background-position: center;{/if}">
           {if $state.title}
-            <h2>{$state.title|escape:'htmlall'}</h2>
+            <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}
           {if $state.content}
-            {$state.content nofilter}
+            <div class="prettyblock-cover-content">
+              {$state.content nofilter}
+            </div>
           {/if}
           {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
             <div class="mt-3 d-flex justify-content-center gap-2">
@@ -49,10 +51,12 @@
            class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if} text-center"
            style="{if isset($state.background_image.url) && $state.background_image.url}background-image: url('{$state.background_image.url|escape:'htmlall'}'); background-size: cover; background-position: center;{/if}">
         {if $state.title}
-          <h2>{$state.title|escape:'htmlall'}</h2>
+          <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
         {/if}
         {if $state.content}
-          {$state.content nofilter}
+          <div class="prettyblock-cover-content">
+            {$state.content nofilter}
+          </div>
         {/if}
         {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
           <div class="mt-3 d-flex justify-content-center gap-2">


### PR DESCRIPTION
## Summary
- allow custom CSS classes for each cover block item
- select heading level for cover titles
- ensure content displays directly beneath titles

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `phpstan analyse` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a2cec9a7a88322b13478f94a57eba1