### PR TITLE
feat: add bootstrap slider option for brands block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -2863,6 +2863,11 @@ class EverblockPrettyBlocks extends ObjectModel
                 ],
                 'config' => [
                     'fields' => [
+                        'slider' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable slider'),
+                            'default' => 0,
+                        ],
                         'padding_left' => [
                             'type' => 'text',
                             'label' => $module->l('Padding left (Please specify the unit of measurement)'),

--- a/views/templates/hook/ever_brand.tpl
+++ b/views/templates/hook/ever_brand.tpl
@@ -16,23 +16,86 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($brands) && $brands}
-  <section class="featured-brands clearfix mt-3">
-    <div class="brands row{if $carousel} ever-slick-carousel{/if}">
-      {foreach from=$brands item=brand}
-        <div class="col-6 col-md-3 mb-3 d-flex justify-content-center align-items-center text-center">
-          <a href="{$brand.url|escape:'htmlall':'UTF-8'}" title="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-link">
-            <picture>
-              <source srcset="{$brand.logo|escape:'htmlall':'UTF-8'}" type="image/webp">
-              <source srcset="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" type="image/jpeg">
-              <img src="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
-                   width="{$brand.width|escape:'htmlall':'UTF-8'}"
-                   height="{$brand.height|escape:'htmlall':'UTF-8'}"
-                   class="brand-image lazyload" loading="lazy">
-            </picture>
-          </a>
+  {if isset($carousel) && $carousel}
+    {assign var="carouselId" value="ever-brand-carousel-"|cat:mt_rand(1000,999999)}
+    <section class="featured-brands clearfix mt-3 d-none d-md-block">
+      <div id="{$carouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+        <div class="carousel-inner brands">
+          {assign var="numBrandsPerSlide" value=4}
+          {foreach from=$brands item=brand name=brands}
+            {if $brand@index % $numBrandsPerSlide == 0}
+              <div class="carousel-item{if $brand@first} active{/if}">
+                <div class="row">
+            {/if}
+            <div class="col-6 col-md-3 mb-3 d-flex justify-content-center align-items-center text-center">
+              <a href="{$brand.url|escape:'htmlall':'UTF-8'}" title="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-link">
+                <picture>
+                  <source srcset="{$brand.logo|escape:'htmlall':'UTF-8'}" type="image/webp">
+                  <source srcset="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" type="image/jpeg">
+                  <img src="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
+                       width="{$brand.width|escape:'htmlall':'UTF-8'}"
+                       height="{$brand.height|escape:'htmlall':'UTF-8'}"
+                       class="brand-image lazyload" loading="lazy">
+                </picture>
+              </a>
+            </div>
+            {if ($brand@index + 1) % $numBrandsPerSlide == 0 || $brand@last}
+                </div>
+              </div>
+            {/if}
+          {/foreach}
         </div>
-      {/foreach}
-    </div>
-  </section>
+        <button class="carousel-control-prev" type="button" data-bs-target="#{$carouselId}" data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#{$carouselId}" data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+        </button>
+      </div>
+    </section>
+    <section class="featured-brands mt-3 d-block d-md-none">
+      <div id="everBrandsCarouselMobile" class="overflow-auto" style="scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch;">
+        <div class="d-flex flex-nowrap">
+          {foreach from=$brands item=brand}
+            <div class="me-3" style="flex: 0 0 85%; scroll-snap-align: start;">
+              <div class="d-flex justify-content-center align-items-center text-center">
+                <a href="{$brand.url|escape:'htmlall':'UTF-8'}" title="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-link">
+                  <picture>
+                    <source srcset="{$brand.logo|escape:'htmlall':'UTF-8'}" type="image/webp">
+                    <source srcset="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" type="image/jpeg">
+                    <img src="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
+                         width="{$brand.width|escape:'htmlall':'UTF-8'}"
+                         height="{$brand.height|escape:'htmlall':'UTF-8'}"
+                         class="brand-image lazyload" loading="lazy">
+                  </picture>
+                </a>
+              </div>
+            </div>
+          {/foreach}
+        </div>
+      </div>
+    </section>
+  {else}
+    <section class="featured-brands clearfix mt-3">
+      <div class="brands row">
+        {foreach from=$brands item=brand}
+          <div class="col-6 col-md-3 mb-3 d-flex justify-content-center align-items-center text-center">
+            <a href="{$brand.url|escape:'htmlall':'UTF-8'}" title="{$brand.name|escape:'htmlall':'UTF-8'}" class="brand-link">
+              <picture>
+                <source srcset="{$brand.logo|escape:'htmlall':'UTF-8'}" type="image/webp">
+                <source srcset="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" type="image/jpeg">
+                <img src="{$brand.logo|replace:'.webp':'.jpg'|escape:'htmlall':'UTF-8'}" alt="{$brand.name|escape:'htmlall':'UTF-8'}"
+                     width="{$brand.width|escape:'htmlall':'UTF-8'}"
+                     height="{$brand.height|escape:'htmlall':'UTF-8'}"
+                     class="brand-image lazyload" loading="lazy">
+              </picture>
+            </a>
+          </div>
+        {/foreach}
+      </div>
+    </section>
+  {/if}
 {/if}
 

--- a/views/templates/hook/prettyblocks/prettyblock_brands.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_brands.tpl
@@ -28,7 +28,7 @@
     {/foreach}
   {/if}
   {if $brands}
-    {include file='module:everblock/views/templates/hook/ever_brand.tpl' brands=$brands carousel=(count($brands) > 4)}
+    {include file='module:everblock/views/templates/hook/ever_brand.tpl' brands=$brands carousel=$block.settings.slider}
   {/if}
 </div>
 


### PR DESCRIPTION
## Summary
- add slider checkbox to Brands prettyblock
- replace Slick carousel with Bootstrap slider for brands

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3e9d494e08322a51d32f8ad3bf096