### PR TITLE
feat: add mobile image upload to text and image block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1889,6 +1889,13 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'url' => '',
                             ],
                         ],
+                        'image_mobile' => [
+                            'type' => 'fileupload',
+                            'label' => 'Mobile layout image',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'image_width' => [
                             'type' => 'text',
                             'label' => 'Image width (e.g., 100px or 50%)',

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -38,12 +38,21 @@
                 
                 {* IMAGE *}
                 <div class="col-md-6 mb-3 mb-md-0 text-center">
+                    {if $state.image_mobile.url}
+                        <picture class="d-block d-md-none">
+                            <source srcset="{$state.image_mobile.url}" type="image/webp">
+                            <source srcset="{$state.image_mobile.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                            <img src="{$state.image_mobile.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                                 {if $state.image_mobile.width > 0} width="{$state.image_mobile.width}"{/if}
+                                 {if $state.image_mobile.height > 0} height="{$state.image_mobile.height}"{/if}
+                                 loading="lazy">
+                        </picture>
+                    {/if}
                     {if $state.image.url}
-                        <picture>
+                        <picture class="{if $state.image_mobile.url}d-none d-md-block{/if}">
                             <source srcset="{$state.image.url}" type="image/webp">
                             <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                            <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}"
-                                 class="img img-fluid rounded mx-auto d-block lazyload"
+                            <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
                                  {if $state.image.width > 0} width="{$state.image.width}"{/if}
                                  {if $state.image.height > 0} height="{$state.image.height}"{/if}
                                  loading="lazy">


### PR DESCRIPTION
## Summary
- add mobile image upload option to text and image block configuration
- render mobile-specific image in template when provided

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68a875d134d083229c351da5f2229618