### PR TITLE
Remove repeater size option and redundant flag limit

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -482,7 +482,6 @@ class Everblock extends Module
             $sql->select('id_everblock_flags');
             $sql->from(EverblockFlagsClass::$definition['table']);
             $sql->where('id_shop = ' . (int) $idShop);
-            $sql->limit(1);
             if (Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql)) {
                 $needHook = true;
             }

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1374,18 +1374,6 @@ class EverblockPrettyBlocks extends ObjectModel
                             'default' => \HelperBuilder::getRandomCategory((int) $context->language->id, (int) $context->shop->id),
                             'force_default_value' => true,
                         ],
-                        'order' => [
-                            'type' => 'select',
-                            'label' => 'Layout width', 
-                            'default' => 'col-12',
-                            'choices' => [
-                                'col-12' => '100%',
-                                'col-12 col-md-6' => '50%',
-                                'col-12 col-md-4' => '33,33%',
-                                'col-12 col-md-3' => '25%',
-                                'col-12 col-md-2' => '16,67%',
-                            ]
-                        ],
                         'image' => [
                             'type' => 'fileupload',
                             'label' => 'Featured category image',

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -27,18 +27,6 @@
     {else}
     {assign var='category_link' value='#'}
     {/if}
-    {* Bootstrap column class based on selected layout width *}
-    {assign var="bootstrapClass" value="col-12"}
-    {if $state.order == '50'}
-      {assign var="bootstrapClass" value="col-12 col-md-6"}
-    {elseif $state.order == '33,33'}
-      {assign var="bootstrapClass" value="col-12 col-md-4"}
-    {elseif $state.order == '25'}
-      {assign var="bootstrapClass" value="col-12 col-md-3"}
-    {elseif $state.order == '16,67'}
-      {assign var="bootstrapClass" value="col-12 col-md-2"}
-    {/if}
-
     <div id="block-{$block.id_prettyblocks}-{$key}" class="col {$state.css_class|escape:'htmlall'}">
       <div class="position-relative overflow-hidden h-100 w-100" style="
         {if $state.padding_left}padding-left:{$state.padding_left};{/if}


### PR DESCRIPTION
## Summary
- drop per-repeater layout width setting for featured category block
- simplify featured category template to rely on block-level columns
- remove redundant SQL limit when checking for flag configuration

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l everblock.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b2af2d3a008322b0ee7f8291d7cdfd