### PR TITLE
style: improve Prettyblock card design

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -21,40 +21,45 @@
       <div class="d-flex flex-nowrap gap-3 pe-1">
         {foreach from=$block.states item=state}
           <div class="flex-shrink-0 prettyblocks-card-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="width:90%;max-width:90%;">
-            <div class="card h-100 mb-3">
-              {if isset($state.image.url) && $state.image.url}
-                {assign var="imgExt" value=$state.image.url|lower|substr:-4}
-                {if $imgExt == '.svg'}
-                  <img src="{$state.image.url}" class="card-img-top img img-fluid" loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if} alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
-                {else}
-                  <picture>
-                    <source srcset="{$state.image.url}" type="image/webp">
-                    <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                    <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="card-img-top img img-fluid lazyload" loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if} alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
-                  </picture>
+            <div class="card h-100 mb-3 border border-light-subtle rounded-4 shadow-sm">
+              <div class="card-body d-flex flex-column h-100 p-4">
+                {if isset($state.image.url) && $state.image.url}
+                  <div class="mb-4">
+                    {assign var="imgExt" value=$state.image.url|lower|substr:-4}
+                    {if $imgExt == '.svg'}
+                      <img src="{$state.image.url}" class="img img-fluid" loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if} alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
+                    {else}
+                      <picture>
+                        <source srcset="{$state.image.url}" type="image/webp">
+                        <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                        <img src="{$state.image.url|replace:'.webp':'.jpg'}" class="img img-fluid lazyload" loading="lazy"{if $state.image_width} width="{$state.image_width|escape:'htmlall'}"{/if}{if $state.image_height} height="{$state.image_height|escape:'htmlall'}"{/if} alt="{if $state.alt}{$state.alt|escape:'htmlall'}{else}{$state.title|escape:'htmlall'}{/if}" title="{$state.title|escape:'htmlall'}">
+                      </picture>
+                    {/if}
+                  </div>
                 {/if}
-              {/if}
-              <div class="card-body">
-                {if $state.title}<span class="card-title h5">{$state.title|escape:'htmlall'}</span>{/if}
-                {if $state.content}<div class="card-text">{$state.content nofilter}</div>{/if}
-              </div>
-              {if $state.button_link}
-                <div class="card-footer bg-transparent border-0">
-                  <a href="{$state.button_link|escape:'htmlall'}" class="card-link d-inline-flex align-items-center" title="{$state.title|escape:'htmlall'}">
-                    En savoir plus <span class="ms-1">&rarr;</span>
-                  </a>
+                <div class="flex-grow-1">
+                  {if $state.title}<span class="card-title h5 d-block mb-2">{$state.title|escape:'htmlall'}</span>{/if}
+                  {if $state.content}<div class="card-text text-body-secondary">{$state.content nofilter}</div>{/if}
                 </div>
-              {/if}
+                {if $state.button_link}
+                  <div class="mt-4 text-end">
+                    <a href="{$state.button_link|escape:'htmlall'}" class="btn btn-light rounded-circle p-2 d-inline-flex align-items-center justify-content-center" title="{$state.title|escape:'htmlall'}">
+                      <span class="visually-hidden">En savoir plus</span>
+                      <span aria-hidden="true">&rarr;</span>
+                    </a>
+                  </div>
+                {/if}
+              </div>
             </div>
           </div>
         {/foreach}
       </div>
     </div>
     <style>
-      @media (min-width: 768px) {
+      @media (min-width: 992px) {
         #block-{$block.id_prettyblocks} .prettyblocks-card-item {
-          width: 25% !important;
-          max-width: 25% !important;
+          width: 20% !important;
+          max-width: 20% !important;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- enhance Prettyblock card layout with Bootstrap 5 utilities
- add circular arrow link and updated spacing for Apple-like card design
- adjust responsive widths to display five cards on large screens

## Testing
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_68a31d11fd4c8322a1a96da8ac33010d