### PR TITLE
Add Prettyblock for clickable map with markers

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -185,6 +185,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_gmap.tpl',
     'views/templates/hook/prettyblocks/prettyblock_heading.tpl',
     'views/templates/hook/prettyblocks/prettyblock_iframe.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_image_map.tpl',
     'views/templates/hook/prettyblocks/prettyblock_img.tpl',
     'views/templates/hook/prettyblocks/prettyblock_img_slider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_layout.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -75,6 +75,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $headingTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heading.tpl';
             $categoryPriceTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_price.tpl';
             $tocTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_toc.tpl';
+            $imageMapTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_image_map.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -3200,6 +3201,109 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'editor',
                             'label' => $module->l('Content'),
                             'default' => '[llorem]',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Image map with markers'),
+                'description' => $module->l('Display a clickable map image with markers'),
+                'code' => 'everblock_image_map',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $imageMapTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Title'),
+                            'default' => '',
+                        ],
+                        'content' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Content'),
+                            'default' => '',
+                        ],
+                        'button_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button text'),
+                            'default' => $module->l('Find a store'),
+                        ],
+                        'button_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button link'),
+                            'default' => '#',
+                        ],
+                        'map_image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Map image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Marker',
+                    'nameFrom' => 'label',
+                    'groups' => [
+                        'label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Marker label'),
+                            'default' => '',
+                        ],
+                        'top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Top position (e.g., 50%)'),
+                            'default' => '0%',
+                        ],
+                        'left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Left position (e.g., 50%)'),
+                            'default' => '0%',
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
@@ -1,0 +1,66 @@
+{*
+ * 2019-2025 Team Ever
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div class="{if $block.settings.default.container}container{/if}" style="
+    {if isset($block.settings.padding_left)}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.padding_right)}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.padding_top)}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.padding_bottom)}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.margin_left)}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.margin_right)}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.margin_top)}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}
+    {if isset($block.settings.margin_bottom)}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}">
+
+  <div class="row align-items-center">
+    <div class="col-md-6 mb-4 mb-md-0">
+      {if $block.settings.title}
+        <h2>{$block.settings.title|escape:'htmlall'}</h2>
+      {/if}
+      {if $block.settings.content}
+        <div>{$block.settings.content nofilter}</div>
+      {/if}
+      {if $block.settings.button_link && $block.settings.button_text}
+        <a href="{$block.settings.button_link|escape:'htmlall'}" class="btn btn-primary mt-3">
+          {$block.settings.button_text|escape:'htmlall'}
+        </a>
+      {/if}
+    </div>
+    <div class="col-md-6 text-center">
+      {if $block.settings.button_link}<a href="{$block.settings.button_link|escape:'htmlall'}" title="{$block.settings.title|escape:'htmlall'}">{/if}
+      <div class="position-relative d-inline-block">
+        {if isset($block.settings.map_image.url) && $block.settings.map_image.url}
+          <picture>
+            <source srcset="{$block.settings.map_image.url}" type="image/webp">
+            <source srcset="{$block.settings.map_image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+            <img src="{$block.settings.map_image.url|replace:'.webp':'.jpg'}" alt="{$block.settings.title|escape:'htmlall'}" class="img-fluid" loading="lazy">
+          </picture>
+        {/if}
+        {if isset($block.states) && $block.states}
+          {foreach from=$block.states item=state}
+            <div class="position-absolute translate-middle text-nowrap" style="top:{$state.top|escape:'htmlall'};left:{$state.left|escape:'htmlall'};">
+              <span class="d-inline-block bg-primary rounded-circle" style="width:10px;height:10px;"></span>
+              {if $state.label}
+                <span class="badge bg-primary ms-1">{$state.label|escape:'htmlall'}</span>
+              {/if}
+            </div>
+          {/foreach}
+        {/if}
+      </div>
+      {if $block.settings.button_link}</a>{/if}
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add Image map with markers prettyblock registration
- implement Smarty template with repeater markers and Bootstrap layout
- allow prettyblock_image_map.tpl in allowed files list

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l views/templates/hook/prettyblocks/prettyblock_image_map.tpl`
- `php -l config/allowed_files.php`


------
https://chatgpt.com/codex/tasks/task_e_68a31cc69e8c832299f06fbc65b97e38