### PR TITLE
Fix ampersand rendering and price alignment in category list

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -28,13 +28,13 @@
         <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
           <a href="{$data.category_link|default:'#'}" class="d-block text-decoration-none" title="{$data.title|escape:'htmlall'}">
             {if $data.image_url}
-              <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|escape:'htmlall'}" width="{$data.image_width}" height="{$data.image_height}" class="img-fluid mb-2" loading="lazy">
+              <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|unescape:'html'|escape:'html':'UTF-8'}" width="{$data.image_width}" height="{$data.image_height}" class="img-fluid mb-2" loading="lazy">
             {/if}
             {if $data.title}
-              <p class="h6">{$data.title|escape:'htmlall'}</p>
+              <p class="h6">{$data.title|unescape:'html'|escape:'html':'UTF-8'}</p>
             {/if}
             {if $data.min_price !== false}
-              <span class="small">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
+              <span class="small d-block">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
             {/if}
           </a>
         </div>


### PR DESCRIPTION
## Summary
- properly decode and escape category titles to avoid double-encoded ampersands
- ensure category prices render on a new line for consistent alignment

## Testing
- `./vendor/bin/php-cs-fixer fix views/templates/hook/prettyblocks/prettyblock_category_price.tpl` *(fails: No such file or directory)*
- `composer global require friendsofphp/php-cs-fixer:^3 --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpstan analyse` *(fails: No such file or directory)*
- `composer global require phpstan/phpstan --no-interaction` *(fails: No composer.json present / CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9494c959083229032a7e839a93019