### PR TITLE
Add Everblock PrettyBlocks repeater

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3682,6 +3682,34 @@ class Everblock extends Module
         }
     }
 
+    public function hookRenderEverblockEverblock($params)
+    {
+        if (empty($params['block']['states']) || !is_array($params['block']['states'])) {
+            return ['block' => $params['block']];
+        }
+        foreach ($params['block']['states'] as &$state) {
+            if (empty($state['id_everblock'])) {
+                $state['content'] = '';
+                continue;
+            }
+            $everblock = new EverBlockClass(
+                (int) $state['id_everblock'],
+                (int) $this->context->language->id,
+                (int) $this->context->shop->id
+            );
+            if (Validate::isLoadedObject($everblock)
+                && !empty($everblock->content[$this->context->language->id])
+            ) {
+                $state['content'] = $everblock->content[$this->context->language->id];
+            } else {
+                $state['content'] = '';
+            }
+        }
+        unset($state);
+
+        return ['block' => $params['block']];
+    }
+
     public function hookBeforeRenderingEverblockCategoryTabs($params)
     {
         $products = [];

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -77,12 +77,21 @@ class EverblockPrettyBlocks extends ObjectModel
             $categoryPriceTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_price.tpl';
             $tocTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_toc.tpl';
             $imageMapTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_image_map.tpl';
+            $everblockTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_everblock.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
                 (int) $context->language->id,
                 (int) $context->shop->id
             );
+            $everblocks = EverBlockClass::getAllBlocks(
+                (int) $context->language->id,
+                (int) $context->shop->id
+            );
+            $everblockChoices = [];
+            foreach ($everblocks as $eblock) {
+                $everblockChoices[$eblock['id_everblock']] = $eblock['id_everblock'] . ' - ' . $eblock['name'];
+            }
             $allHooks = Hook::getHooks(false, true);
             $prettyBlocksHooks = [];
             foreach ($allHooks as $hook) {
@@ -376,6 +385,86 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'h6' => 'H6',
                             ],
                             'default' => 'h2',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Everblocks'),
+                'description' => $module->l('Render existing Everblocks'),
+                'code' => 'everblock_everblock',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $everblockTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Everblock',
+                    'nameFrom' => 'id_everblock',
+                    'groups' => [
+                        'id_everblock' => [
+                            'type' => 'select',
+                            'label' => $module->l('Select an Everblock'),
+                            'choices' => $everblockChoices,
+                            'default' => '',
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block background color'),
+                        ],
+                        'text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block text color'),
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
@@ -39,9 +39,6 @@
     </div>
     {/foreach}
     {/if}
-    {if $block.settings.default.container}
-        </div>
-    {/if}
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>
   {/if}


### PR DESCRIPTION
## Summary
- add PrettyBlocks block to select existing Everblocks
- render hook injects selected Everblock content
- include template for rendering chosen Everblocks

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7499939b483229145e0145399caa0