### PR TITLE
Add Lookbook prettyblock with product links

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -199,6 +199,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_layout.tpl',
     'views/templates/hook/prettyblocks/prettyblock_link_list.tpl',
     'views/templates/hook/prettyblocks/prettyblock_login.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_lookbook.tpl',
     'views/templates/hook/prettyblocks/prettyblock_masonry_gallery.tpl',
     'views/templates/hook/prettyblocks/prettyblock_modal.tpl',
     'views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl',

--- a/everblock.php
+++ b/everblock.php
@@ -341,14 +341,23 @@ class Everblock extends Module
                 $hook->description = 'This hook triggers before category price block is rendered';
                 $hook->save();
             }
+            if (!Hook::getIdByName('beforeRenderingEverblockLookbook')) {
+                $hook = new Hook();
+                $hook->name = 'beforeRenderingEverblockLookbook';
+                $hook->title = 'Before rendering lookbook block';
+                $hook->description = 'This hook triggers before lookbook block is rendered';
+                $hook->save();
+            }
             $this->registerHook('beforeRenderingEverblockProductHighlight');
             $this->registerHook('beforeRenderingEverblockCategoryTabs');
             $this->registerHook('beforeRenderingEverblockCategoryPrice');
+            $this->registerHook('beforeRenderingEverblockLookbook');
             $this->registerHook('beforeRenderingEverblockEverblock');
         } else {
             $this->unregisterHook('beforeRenderingEverblockProductHighlight');
             $this->unregisterHook('beforeRenderingEverblockCategoryTabs');
             $this->unregisterHook('beforeRenderingEverblockCategoryPrice');
+            $this->unregisterHook('beforeRenderingEverblockLookbook');
             $this->unregisterHook('beforeRenderingEverblockEverblock');
         }
         // Vérifier si l'onglet "AdminEverBlockParent" existe déjà
@@ -3890,6 +3899,29 @@ class Everblock extends Module
                 ], $this->context);
                 if (!empty($presented)) {
                     $products[$key] = reset($presented);
+                }
+            }
+        }
+
+        return ['products' => $products];
+    }
+
+    public function hookBeforeRenderingEverblockLookbook($params)
+    {
+        $products = [];
+        if (!empty($params['block']['states']) && is_array($params['block']['states'])) {
+            foreach ($params['block']['states'] as $key => $state) {
+                if (empty($state['product_ids'])) {
+                    continue;
+                }
+                $ids = array_filter(array_map('intval', explode(',', $state['product_ids'])));
+                $ids = array_slice($ids, 0, 8);
+                if (!$ids) {
+                    continue;
+                }
+                $presented = EverblockTools::everPresentProducts($ids, $this->context);
+                if (!empty($presented)) {
+                    $products[$key] = $presented;
                 }
             }
         }

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -80,6 +80,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $tocTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_toc.tpl';
             $imageMapTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_image_map.tpl';
             $everblockTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_everblock.tpl';
+            $lookbookTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -3682,6 +3683,97 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Choose a product'),
                             'collection' => 'Product',
                             'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Lookbook'),
+                'description' => $module->l('Display looks with associated products'),
+                'code' => 'everblock_lookbook',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $lookbookTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Look',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Look title'),
+                            'default' => '',
+                        ],
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Look image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'product_ids' => [
+                            'type' => 'text',
+                            'label' => $module->l('Associated product IDs (comma-separated)'),
+                            'default' => '',
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block background color'),
+                        ],
+                        'text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block text color'),
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
                     ],

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -1,0 +1,45 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+
+  {if isset($block.states) && $block.states}
+    <div class="{if $block.settings.default.container}container{/if}">
+      {foreach from=$block.states item=state key=key}
+        <div class="mb-4 {if $state.css_class}{$state.css_class}{/if}"
+             style="{if $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
+          <div class="lookbook-image mb-3">
+            <img src="{$state.image.url}" alt="{$state.title|escape:'htmlall':'UTF-8'}" class="img-fluid w-100" loading="lazy">
+          </div>
+          {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
+            {assign var='useCarousel' value=count($block.extra.products[$key]) > 4}
+            {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=$useCarousel shortcodeClass='lookbook-products'}
+          {/if}
+        </div>
+      {/foreach}
+    </div>
+  {/if}
+
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- precompute lookbook product lists via hookBeforeRenderingEverblockLookbook
- use hook-provided products in lookbook template and enable carousel when more than four items
- register beforeRenderingEverblockLookbook hook in checkHooks

## Testing
- `php -l everblock.php`
- `phpstan analyse` *(fails: command not found)*
- `php-cs-fixer fix --dry-run --diff` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b411e029c88322a35ab43372aa5399