### PR TITLE
Handle missing state data in category price block

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -23,20 +23,22 @@
   {/if}
   {if isset($block.states) && $block.states}
     {foreach from=$block.states item=state key=key}
-      {assign var=data value=$block.extra.state_data[$key]}
-      <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
-        <a href="{$data.category_link}" class="d-block text-decoration-none">
-          {if $data.image_url}
-            <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|escape:'htmlall'}" class="img-fluid mb-2" loading="lazy">
-          {/if}
-          {if $data.title}
-            <p class="h6">{$data.title|escape:'htmlall'}</p>
-          {/if}
-          {if $data.min_price !== false}
-            <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
-          {/if}
-        </a>
-      </div>
+      {assign var=data value=$block.extra.state_data[$key]|default:null}
+      {if $data}
+        <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
+          <a href="{$data.category_link|default:'#'}" class="d-block text-decoration-none">
+            {if $data.image_url}
+              <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|escape:'htmlall'}" class="img-fluid mb-2" loading="lazy">
+            {/if}
+            {if $data.title}
+              <p class="h6">{$data.title|escape:'htmlall'}</p>
+            {/if}
+            {if $data.min_price !== false}
+              <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
+            {/if}
+          </a>
+        </div>
+      {/if}
     {/foreach}
   {/if}
   {if $block.settings.default.force_full_width || $block.settings.default.container}


### PR DESCRIPTION
## Summary
- avoid PHP notices by checking if state data exists before rendering category price block

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a2f07425b48322bcca76ea4ec3afed