### PR TITLE
Add animated counters prettyblock

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -185,6 +185,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_category_price.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl',
     'views/templates/hook/prettyblocks/prettyblock_contact.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_counters.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cover.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cta.tpl',
     'views/templates/hook/prettyblocks/prettyblock_divider.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -74,6 +74,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
             $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
             $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
+            $countersTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_counters.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
@@ -3959,6 +3960,43 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'text',
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Counters'),
+                'description' => $module->l('Display animated counters'),
+                'code' => 'everblock_counters',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $countersTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Counter',
+                    'nameFrom' => 'label',
+                    'groups' => [
+                        'icon' => [
+                            'type' => 'text',
+                            'label' => $module->l('Icon class'),
+                            'default' => '',
+                        ],
+                        'value' => [
+                            'type' => 'text',
+                            'label' => $module->l('Counter value'),
+                            'default' => '100',
+                        ],
+                        'label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Counter label'),
+                            'default' => $module->l('Projects'),
+                        ],
+                        'animation_speed' => [
+                            'type' => 'text',
+                            'label' => $module->l('Animation speed (ms)'),
+                            'default' => '2000',
                         ],
                     ],
                 ],

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -656,3 +656,9 @@ $_MODULE['<{everblock}prestashop>storelocator_1d66769fe7f641de0c633976e5f46cb5']
 $_MODULE['<{everblock}prestashop>storelocator_13348442cc6a27032d2b4aa28b75a5d3'] = 'Rechercher';
 $_MODULE['<{everblock}prestashop>storelocator_46f3ea056caa3126b91f3f70beea068c'] = 'Carte';
 $_MODULE['<{everblock}prestashop>storelocator_821b8ee6937cec96c30fdafbfe836d68'] = 'Magasins';
+$_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Compteurs';
+$_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Afficher des compteurs animés';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Classe d\'icône';
+$_MODULE['<{everblock}prestashop>everblock_2c4d66afba61b600b2932ccd3de0c7e1'] = 'Valeur du compteur';
+$_MODULE['<{everblock}prestashop>everblock_7f576abcf2e228af10d567bb0d2df452'] = 'Libellé du compteur';
+$_MODULE['<{everblock}prestashop>everblock_dee7cae0a61d46454861d5fc218842ba'] = 'Vitesse d\'animation (ms)';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -18,3 +18,9 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Number of brands per slide';
+$_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Counters';
+$_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Display animated counters';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Icon class';
+$_MODULE['<{everblock}prestashop>everblock_2c4d66afba61b600b2932ccd3de0c7e1'] = 'Counter value';
+$_MODULE['<{everblock}prestashop>everblock_7f576abcf2e228af10d567bb0d2df452'] = 'Counter label';
+$_MODULE['<{everblock}prestashop>everblock_dee7cae0a61d46454861d5fc218842ba'] = 'Animation speed (ms)';

--- a/translations/it.php
+++ b/translations/it.php
@@ -18,3 +18,9 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Numero di marchi per diapositiva';
+$_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Contatori';
+$_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Mostra contatori animati';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Classe dell\'icona';
+$_MODULE['<{everblock}prestashop>everblock_2c4d66afba61b600b2932ccd3de0c7e1'] = 'Valore del contatore';
+$_MODULE['<{everblock}prestashop>everblock_7f576abcf2e228af10d567bb0d2df452'] = 'Etichetta del contatore';
+$_MODULE['<{everblock}prestashop>everblock_dee7cae0a61d46454861d5fc218842ba'] = 'Velocità dell\'animazione (ms)';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -18,3 +18,9 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Aantal merken per dia';
+$_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Tellers';
+$_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Toon geanimeerde tellers';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Icoonklasse';
+$_MODULE['<{everblock}prestashop>everblock_2c4d66afba61b600b2932ccd3de0c7e1'] = 'Tellerwaarde';
+$_MODULE['<{everblock}prestashop>everblock_7f576abcf2e228af10d567bb0d2df452'] = 'Tellerlabel';
+$_MODULE['<{everblock}prestashop>everblock_dee7cae0a61d46454861d5fc218842ba'] = 'Animatiesnelheid (ms)';

--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -95,3 +95,21 @@
     content: '\25BC';
 }
 
+/* Counter styles */
+.ever-counters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+.ever-counter i {
+    display: block;
+    font-size: 2rem;
+    margin-bottom: .5rem;
+}
+.ever-counter-value {
+    display: block;
+    font-size: 2rem;
+    font-weight: bold;
+}
+

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -316,4 +316,21 @@ $(document).ready(function(){
         });
     }
 
+    // Counter animation
+    $('.ever-counter-value').each(function() {
+        var $this = $(this);
+        var target = parseInt($this.data('value'));
+        var speed = parseInt($this.data('speed')) || 2000;
+        $({countNum: 0}).animate({countNum: target}, {
+            duration: speed,
+            easing: 'swing',
+            step: function() {
+                $this.text(Math.floor(this.countNum));
+            },
+            complete: function() {
+                $this.text(this.countNum);
+            }
+        });
+    });
+
 });

--- a/views/templates/hook/prettyblocks/prettyblock_counters.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_counters.tpl
@@ -1,0 +1,46 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+<div class="{if $block.settings.default.container}container{/if}"  style="{if isset($block.settings.padding_left) && $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_right) && $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_top) && $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_bottom) && $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_left) && $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_right) && $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_top) && $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_bottom) && $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    {if $block.settings.default.container}
+        <div class="row ever-counters">
+    {else}
+        <div class="ever-counters">
+    {/if}
+    {foreach from=$block.states item=state}
+        <div class="col ever-counter text-center">
+            {if $state.icon}<i class="{$state.icon|escape:'htmlall':'UTF-8'}"></i>{/if}
+            <span class="ever-counter-value" data-value="{$state.value|escape:'htmlall':'UTF-8'}" data-speed="{$state.animation_speed|escape:'htmlall':'UTF-8'}">0</span>
+            {if $state.label}<span class="ever-counter-label">{$state.label|escape:'htmlall':'UTF-8'}</span>{/if}
+        </div>
+    {/foreach}
+        </div>
+    {if $block.settings.default.container}
+        </div>
+    {/if}
+</div>
+
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add `everblock_counters` block with animated counting
- style and script counter display
- add template path and translations

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `php -l translations/fr.php`
- `php -l translations/gb.php`
- `php -l translations/it.php`
- `php -l translations/nl.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9c95e924c832299b8d78f18f3c2fa