### PR TITLE
feat: add mobile slider for category price

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -16,32 +16,58 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
-  {if $block.settings.default.force_full_width}
-    <div class="row row-cols-1 row-cols-md-5 gx-0 no-gutters">
-  {elseif $block.settings.default.container}
-    <div class="row">
-  {/if}
   {if isset($block.states) && $block.states}
-    {foreach from=$block.states item=state key=key}
-      {assign var=data value=$block.extra.state_data[$key]|default:null}
-      {if $data}
-        <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
-          <a href="{$data.category_link|default:'#'}" class="d-flex flex-column align-items-center text-decoration-none h-100" title="{$data.title|escape:'htmlall'}">
-            {if $data.image_url}
-              <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|unescape:'html'|escape:'html':'UTF-8'}" width="{$data.image_width}" height="{$data.image_height}" class="img-fluid mb-2 mx-auto" loading="lazy">
-            {/if}
-            {if $data.title}
-              <p class="h6 mb-2 text-center">{$data.title|unescape:'html'|escape:'html':'UTF-8'}</p>
-            {/if}
-            {if $data.min_price !== false}
-              <span class="small d-block mt-auto text-center">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
-            {/if}
-          </a>
+    <div class="d-none d-md-block">
+      {if $block.settings.default.force_full_width}
+        <div class="row row-cols-1 row-cols-md-5 gx-0 no-gutters">
+      {elseif $block.settings.default.container}
+        <div class="row">
+      {/if}
+        {foreach from=$block.states item=state key=key}
+          {assign var=data value=$block.extra.state_data[$key]|default:null}
+          {if $data}
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="col text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
+              <a href="{$data.category_link|default:'#'}" class="d-flex flex-column align-items-center text-decoration-none h-100" title="{$data.title|escape:'htmlall'}">
+                {if $data.image_url}
+                  <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|unescape:'html'|escape:'html':'UTF-8'}" width="{$data.image_width}" height="{$data.image_height}" class="img-fluid mb-2 mx-auto" loading="lazy">
+                {/if}
+                {if $data.title}
+                  <p class="h6 mb-2 text-center">{$data.title|unescape:'html'|escape:'html':'UTF-8'}</p>
+                {/if}
+                {if $data.min_price !== false}
+                  <span class="small d-block mt-auto text-center">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
+                {/if}
+              </a>
+            </div>
+          {/if}
+        {/foreach}
+      {if $block.settings.default.force_full_width || $block.settings.default.container}
         </div>
       {/if}
-    {/foreach}
-  {/if}
-  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+    <div class="d-block d-md-none">
+      <div class="overflow-auto" style="scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch;">
+        <div class="d-flex flex-nowrap">
+          {foreach from=$block.states item=state key=key}
+            {assign var=data value=$block.extra.state_data[$key]|default:null}
+            {if $data}
+              <div id="block-{$block.id_prettyblocks}-{$key}-mobile" class="text-center me-3{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="flex:0 0 85%; scroll-snap-align:start;{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
+                <a href="{$data.category_link|default:'#'}" class="d-flex flex-column align-items-center text-decoration-none h-100" title="{$data.title|escape:'htmlall'}">
+                  {if $data.image_url}
+                    <img src="{$data.image_url|escape:'htmlall'}" alt="{$data.title|unescape:'html'|escape:'html':'UTF-8'}" width="{$data.image_width}" height="{$data.image_height}" class="img-fluid mb-2 mx-auto" loading="lazy">
+                  {/if}
+                  {if $data.title}
+                    <p class="h6 mb-2 text-center">{$data.title|unescape:'html'|escape:'html':'UTF-8'}</p>
+                  {/if}
+                  {if $data.min_price !== false}
+                    <span class="small d-block mt-auto text-center">{l s='From' mod='everblock'} {Tools::displayPrice($data.min_price)}</span>
+                  {/if}
+                </a>
+              </div>
+            {/if}
+          {/foreach}
+        </div>
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- add mobile-only slider to Prettyblock Category Price list

## Testing
- `vendor/bin/phpstan analyse --no-progress` *(fails: No such file or directory)*
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_68b9ad566a5083228a671db23e95a53e