### PR TITLE
Use absolute module path for social icon SVGs

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -30,9 +30,9 @@
               {assign var="icon_url" value=$state.icon.url}
             {elseif isset($state.icon) && is_string($state.icon)}
               {if $state.icon|substr:-4 == '.svg'}
-                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+                {assign var="icon_url" value=$smarty.const._PS_MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
               {else}
-                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+                {assign var="icon_url" value=$smarty.const._PS_MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
               {/if}
             {/if}
             {if $icon_url}


### PR DESCRIPTION
## Summary
- fix open_basedir warnings by reading SVG icons from absolute module directory

## Testing
- `php -l views/templates/hook/prettyblocks/prettyblock_social_links.tpl`


------
https://chatgpt.com/codex/tasks/task_e_68a43337a36c83228c41445110b81d5e