### PR TITLE
fix: ensure presented products carousel is responsive

### DIFF
--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -34,7 +34,7 @@
               <div class="carousel-item{if $product@first} active{/if}">
                 <div class="row">
             {/if}
-            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
+            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-12 col-sm-6 col-lg-4 col-xl-3"}
             {if ($product@index + 1) % $numProductsPerSlide == 0 || $product@last}
                 </div>
               </div>
@@ -58,7 +58,7 @@
       <div class="products row">
         {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
         {foreach $everPresentProducts item=product}
-          {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
+          {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-12 col-sm-6 col-lg-4 col-xl-3"}
         {/foreach}
         {hook h='displayAfterProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
       </div>


### PR DESCRIPTION
## Summary
- use current Bootstrap grid classes in presented products slider to improve responsiveness

## Testing
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_68aff4a2db308322a50470a661cd8e44