### PR TITLE
Fix icon URL detection for string-defined icons

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -26,7 +26,7 @@
     {foreach from=$block.states item=state key=key}
       {* Génère l'URL de l'icône depuis le nom brut *}
       {assign var="icon_url" value=false}
-      {if isset($state.icon.url) && $state.icon.url}
+      {if (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
         {assign var="icon_url" value=$state.icon.url}
       {elseif isset($state.icon) && is_string($state.icon)}
         {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -26,7 +26,7 @@
         {foreach from=$block.states item=state}
           {if isset($state.url) && $state.url}
             {assign var="icon_url" value=false}
-            {if isset($state.icon.url) && $state.icon.url}
+            {if (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
               {assign var="icon_url" value=$state.icon.url}
             {elseif isset($state.icon) && is_string($state.icon)}
               {if $state.icon|substr:-4 == '.svg'}


### PR DESCRIPTION
## Summary
- handle icons defined as strings in social links block
- ensure reassurance block checks icon type before using URL

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4306250a08322919bc74d08b8ba74