### PR TITLE
Load category price data via hook

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -23,37 +23,17 @@
   {/if}
   {if isset($block.states) && $block.states}
     {foreach from=$block.states item=state key=key}
-      {if isset($state.category.id) && $state.category.id}
-        {assign var=category_obj value=new Category($state.category.id, $block.id_lang)}
-        {assign var=category_link value=Context::getContext()->link->getCategoryLink($state.category.id)}
-        {if $state.image.url}
-          {assign var=image_url value=$state.image.url}
-        {else}
-          {assign var=image_url value=Context::getContext()->link->getCatImageLink(ImageType::getFormattedName('category'), $state.category.id)}
-        {/if}
-        {assign var=title value=$state.name|default:$category_obj->name}
-        {assign var=products value=Product::getProducts($block.id_lang, 0, 1, 'price', 'asc', $state.category.id, true)}
-        {if $products|@count}
-          {assign var=min_price value=$products[0]['price']}
-        {else}
-          {assign var=min_price value=false}
-        {/if}
-      {else}
-        {assign var=category_link value="#"}
-        {assign var=image_url value=""}
-        {assign var=title value=$state.name}
-        {assign var=min_price value=false}
-      {/if}
+      {assign var=data value=$block.extra.state_data[$key]}
       <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
-        <a href="{$category_link}" class="d-block text-decoration-none">
-          {if $image_url}
-            <img src="{$image_url|escape:'htmlall'}" alt="{$title|escape:'htmlall'}" class="img-fluid mb-2" loading="lazy">
+        <a href="{$data.category_link}" class="d-block text-decoration-none">
+          {if $data.image_url}
+            <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|escape:'htmlall'}" class="img-fluid mb-2" loading="lazy">
           {/if}
-          {if $title}
-            <p class="h6">{$title|escape:'htmlall'}</p>
+          {if $data.title}
+            <p class="h6">{$data.title|escape:'htmlall'}</p>
           {/if}
-          {if $min_price !== false}
-            <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($min_price)}</span>
+          {if $data.min_price !== false}
+            <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
           {/if}
         </a>
       </div>


### PR DESCRIPTION
## Summary
- prepare everblock to register `beforeRenderingEverblockCategoryPrice` hook
- move category price block data preparation into new hook
- simplify category price template to use precomputed state data

## Testing
- `php -l everblock.php`
- `composer validate --no-check-all --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a2ec816c1483229180595d3cdbab82