### PR TITLE
Add customizable brands prettyblock

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -179,6 +179,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_accordeon.tpl',
     'views/templates/hook/prettyblocks/prettyblock_alert.tpl',
     'views/templates/hook/prettyblocks/prettyblock_button.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_brands.tpl',
     'views/templates/hook/prettyblocks/prettyblock_card.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_price.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -69,6 +69,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $sharerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_sharer.tpl';
             $linkListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_link_list.tpl';
             $socialLinksTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_social_links.tpl';
+            $brandListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_brands.tpl';
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
@@ -2832,6 +2833,74 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Select an icon'),
                             'choices' => EverblockTools::getAvailableSvgIcons(),
                             'default' => 'facebook.svg',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Brands'),
+                'description' => $module->l('Display selected brands side by side'),
+                'code' => 'everblock_brands',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $brandListTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Brand',
+                    'nameFrom' => 'brand',
+                    'groups' => [
+                        'brand' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Choose a brand'),
+                            'collection' => 'Manufacturer',
+                            'selector' => '{id} - {name}',
+                            'default' => '',
                         ],
                     ],
                 ],

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -457,6 +457,8 @@ $_MODULE['<{everblock}prestashop>everblockprettyblocks_15fcc7ab64c322448d2045441
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_90c599b1c29354c8d3cac24beb2c9c26'] = 'Couleur du texte du bouton';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_212f9ac581ccabed469caf2e605a7c75'] = 'Carousel d\'images';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_46b883ef3f1530fd1c2b28b381800084'] = 'Affiche un carousel d\'images (les images doivent avoir la même taille)';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_84be54bb4bd1b755a27d86388700d097'] = 'Marques';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_8f9eabc1113072d009965c1009eeb5ce'] = 'Affiche une liste de marques sélectionnées';
 $_MODULE['<{everblock}prestashop>configure_621886d5d907cadfb35840e0bc9688d3'] = 'Qu\'est-ce qu\'un hook ?';
 $_MODULE['<{everblock}prestashop>configure_714f82bdd35410e27b403a7ed10fa67e'] = 'Un hook est un endroit où vous pouvez « greffer » un module. Très nombreux sur Prestashop, ils sont enregistrés dans votre base de données, et affichés par votre thème et vos modules.';
 $_MODULE['<{everblock}prestashop>configure_6c9cc2811d8dd20065be04ab58bbcaa7'] = 'Ces hooks sont disponibles à la fois sur votre site, mais aussi dans l\'administration de votre boutique.';

--- a/views/templates/hook/ever_brand.tpl
+++ b/views/templates/hook/ever_brand.tpl
@@ -17,14 +17,18 @@
 *}
 {if isset($brands) && $brands}
   <section class="featured-brands clearfix mt-3">
-    <div class="brands row ever-slick-carousel">
+    <div class="brands row{if $carousel} ever-slick-carousel{/if}">
       {foreach from=$brands item=brand}
-        <div class="col-md-3 mb-3 d-flex justify-content-center align-items-center text-center">
+        <div class="col-6 col-md-3 mb-3 d-flex justify-content-center align-items-center text-center">
           <a href="{$brand.url|escape:'htmlall':'UTF-8'}" title="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-link">
-            <img src="{$brand.logo|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
-                 width="{$brand.width|escape:'htmlall':'UTF-8'}"
-                 height="{$brand.height|escape:'htmlall':'UTF-8'}"
-                 class="brand-image lazyload" loading="lazy">
+            <picture>
+              <source srcset="{$brand.logo|escape:'htmlall':'UTF-8'}" type="image/webp">
+              <source srcset="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" type="image/jpeg">
+              <img src="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
+                   width="{$brand.width|escape:'htmlall':'UTF-8'}"
+                   height="{$brand.height|escape:'htmlall':'UTF-8'}"
+                   class="brand-image lazyload" loading="lazy">
+            </picture>
           </a>
         </div>
       {/foreach}

--- a/views/templates/hook/prettyblocks/prettyblock_brands.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_brands.tpl
@@ -1,0 +1,34 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {assign var=brands value=[]}
+  {if isset($block.states) && $block.states}
+    {foreach from=$block.states item=state}
+      {if isset($state.brand.id) && $state.brand.id}
+        {assign var=brandData value=EverblockTools::getBrandDataById($state.brand.id, Context::getContext())}
+        {if $brandData}
+          {assign var=brands value=$brands|@array_merge:[$brandData]}
+        {/if}
+      {/if}
+    {/foreach}
+  {/if}
+  {if $brands}
+    {include file='module:everblock/views/templates/hook/ever_brand.tpl' brands=$brands carousel=(count($brands) > 4)}
+  {/if}
+</div>
+


### PR DESCRIPTION
## Summary
- add Brands prettyblock with repeater to select manufacturers
- support webp brand logos and optional slider when more than four brands
- enable brands template usage and translations

## Testing
- `php -l models/EverblockTools.php`
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `php -l translations/fr.php`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b02eda8ddc8322aedc05cfea54a817