### PR TITLE
Normalise cover overlay position classes

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -59,7 +59,7 @@
           {/if}
 
         {if $state.name}
-          <div class="prettyblock-cover-overlay category_state_name position-desktop-{$state.title_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.title_position_mobile|default:'center'|escape:'htmlall'}">
+          <div class="prettyblock-cover-overlay category_state_name position-desktop-{$state.title_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.title_position_mobile|default:'center'|lower|escape:'htmlall'}">
             <h2 class="m-0 text-white">{$state.name nofilter}</h2>
           </div>
         {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -40,7 +40,7 @@
                      class="prettyblock-cover-image">
               </picture>
             {/if}
-          <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|escape:'htmlall'}">
+          <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
             {if $state.title}
               <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
             {/if}
@@ -78,7 +78,7 @@
                  class="prettyblock-cover-image">
           </picture>
         {/if}
-        <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|escape:'htmlall'}">
+        <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
           {if $state.title}
             <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}


### PR DESCRIPTION
## Summary
- enforce lowercase desktop and mobile position classes in cover block templates

## Testing
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68b7f110cb988322b69591f70ca6c9eb