### PR TITLE
feat: improve PrettyBlocks cover block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -3132,6 +3132,12 @@ class EverblockPrettyBlocks extends ObjectModel
                             ],
                             'default' => 'h2',
                         ],
+                        'title_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Title color'),
+                            'default' => '#000000',
+                        ],
                         'content' => [
                             'type' => 'editor',
                             'label' => $module->l('Content'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -325,9 +325,14 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-/*    justify-content: center;*/
+    justify-content: center;
     align-items: center;
     text-align: center;
+    padding: 1rem;
+}
+
+.prettyblock-cover-overlay .d-flex {
+    flex-wrap: wrap;
 }
 
 /* Cover block slider */

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -37,7 +37,7 @@
           {/if}
           <div class="prettyblock-cover-overlay">
             {if $state.title}
-              <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
+              <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
             {/if}
             {if $state.content}
               <div class="prettyblock-cover-content">
@@ -70,7 +70,7 @@
         {/if}
         <div class="prettyblock-cover-overlay">
           {if $state.title}
-            <{$state.title_tag|default:'h2'}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
+            <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}
           {if $state.content}
             <div class="prettyblock-cover-content">


### PR DESCRIPTION
## Summary
- allow custom title color in PrettyBlocks cover block
- center cover overlay and better mobile wrapping

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6021d782483228fbbbe8c13876054