### PR TITLE
chore: remove overlay center justification

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -325,7 +325,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
     text-align: center;
     padding: 1rem;


### PR DESCRIPTION
## Summary
- remove center justification from .prettyblock-cover-overlay

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a87b8bc9588322959112946e1160ef