### PR TITLE
Fix getProductsByCategoryId return type

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -1335,7 +1335,8 @@ class EverblockTools extends ObjectModel
             return $return;
         }
 
-        return EverblockCache::cacheRetrieve($cacheId);
+        $cachedProducts = EverblockCache::cacheRetrieve($cacheId);
+        return is_array($cachedProducts) ? $cachedProducts : [];
     }
 
     public static function getManufacturerShortcodes($message, $context, Everblock $module)


### PR DESCRIPTION
## Summary
- ensure `EverblockTools::getProductsByCategoryId` always returns an array

## Testing
- `php -l models/EverblockTools.php`
- `php vendor/bin/phpstan analyse` *(fails: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_68a57093ccf883229cd06fe61eb0ecfa