### PR TITLE
Add PrettyBlock to present category products

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -190,6 +190,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_divider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_everblock.tpl',
     'views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_category_products.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gallery.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gmap.tpl',
     'views/templates/hook/prettyblocks/prettyblock_heading.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -73,6 +73,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
             $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
+            $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
@@ -3768,6 +3769,104 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Choose a product'),
                             'collection' => 'Product',
                             'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Category products'),
+                'description' => $module->l('Display products from selected categories'),
+                'code' => 'everblock_category_products',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $categoryProductsTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Category',
+                    'nameFrom' => 'category',
+                    'groups' => [
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Upload image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'category' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Choose a category'),
+                            'collection' => 'Category',
+                            'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                        'product_limit' => [
+                            'type' => 'text',
+                            'label' => $module->l('Number of products to display'),
+                            'default' => '4',
+                        ],
+                        'slider' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable slider'),
+                            'default' => 0,
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block background color'),
+                        ],
+                        'text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block text color'),
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
                     ],

--- a/views/templates/hook/prettyblocks/prettyblock_category_products.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_products.tpl
@@ -1,0 +1,44 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{if isset($block.states) && $block.states}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+    <div class="{if $block.settings.default.container}container{/if}">
+      {foreach from=$block.states item=state key=key}
+        <div id="block-{$block.id_prettyblocks}-{$key}" class="{if isset($state.css_class) && $state.css_class}{$state.css_class|escape:'htmlall':'UTF-8'}{/if}"
+             style="{if $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
+          {if isset($state.image.url) && $state.image.url}
+            <div class="mb-3">
+              <img src="{$state.image.url}" alt="" class="img-fluid w-100" loading="lazy">
+            </div>
+          {/if}
+          {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
+            {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=$state.slider shortcodeClass='category-products'}
+          {/if}
+        </div>
+      {/foreach}
+    </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- add PrettyBlock to show products from selected categories with optional carousel and image
- expose new `beforeRenderingEverblockCategoryProducts` hook and integrate it in hook checks
- allow prettyblock category template

## Testing
- `php -l everblock.php`
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68b80846cec88322a1fc4f1f1e33e2e8