### PR TITLE
feat: make featured category columns configurable

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1331,6 +1331,23 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $featuredCategoryTemplate
                 ],
+                'config' => [
+                    'fields' => [
+                        'desktop_columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Desktop columns'),
+                            'default' => '2',
+                            'choices' => [
+                                '1' => '1',
+                                '2' => '2',
+                                '3' => '3',
+                                '4' => '4',
+                                '5' => '5',
+                                '6' => '6',
+                            ],
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Menu',
                     'nameFrom' => 'name',

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -17,9 +17,9 @@
 *}
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
     {if $block.settings.default.force_full_width}
-      <div class="row row-cols-1 row-cols-md-5 gx-0 no-gutters">
+      <div class="row row-cols-1 row-cols-md-{$block.settings.desktop_columns|default:2} gx-0 no-gutters">
   {elseif $block.settings.default.container}
-    <div class="row">
+    <div class="row row-cols-1 row-cols-md-{$block.settings.desktop_columns|default:2}">
   {/if}
   {foreach from=$block.states item=state key=key}
     {if isset($state.category.id) && $state.category.id}


### PR DESCRIPTION
## Summary
- allow selecting desktop column count for featured category block
- adjust template to respect user-defined desktop columns while keeping mobile items stacked

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b293c7dde08322ba6d87fb886bee2e