### PR TITLE
Allow optional carousel parameter in crossselling shortcode

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -670,7 +670,7 @@ class EverblockTools extends ObjectModel
     {
 
         preg_match_all(
-            '/\[crosselling(?:\s+nb=(\d+))?(?:\s+limit=(\d+))?(?:\s+orderby=(\w+))?(?:\s+orderway=(ASC|DESC))?\]/i',
+            '/\[crosselling(?:\s+nb=(\d+))?(?:\s+limit=(\d+))?(?:\s+orderby=(\w+))?(?:\s+orderway=(ASC|DESC))?(?:\s+carousel=(true|false))?\]/i',
             $txt,
             $matches,
             PREG_SET_ORDER
@@ -680,6 +680,7 @@ class EverblockTools extends ObjectModel
             $limit = isset($match[1]) && $match[1] !== '' ? (int) $match[1] : (isset($match[2]) ? (int) $match[2] : 4);
             $orderBy = isset($match[3]) ? strtolower($match[3]) : 'id_product';
             $orderWay = isset($match[4]) ? strtoupper($match[4]) : 'ASC';
+            $carousel = isset($match[5]) && strtolower($match[5]) === 'true';
 
             $allowedOrderBy = ['id_product', 'price', 'name', 'date_add', 'position'];
             $allowedOrderWay = ['ASC', 'DESC'];
@@ -702,7 +703,7 @@ class EverblockTools extends ObjectModel
                 if (!empty($everPresentProducts)) {
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => false,
+                        'carousel' => $carousel,
                         'shortcodeClass' => 'crosselling',
                     ]);
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
@@ -785,7 +786,7 @@ class EverblockTools extends ObjectModel
                 if (!empty($everPresentProducts)) {
                     $context->smarty->assign([
                         'everPresentProducts' => $everPresentProducts,
-                        'carousel' => false,
+                        'carousel' => $carousel,
                         'shortcodeClass' => 'crosselling',
                     ]);
                     $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);
@@ -803,7 +804,7 @@ class EverblockTools extends ObjectModel
             if (!empty($everPresentProducts)) {
                 $context->smarty->assign([
                     'everPresentProducts' => $everPresentProducts,
-                    'carousel' => false,
+                    'carousel' => $carousel,
                     'shortcodeClass' => 'crosselling',
                 ]);
                 $templatePath = static::getTemplatePath('hook/ever_presented_products.tpl', $module);

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -17,12 +17,35 @@
 *}
 {if isset($everPresentProducts) && $everPresentProducts}
   <section class="ever-featured-products featured-products clearfix mt-3{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
-    <div class="products row {if isset($carousel) && $carousel}ever-slick-carousel{/if}">
-      {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
-      {foreach $everPresentProducts item=product}
-        {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
-      {/foreach}
-      {hook h='displayAfterProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
-    </div>
+    {if isset($carousel) && $carousel}
+      {$carouselId = 'ever-presented-carousel-'|cat:rand(1000, 9999)}
+      <div id="{$carouselId}" class="carousel slide" data-ride="carousel">
+        <div class="carousel-inner products">
+          {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
+          {foreach $everPresentProducts item=product name=evercarousel}
+            <div class="carousel-item{if $smarty.foreach.evercarousel.first} active{/if}">
+              {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="d-block w-100"}
+            </div>
+          {/foreach}
+          {hook h='displayAfterProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
+        </div>
+        <a class="carousel-control-prev" href="#{$carouselId}" role="button" data-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="sr-only">{l s='Previous' mod='everblock'}</span>
+        </a>
+        <a class="carousel-control-next" href="#{$carouselId}" role="button" data-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="sr-only">{l s='Next' mod='everblock'}</span>
+        </a>
+      </div>
+    {else}
+      <div class="products row">
+        {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
+        {foreach $everPresentProducts item=product}
+          {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
+        {/foreach}
+        {hook h='displayAfterProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
+      </div>
+    {/if}
   </section>
 {/if}


### PR DESCRIPTION
## Summary
- enable optional `carousel` flag in `[crosselling]` shortcode via regex update
- pass `carousel` option through to product template assignments
- render cross-selling blocks as Bootstrap carousels when `carousel` is true

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_68a33a1597388322aafe5fa964297bd0