### PR TITLE
Handle missing products key in product selector template

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl
@@ -22,7 +22,7 @@
     <div class="row">
   {/if}
     <div class="mt-2{if $block.settings.default.container} container{/if}"  style="{if isset($block.settings.padding_left) && $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_right) && $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_top) && $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_bottom) && $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_left) && $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_right) && $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_top) && $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_bottom) && $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
-      {if $block.extra.products}
+      {if isset($block.extra.products) && $block.extra.products}
         {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products carousel=$block.settings.slider shortcodeClass='product_selector'}
       {/if}
     </div>


### PR DESCRIPTION
## Summary
- prevent warnings when `$block.extra.products` is undefined

## Testing
- `find . -name '*.php' -not -path './vendor/*' -print0 | xargs -0 -n1 php -l`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68af22ad2aa483228e5c1de182b505b7