### PR TITLE
Add configurable text placement for cover block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -3308,6 +3308,30 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'dark' => 'dark',
                             ],
                         ],
+                        'content_position_desktop' => [
+                            'type' => 'select',
+                            'label' => $module->l('Content position (desktop)'),
+                            'choices' => [
+                                'center' => $module->l('Center'),
+                                'top' => $module->l('Top'),
+                                'bottom' => $module->l('Bottom'),
+                                'left' => $module->l('Left'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'center',
+                        ],
+                        'content_position_mobile' => [
+                            'type' => 'select',
+                            'label' => $module->l('Content position (mobile)'),
+                            'choices' => [
+                                'center' => $module->l('Center'),
+                                'top' => $module->l('Top'),
+                                'bottom' => $module->l('Bottom'),
+                                'left' => $module->l('Left'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'center',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -330,6 +330,68 @@
     padding: 1rem;
 }
 
+.prettyblock-cover-overlay.position-desktop-top {
+    justify-content: flex-start;
+    align-items: center;
+    text-align: center;
+}
+
+.prettyblock-cover-overlay.position-desktop-bottom {
+    justify-content: flex-end;
+    align-items: center;
+    text-align: center;
+}
+
+.prettyblock-cover-overlay.position-desktop-left {
+    justify-content: center;
+    align-items: flex-start;
+    text-align: left;
+}
+
+.prettyblock-cover-overlay.position-desktop-right {
+    justify-content: center;
+    align-items: flex-end;
+    text-align: right;
+}
+
+.prettyblock-cover-overlay.position-desktop-center {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
+@media (max-width: 767px) {
+    .prettyblock-cover-overlay.position-mobile-top {
+        justify-content: flex-start;
+        align-items: center;
+        text-align: center;
+    }
+
+    .prettyblock-cover-overlay.position-mobile-bottom {
+        justify-content: flex-end;
+        align-items: center;
+        text-align: center;
+    }
+
+    .prettyblock-cover-overlay.position-mobile-left {
+        justify-content: center;
+        align-items: flex-start;
+        text-align: left;
+    }
+
+    .prettyblock-cover-overlay.position-mobile-right {
+        justify-content: center;
+        align-items: flex-end;
+        text-align: right;
+    }
+
+    .prettyblock-cover-overlay.position-mobile-center {
+        justify-content: center;
+        align-items: center;
+        text-align: center;
+    }
+}
+
 .prettyblock-cover-overlay .d-flex {
     flex-wrap: wrap;
 }

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -40,7 +40,7 @@
                      class="prettyblock-cover-image">
               </picture>
             {/if}
-          <div class="prettyblock-cover-overlay">
+          <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|escape:'htmlall'}">
             {if $state.title}
               <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
             {/if}
@@ -78,7 +78,7 @@
                  class="prettyblock-cover-image">
           </picture>
         {/if}
-        <div class="prettyblock-cover-overlay">
+        <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|escape:'htmlall'}">
           {if $state.title}
             <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}


### PR DESCRIPTION
## Summary
- allow setting cover text position separately for desktop and mobile
- style overlays for top, bottom, left, right and center placements

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac137687b083229f413889b51567d9