### PR TITLE
feat: add parallax option to text and image block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1906,6 +1906,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => 'Image height (e.g., 100px)',
                             'default' => 'auto',
                         ],
+                        'parallax' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Parallax mode'),
+                            'default' => false,
+                        ],
                         'content' => [
                             'type' => 'editor',
                             'label' => 'Layout content',

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -38,25 +38,48 @@
                 
                 {* IMAGE *}
                 <div class="col-md-6 mb-3 mb-md-0 text-center">
-                    {if $state.image_mobile.url}
-                        <picture class="d-block d-md-none">
-                            <source srcset="{$state.image_mobile.url}" type="image/webp">
-                            <source srcset="{$state.image_mobile.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                            <img src="{$state.image_mobile.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
-                                 {if $state.image_mobile.width > 0} width="{$state.image_mobile.width}"{/if}
-                                 {if $state.image_mobile.height > 0} height="{$state.image_mobile.height}"{/if}
-                                 loading="lazy">
-                        </picture>
-                    {/if}
-                    {if $state.image.url}
-                        <picture class="{if $state.image_mobile.url}d-none d-md-block{/if}">
-                            <source srcset="{$state.image.url}" type="image/webp">
-                            <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                            <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
-                                 {if $state.image.width > 0} width="{$state.image.width}"{/if}
-                                 {if $state.image.height > 0} height="{$state.image.height}"{/if}
-                                 loading="lazy">
-                        </picture>
+                    {if $state.parallax}
+                        {if $state.image_mobile.url}
+                            <div class="d-block d-md-none" style="
+                                background-image:url('{$state.image_mobile.url|replace:'.webp':'.jpg'}');
+                                background-size:cover;
+                                background-position:center;
+                                background-repeat:no-repeat;
+                                background-attachment:fixed;
+                                {if $state.image_mobile.height > 0}min-height:{$state.image_mobile.height}px;{/if}">
+                            </div>
+                        {/if}
+                        {if $state.image.url}
+                            <div class="{if $state.image_mobile.url}d-none d-md-block{/if}" style="
+                                background-image:url('{$state.image.url|replace:'.webp':'.jpg'}');
+                                background-size:cover;
+                                background-position:center;
+                                background-repeat:no-repeat;
+                                background-attachment:fixed;
+                                {if $state.image.height > 0}min-height:{$state.image.height}px;{/if}">
+                            </div>
+                        {/if}
+                    {else}
+                        {if $state.image_mobile.url}
+                            <picture class="d-block d-md-none">
+                                <source srcset="{$state.image_mobile.url}" type="image/webp">
+                                <source srcset="{$state.image_mobile.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                                <img src="{$state.image_mobile.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                                     {if $state.image_mobile.width > 0} width="{$state.image_mobile.width}"{/if}
+                                     {if $state.image_mobile.height > 0} height="{$state.image_mobile.height}"{/if}
+                                     loading="lazy">
+                            </picture>
+                        {/if}
+                        {if $state.image.url}
+                            <picture class="{if $state.image_mobile.url}d-none d-md-block{/if}">
+                                <source srcset="{$state.image.url}" type="image/webp">
+                                <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                                <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                                     {if $state.image.width > 0} width="{$state.image.width}"{/if}
+                                     {if $state.image.height > 0} height="{$state.image.height}"{/if}
+                                     loading="lazy">
+                            </picture>
+                        {/if}
                     {/if}
                 </div>
 


### PR DESCRIPTION
## Summary
- allow configuring a parallax effect on Prettyblock's text and image block
- render image as fixed background when parallax option is enabled

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8a3d96abc83229d45ccddf32f5489