### PR TITLE
Add Prettyblock for custom social links

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -200,6 +200,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_sharer.tpl',
     'views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl',
     'views/templates/hook/prettyblocks/prettyblock_shortcode.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_social_links.tpl',
     'views/templates/hook/prettyblocks/prettyblock_spacer.tpl',
     'views/templates/hook/prettyblocks/prettyblock_tab.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -68,6 +68,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $ctaTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cta.tpl';
             $sharerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_sharer.tpl';
             $linkListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_link_list.tpl';
+            $socialLinksTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_social_links.tpl';
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
@@ -2661,6 +2662,35 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'text',
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Social links'),
+                'description' => $module->l('Display custom links to social networks'),
+                'code' => 'everblock_social_links',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $socialLinksTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Social link',
+                    'nameFrom' => 'url',
+                    'groups' => [
+                        'url' => [
+                            'type' => 'text',
+                            'label' => $module->l('Link URL'),
+                            'default' => '#',
+                        ],
+                        'icon' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('SVG icon'),
+                            'default' => [
+                                'url' => '',
+                            ],
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -1,0 +1,41 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<!-- Module Ever Block -->
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}w-100 px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+    <div class="everblock-social-links d-flex">
+      {foreach from=$block.states item=state}
+        {if isset($state.url) && $state.url}
+          <a href="{$state.url|escape:'htmlall'}" class="obfme" title="{$state.url|escape:'htmlall'}" target="_blank">
+            {if isset($state.icon.url) && $state.icon.url}
+              <img src="{$state.icon.url|escape:'htmlall'}" alt="{$state.url|escape:'htmlall'}" />
+            {/if}
+          </a>
+        {/if}
+      {/foreach}
+    </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+<!-- /Module Ever Block -->
+


### PR DESCRIPTION
## Summary
- add social links Prettyblock with repeater for URL and SVG icon
- render social icons inline with obfuscated links
- allow social links template in module's allowed files list

## Testing
- `php -l config/allowed_files.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a337c6ff9083229bbf788de94f6555