### PR TITLE
feat: inline social link svgs

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2676,6 +2676,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $socialLinksTemplate,
                 ],
+                'config' => [
+                    'fields' => [
+                        'icon_color' => [
+                            'type' => 'color',
+                            'label' => $module->l('Icon color'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Social link',
                     'nameFrom' => 'url',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -89,9 +89,10 @@
   align-items: center;
 }
 
-.everblock-social-links img {
+.everblock-social-links svg {
   width: 32px;
   height: 32px;
+  display: block;
 }
 .everblock-gallery img {
     cursor: pointer;

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -25,21 +25,25 @@
     <div class="everblock-social-links d-flex">
         {foreach from=$block.states item=state}
           {if isset($state.url) && $state.url}
-            <a href="{$state.url|escape:'htmlall'}" class="obfme" title="{$state.url|escape:'htmlall'}" target="_blank">
-              {assign var="icon_url" value=false}
-              {if isset($state.icon.url) && $state.icon.url}
-                {assign var="icon_url" value=$state.icon.url}
-              {elseif isset($state.icon) && is_string($state.icon)}
-                {if $state.icon|substr:-4 == '.svg'}
-                  {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
-                {else}
-                  {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
-                {/if}
+            {assign var="icon_url" value=false}
+            {if isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon)}
+              {if $state.icon|substr:-4 == '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
               {/if}
-              {if $icon_url}
-                <img src="{$icon_url|escape:'htmlall'}" alt="{$state.url|escape:'htmlall'}" />
+            {/if}
+            {if $icon_url}
+              {assign var="svg_content" value=$icon_url|@file_get_contents}
+              {if isset($block.settings.icon_color) && $block.settings.icon_color}
+                {assign var="svg_content" value=$svg_content|regex_replace:'/fill="[^"]+"/':'fill="currentColor"'}
               {/if}
-            </a>
+              <a href="{$state.url|escape:'htmlall'}" class="obfme" title="{$state.url|escape:'htmlall'}" target="_blank" style="{if isset($block.settings.icon_color) && $block.settings.icon_color}color:{$block.settings.icon_color|escape:'htmlall'};{/if}">
+                {$svg_content nofilter}
+              </a>
+            {/if}
           {/if}
         {/foreach}
       </div>


### PR DESCRIPTION
## Summary
- render social link icons inline instead of `<img>` tags
- allow custom color for social link icons
- ensure social icons display side by side

## Testing
- `php -l models/EverblockPrettyBlocks.php`

------
https://chatgpt.com/codex/tasks/task_e_68a428588254832294b2909c8e930407