### PR TITLE
feat: allow custom title position in category highlight

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1390,6 +1390,30 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Open in new tab (only if not obfuscated)'),
                             'default' => '0',
                         ],
+                        'title_position_desktop' => [
+                            'type' => 'select',
+                            'label' => $module->l('Title position (desktop)'),
+                            'choices' => [
+                                'center' => $module->l('Center'),
+                                'top' => $module->l('Top'),
+                                'bottom' => $module->l('Bottom'),
+                                'left' => $module->l('Left'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'center',
+                        ],
+                        'title_position_mobile' => [
+                            'type' => 'select',
+                            'label' => $module->l('Title position (mobile)'),
+                            'choices' => [
+                                'center' => $module->l('Center'),
+                                'top' => $module->l('Top'),
+                                'bottom' => $module->l('Bottom'),
+                                'left' => $module->l('Left'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'center',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -71,7 +71,7 @@
           {/if}
 
         {if $state.name}
-          <div class="position-absolute bottom-0 end-0 text-white category_state_name">
+          <div class="prettyblock-cover-overlay category_state_name position-desktop-{$state.title_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.title_position_mobile|default:'center'|escape:'htmlall'}">
             <h2 class="m-0 text-white">{$state.name nofilter}</h2>
           </div>
         {/if}


### PR DESCRIPTION
## Summary
- add desktop/mobile title position options to featured category block
- render featured category title using responsive overlay classes

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5e03c8e48322a489b0986971e569