### PR TITLE
Include Quill formatting CSS

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3167,6 +3167,11 @@ class Everblock extends Module
             'modules/' . $this->name . '/views/css/' . $this->name . '.css',
             ['media' => 'all', 'priority' => 200]
         );
+        $this->context->controller->registerStylesheet(
+            'module-' . $this->name . '-quill-css',
+            'modules/' . $this->name . '/views/css/quill.css',
+            ['media' => 'all', 'priority' => 200]
+        );
         $flagsCssFile = _PS_MODULE_DIR_ . $this->name . '/views/css/feature-flags-' . $idShop . '.css';
         if (file_exists($flagsCssFile) && filesize($flagsCssFile) > 0) {
             $this->context->controller->registerStylesheet(

--- a/views/css/quill.css
+++ b/views/css/quill.css
@@ -1,0 +1,10 @@
+/* Minimal QuillJS formatting classes for Prettyblock content */
+.ql-align-center { text-align: center; }
+.ql-align-right { text-align: right; }
+.ql-align-justify { text-align: justify; }
+.ql-direction-rtl { direction: rtl; text-align: inherit; }
+.ql-font-serif { font-family: serif; }
+.ql-font-monospace { font-family: monospace; }
+.ql-size-small { font-size: 0.75em; }
+.ql-size-large { font-size: 1.5em; }
+.ql-size-huge { font-size: 2.5em; }


### PR DESCRIPTION
## Summary
- register Quill stylesheet so ql-* classes from PrettyBlock are styled
- add minimal Quill CSS for alignment, font, and size classes

## Testing
- `php -l everblock.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68a2f46e9be08322bfe0c4a758169aec