### PR TITLE
Add placeholder SVG icons for e-commerce module

### DIFF
--- a/views/img/svg/arrow-down-up.svg
+++ b/views/img/svg/arrow-down-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">arrow-down-up</text></svg>

--- a/views/img/svg/arrow-repeat.svg
+++ b/views/img/svg/arrow-repeat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">arrow-repeat</text></svg>

--- a/views/img/svg/bag-plus.svg
+++ b/views/img/svg/bag-plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">bag-plus</text></svg>

--- a/views/img/svg/bag.svg
+++ b/views/img/svg/bag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">bag</text></svg>

--- a/views/img/svg/barcode.svg
+++ b/views/img/svg/barcode.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">barcode</text></svg>

--- a/views/img/svg/box-arrow-in-right.svg
+++ b/views/img/svg/box-arrow-in-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">box-arrow-in-right</text></svg>

--- a/views/img/svg/box-arrow-right.svg
+++ b/views/img/svg/box-arrow-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">box-arrow-right</text></svg>

--- a/views/img/svg/box-seam.svg
+++ b/views/img/svg/box-seam.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">box-seam</text></svg>

--- a/views/img/svg/cart-plus.svg
+++ b/views/img/svg/cart-plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">cart-plus</text></svg>

--- a/views/img/svg/cart.svg
+++ b/views/img/svg/cart.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">cart</text></svg>

--- a/views/img/svg/chat-dots.svg
+++ b/views/img/svg/chat-dots.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">chat-dots</text></svg>

--- a/views/img/svg/check.svg
+++ b/views/img/svg/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">check</text></svg>

--- a/views/img/svg/clock.svg
+++ b/views/img/svg/clock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">clock</text></svg>

--- a/views/img/svg/credit-card.svg
+++ b/views/img/svg/credit-card.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">credit-card</text></svg>

--- a/views/img/svg/download.svg
+++ b/views/img/svg/download.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">download</text></svg>

--- a/views/img/svg/envelope.svg
+++ b/views/img/svg/envelope.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">envelope</text></svg>

--- a/views/img/svg/funnel.svg
+++ b/views/img/svg/funnel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">funnel</text></svg>

--- a/views/img/svg/gear.svg
+++ b/views/img/svg/gear.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">gear</text></svg>

--- a/views/img/svg/grid.svg
+++ b/views/img/svg/grid.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">grid</text></svg>

--- a/views/img/svg/heart.svg
+++ b/views/img/svg/heart.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">heart</text></svg>

--- a/views/img/svg/hourglass.svg
+++ b/views/img/svg/hourglass.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">hourglass</text></svg>

--- a/views/img/svg/house.svg
+++ b/views/img/svg/house.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">house</text></svg>

--- a/views/img/svg/list-ul.svg
+++ b/views/img/svg/list-ul.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">list-ul</text></svg>

--- a/views/img/svg/list.svg
+++ b/views/img/svg/list.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">list</text></svg>

--- a/views/img/svg/lock.svg
+++ b/views/img/svg/lock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">lock</text></svg>

--- a/views/img/svg/map-pin.svg
+++ b/views/img/svg/map-pin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">map-pin</text></svg>

--- a/views/img/svg/map.svg
+++ b/views/img/svg/map.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">map</text></svg>

--- a/views/img/svg/percent.svg
+++ b/views/img/svg/percent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">percent</text></svg>

--- a/views/img/svg/person.svg
+++ b/views/img/svg/person.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">person</text></svg>

--- a/views/img/svg/question-circle.svg
+++ b/views/img/svg/question-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">question-circle</text></svg>

--- a/views/img/svg/receipt.svg
+++ b/views/img/svg/receipt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">receipt</text></svg>

--- a/views/img/svg/search.svg
+++ b/views/img/svg/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">search</text></svg>

--- a/views/img/svg/share.svg
+++ b/views/img/svg/share.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">share</text></svg>

--- a/views/img/svg/star.svg
+++ b/views/img/svg/star.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">star</text></svg>

--- a/views/img/svg/stars.svg
+++ b/views/img/svg/stars.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">stars</text></svg>

--- a/views/img/svg/tag.svg
+++ b/views/img/svg/tag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">tag</text></svg>

--- a/views/img/svg/telephone.svg
+++ b/views/img/svg/telephone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">telephone</text></svg>

--- a/views/img/svg/truck.svg
+++ b/views/img/svg/truck.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">truck</text></svg>

--- a/views/img/svg/upload.svg
+++ b/views/img/svg/upload.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">upload</text></svg>

--- a/views/img/svg/wallet.svg
+++ b/views/img/svg/wallet.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">wallet</text></svg>

--- a/views/img/svg/x.svg
+++ b/views/img/svg/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect width="24" height="24" fill="#EEE"/><text x="12" y="12" font-size="5" text-anchor="middle" dominant-baseline="middle" fill="#555">x</text></svg>


### PR DESCRIPTION
## Summary
- add placeholder SVGs for navigation (cart, wishlist, account, menu, etc.)
- include product, shipping, payment and utility icons for future design

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a46602bb28832289a58cf54350f297