### PR TITLE
Add inline display option for reassurance block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -809,6 +809,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $reassuranceTemplate,
                 ],
+                'settings' => [
+                    'default' => [
+                        'display_inline' => [
+                            'type' => 'switch',
+                            'label' => $module->l('Display reassurances side by side'),
+                            'default' => false,
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Reassurances',
                     'nameFrom' => 'title',

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -38,7 +38,7 @@
         {/if}
       {/if}
 
-      <div id="block-{$block.id_prettyblocks}-{$key}" class="text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
+      <div id="block-{$block.id_prettyblocks}-{$key}" class="{if $block.settings.default.display_inline}col {/if}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
         {if $state.padding_left}padding-left:{$state.padding_left};{/if}
         {if $state.padding_right}padding-right:{$state.padding_right};{/if}
         {if $state.padding_top}padding-top:{$state.padding_top};{/if}


### PR DESCRIPTION
## Summary
- add toggle to display reassurance items side by side
- apply column class in template when enabled

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68af3d0a2d148322bc386cd6bd788dd8