### PR TITLE
Add flash deals prettyblock with countdown

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -189,6 +189,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_cta.tpl',
     'views/templates/hook/prettyblocks/prettyblock_divider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_everblock.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gallery.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gmap.tpl',
     'views/templates/hook/prettyblocks/prettyblock_heading.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -72,6 +72,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $brandListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_brands.tpl';
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
+            $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
@@ -3676,6 +3677,79 @@ class EverblockPrettyBlocks extends ObjectModel
                 ],
                 'repeater' => [
                     'name' => 'Product',
+                    'nameFrom' => 'product',
+                    'groups' => [
+                        'product' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Choose a product'),
+                            'collection' => 'Product',
+                            'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Flash deals'),
+                'description' => $module->l('Display temporary deals with a countdown timer'),
+                'code' => 'everblock_flash_deals',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $flashDealsTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'slider' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable slider'),
+                            'default' => 0,
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Deal',
                     'nameFrom' => 'product',
                     'groups' => [
                         'product' => [

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -254,6 +254,44 @@ $(document).ready(function(){
         });
     });
 
+    // Flash deals countdown
+    document.querySelectorAll('.flash-deals-wrapper').forEach(function(wrapper) {
+        var dealsData = wrapper.dataset.deals;
+        if (!dealsData) {
+            return;
+        }
+        try {
+            var deals = JSON.parse(dealsData);
+        } catch (e) {
+            return;
+        }
+        deals.forEach(function(deal) {
+            var productEl = wrapper.querySelector('[data-id-product="' + deal.id_product + '"]');
+            if (!productEl) {
+                return;
+            }
+            productEl.style.position = 'relative';
+            var timer = document.createElement('div');
+            timer.className = 'flash-deal-countdown badge bg-danger position-absolute';
+            timer.style.top = '0.5rem';
+            timer.style.left = '0.5rem';
+            productEl.appendChild(timer);
+            function updateTimer() {
+                var distance = new Date(deal.end_date).getTime() - new Date().getTime();
+                if (distance <= 0) {
+                    timer.textContent = '';
+                    return;
+                }
+                var hours = Math.floor(distance / (1000 * 60 * 60));
+                var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+                var seconds = Math.floor((distance % (1000 * 60)) / 1000);
+                timer.textContent = hours + 'h ' + minutes + 'm ' + seconds + 's';
+            }
+            updateTimer();
+            setInterval(updateTimer, 1000);
+        });
+    });
+
     // Play video on scroll
     const everVideos = document.querySelectorAll('.everblock-scroll-video');
     if (everVideos.length) {

--- a/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl
@@ -1,0 +1,34 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{if isset($block.extra.deals) && $block.extra.deals}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+    <div class="mt-2{if $block.settings.default.container} container{/if}" style="{if isset($block.settings.padding_left) && $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_right) && $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_top) && $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_bottom) && $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_left) && $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_right) && $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_top) && $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_bottom) && $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+                <div class="flash-deals-wrapper" data-deals="{$block.extra.deals|json_encode|escape:'htmlall':'UTF-8'}">
+          {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.deals carousel=$block.settings.slider shortcodeClass='flash-deals'}
+        </div>
+    </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- load flash deal countdown logic from Everblock.js instead of inline template script
- derive flash deal end dates from database discounts and skip manual date field
- expose deal data to JS via data attribute in flash deals template
- filter flash deal discounts by current customer and group and hide block when none apply

## Testing
- `php -l everblock.php`
- `vendor/bin/phpstan analyse everblock.php models/EverblockPrettyBlocks.php --no-progress` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b55e5ebd8883229b7630917062739f