### PR TITLE
Ensure Prettyblock Social Links icons align horizontally

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -85,7 +85,13 @@
 
 .everblock-social-links {
   display: flex;
+  flex-direction: row;
   gap: 10px;
+  align-items: center;
+}
+
+.everblock-social-links a {
+  display: inline-flex;
   align-items: center;
 }
 

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -22,7 +22,7 @@
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
-    <div class="everblock-social-links d-flex">
+    <div class="everblock-social-links d-flex flex-row">
         {foreach from=$block.states item=state}
           {if isset($state.url) && $state.url}
             {assign var="icon_url" value=false}


### PR DESCRIPTION
## Summary
- Ensure social link icons display side by side using flex layout
- Explicitly set row layout for social link container

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `composer global require friendsofphp/php-cs-fixer` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `composer global require phpstan/phpstan` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad61c131808322a59c5982bdf28257