### PR TITLE
Add PrettyBlocks block for category minimum price

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -174,6 +174,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_button.tpl',
     'views/templates/hook/prettyblocks/prettyblock_card.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_category_price.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl',
     'views/templates/hook/prettyblocks/prettyblock_contact.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cover.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -73,6 +73,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
             $headingTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heading.tpl';
+            $categoryPriceTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_price.tpl';
             $tocTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_toc.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
@@ -1290,6 +1291,88 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'checkbox',
                             'label' => $module->l('Open in new tab (only if not obfuscated)'),
                             'default' => '0',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Category price list'),
+                'description' => $module->l('Display categories with starting price'),
+                'code' => 'everblock_category_price',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $categoryPriceTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Category',
+                    'nameFrom' => 'name',
+                    'groups' => [
+                        'category' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Category'),
+                            'collection' => 'Category',
+                            'selector' => '{id} - {name}',
+                            'default' => \HelperBuilder::getRandomCategory((int) $context->language->id, (int) $context->shop->id),
+                            'force_default_value' => true,
+                        ],
+                        'name' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom title'),
+                            'default' => '',
+                        ],
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Custom image'),
+                            'default' => [
+                                'url' => '',
+                            ],
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -402,6 +402,11 @@ $_MODULE['<{everblock}prestashop>everblockprettyblocks_450054db166bd415e164f0804
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_7015777bcc86cd0c5e4819310d62b040'] = 'Onglets';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_9c18ae405b0392cb1b891f61704d6834'] = 'Affiche des onglets personnalisés';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_ca50c06475296d0be9139f99c4d7619b'] = 'Classes CSS personnalisées';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_0d833ed39f0a07e4fe6859b06bea8056'] = 'Liste de catégories avec prix';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_d78ab4d601183262f8c05c7764ceb35d'] = 'Affiche les catégories avec prix à partir de';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_52a50957d1ee14019892f73e90365d97'] = 'Titre personnalisé';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_2961f0afba69c259ed850360b31300db'] = 'Image personnalisée';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_3adbdb3ac060038aa0e6e6c138ef9873'] = 'Catégorie';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_b26dc9fae955d0b01b1b891924323b73'] = 'Accordéons';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_4cd56f41414ba3543d0cb1acdd83e1ec'] = 'Ajoute des accordéons horizontaux';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_7db42eaafb8768893b008c792d42054c'] = 'Couleur du titre de l\'accordéon';
@@ -635,6 +640,7 @@ $_MODULE['<{everblock}prestashop>prettyblock_login_0afbbf2f70d39364971ef07f8fa07
 $_MODULE['<{everblock}prestashop>prettyblock_shopping_cart_a85eba4c6c699122b2bb1387ea4813ad'] = 'Panier';
 $_MODULE['<{everblock}prestashop>prettyblock_shopping_cart_96b0141273eabab320119c467cdcaf17'] = 'Total';
 $_MODULE['<{everblock}prestashop>prettyblock_shopping_cart_59fc69e031ecb0f82efe467fd6692383'] = 'Voir le panier';
+$_MODULE['<{everblock}prestashop>prettyblock_category_price_5da618e8e4b89c66fe86e32cdafde142'] = 'À partir de';
 $_MODULE['<{everblock}prestashop>prettyblock_silo_78f6f209024537ab3369e54b172c94b6'] = 'Retrouvez ce produit dans nos univers';
 $_MODULE['<{everblock}prestashop>prettyblock_silo_5becdb6da34b0a9ce1de8b8e1066baae'] = 'Retrouvez cette catégorie dans nos univers';
 $_MODULE['<{everblock}prestashop>ever_presented_products_124117dd22bc1dce2b0687b65f35f091'] = 'Vous pourriez aussi aimer';

--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -1,0 +1,65 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}w-100 px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row row-cols-1 row-cols-md-5 gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  {if isset($block.states) && $block.states}
+    {foreach from=$block.states item=state key=key}
+      {if isset($state.category.id) && $state.category.id}
+        {assign var=category_obj value=new Category($state.category.id, $block.id_lang)}
+        {assign var=category_link value=Context::getContext()->link->getCategoryLink($state.category.id)}
+        {if $state.image.url}
+          {assign var=image_url value=$state.image.url}
+        {else}
+          {assign var=image_url value=Context::getContext()->link->getCatImageLink(ImageType::getFormattedName('category'), $state.category.id)}
+        {/if}
+        {assign var=title value=$state.name|default:$category_obj->name}
+        {assign var=products value=Product::getProducts($block.id_lang, 0, 1, 'price', 'asc', $state.category.id, true)}
+        {if $products|@count}
+          {assign var=min_price value=$products[0]['price']}
+        {else}
+          {assign var=min_price value=false}
+        {/if}
+      {else}
+        {assign var=category_link value="#"}
+        {assign var=image_url value=""}
+        {assign var=title value=$state.name}
+        {assign var=min_price value=false}
+      {/if}
+      <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
+        <a href="{$category_link}" class="d-block text-decoration-none">
+          {if $image_url}
+            <img src="{$image_url|escape:'htmlall'}" alt="{$title|escape:'htmlall'}" class="img-fluid mb-2" loading="lazy">
+          {/if}
+          {if $title}
+            <p class="h6">{$title|escape:'htmlall'}</p>
+          {/if}
+          {if $min_price !== false}
+            <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($min_price)}</span>
+          {/if}
+        </a>
+      </div>
+    {/foreach}
+  {/if}
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add Category price list PrettyBlocks block with custom image, title and classes
- show "From" with lowest product price for each category
- localize new strings
- render category titles using a paragraph with heading class instead of heading tags

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `php -l translations/fr.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2d73ba56483229b97e2151dbe8f74