### PR TITLE
Allow setting PrettyBlock cover title color

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -3132,6 +3132,12 @@ class EverblockPrettyBlocks extends ObjectModel
                             ],
                             'default' => 'h2',
                         ],
+                        'title_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '#000000',
+                            'label' => $module->l('Title color'),
+                        ],
                         'content' => [
                             'type' => 'editor',
                             'label' => $module->l('Content'),

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -37,7 +37,7 @@
           {/if}
           <div class="prettyblock-cover-overlay">
             {if $state.title}
-              <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
+              <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color:{$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
             {/if}
             {if $state.content}
               <div class="prettyblock-cover-content">
@@ -70,7 +70,7 @@
         {/if}
         <div class="prettyblock-cover-overlay">
           {if $state.title}
-            <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
+            <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color:{$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}
           {if $state.content}
             <div class="prettyblock-cover-content">


### PR DESCRIPTION
## Summary
- add `title_color` option to PrettyBlock cover block
- apply selected color when rendering cover block titles

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_68a5dee937dc8322b2719ff02a576343