### PR TITLE
Add steps prettyblock with layout options

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -214,6 +214,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_shortcode.tpl',
     'views/templates/hook/prettyblocks/prettyblock_social_links.tpl',
     'views/templates/hook/prettyblocks/prettyblock_spacer.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_steps.tpl',
     'views/templates/hook/prettyblocks/prettyblock_tab.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -75,6 +75,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
             $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
+            $stepsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_steps.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
             $headingTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heading.tpl';
@@ -3823,6 +3824,101 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'color',
                             'default' => '',
                             'label' => $module->l('Block text color'),
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                    'margin_bottom' => [
+                        'type' => 'text',
+                        'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                        'default' => '',
+                    ],
+                ],
+            ],
+        ];
+            $blocks[] = [
+                'name' => $module->l('Steps'),
+                'description' => $module->l('Display steps with icons'),
+                'code' => 'everblock_steps',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $stepsTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'orientation' => [
+                            'type' => 'select',
+                            'label' => $module->l('Orientation'),
+                            'default' => 'row',
+                            'choices' => [
+                                'row' => $module->l('Row'),
+                                'column' => $module->l('Column'),
+                            ],
+                        ],
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Step',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'step_number' => [
+                            'type' => 'text',
+                            'label' => $module->l('Step number'),
+                            'default' => '1',
+                        ],
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Step title'),
+                            'default' => $module->l('Step title'),
+                        ],
+                        'description' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Step description'),
+                            'default' => $module->l('Step description'),
+                        ],
+                        'icon' => [
+                            'type' => 'text',
+                            'label' => $module->l('Icon class'),
+                            'default' => 'fa fa-check',
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -656,3 +656,12 @@ $_MODULE['<{everblock}prestashop>storelocator_1d66769fe7f641de0c633976e5f46cb5']
 $_MODULE['<{everblock}prestashop>storelocator_13348442cc6a27032d2b4aa28b75a5d3'] = 'Rechercher';
 $_MODULE['<{everblock}prestashop>storelocator_46f3ea056caa3126b91f3f70beea068c'] = 'Carte';
 $_MODULE['<{everblock}prestashop>storelocator_821b8ee6937cec96c30fdafbfe836d68'] = 'Magasins';
+$_MODULE['<{everblock}prestashop>everblock_f3a29486bed19a90f2da6d007818b427'] = 'Étapes';
+$_MODULE['<{everblock}prestashop>everblock_f915978312774e1377b9a1eb3502adb8'] = 'Afficher les étapes avec icônes';
+$_MODULE['<{everblock}prestashop>everblock_0cd5cd06174b8a0859328110d25a2367'] = 'Numéro de l\'étape';
+$_MODULE['<{everblock}prestashop>everblock_6012d4e2f8ebde4b5a1c7f088e21d351'] = 'Titre de l\'étape';
+$_MODULE['<{everblock}prestashop>everblock_2a05a1cb0f6f03113cf6e2f0f7dc7eb0'] = 'Description de l\'étape';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Classe de l\'icône';
+$_MODULE['<{everblock}prestashop>everblock_abbd64f40c34c537d3a571af068fce29'] = 'Orientation';
+$_MODULE['<{everblock}prestashop>everblock_a70367aa7cb74e510f4f9413ccf059d3'] = 'Ligne';
+$_MODULE['<{everblock}prestashop>everblock_1976d7f704de389d9fe064e08ea35b2d'] = 'Colonne';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -18,3 +18,12 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Number of brands per slide';
+$_MODULE['<{everblock}prestashop>everblock_f3a29486bed19a90f2da6d007818b427'] = 'Steps';
+$_MODULE['<{everblock}prestashop>everblock_f915978312774e1377b9a1eb3502adb8'] = 'Display steps with icons';
+$_MODULE['<{everblock}prestashop>everblock_0cd5cd06174b8a0859328110d25a2367'] = 'Step number';
+$_MODULE['<{everblock}prestashop>everblock_6012d4e2f8ebde4b5a1c7f088e21d351'] = 'Step title';
+$_MODULE['<{everblock}prestashop>everblock_2a05a1cb0f6f03113cf6e2f0f7dc7eb0'] = 'Step description';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Icon class';
+$_MODULE['<{everblock}prestashop>everblock_abbd64f40c34c537d3a571af068fce29'] = 'Orientation';
+$_MODULE['<{everblock}prestashop>everblock_a70367aa7cb74e510f4f9413ccf059d3'] = 'Row';
+$_MODULE['<{everblock}prestashop>everblock_1976d7f704de389d9fe064e08ea35b2d'] = 'Column';

--- a/translations/it.php
+++ b/translations/it.php
@@ -18,3 +18,12 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Numero di marchi per diapositiva';
+$_MODULE['<{everblock}prestashop>everblock_f3a29486bed19a90f2da6d007818b427'] = 'Passaggi';
+$_MODULE['<{everblock}prestashop>everblock_f915978312774e1377b9a1eb3502adb8'] = 'Mostra passaggi con icone';
+$_MODULE['<{everblock}prestashop>everblock_0cd5cd06174b8a0859328110d25a2367'] = 'Numero del passaggio';
+$_MODULE['<{everblock}prestashop>everblock_6012d4e2f8ebde4b5a1c7f088e21d351'] = 'Titolo del passaggio';
+$_MODULE['<{everblock}prestashop>everblock_2a05a1cb0f6f03113cf6e2f0f7dc7eb0'] = 'Descrizione del passaggio';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Classe dell\'icona';
+$_MODULE['<{everblock}prestashop>everblock_abbd64f40c34c537d3a571af068fce29'] = 'Orientamento';
+$_MODULE['<{everblock}prestashop>everblock_a70367aa7cb74e510f4f9413ccf059d3'] = 'Riga';
+$_MODULE['<{everblock}prestashop>everblock_1976d7f704de389d9fe064e08ea35b2d'] = 'Colonna';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -18,3 +18,12 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Aantal merken per dia';
+$_MODULE['<{everblock}prestashop>everblock_f3a29486bed19a90f2da6d007818b427'] = 'Stappen';
+$_MODULE['<{everblock}prestashop>everblock_f915978312774e1377b9a1eb3502adb8'] = 'Toon stappen met pictogrammen';
+$_MODULE['<{everblock}prestashop>everblock_0cd5cd06174b8a0859328110d25a2367'] = 'Stapnummer';
+$_MODULE['<{everblock}prestashop>everblock_6012d4e2f8ebde4b5a1c7f088e21d351'] = 'Stap titel';
+$_MODULE['<{everblock}prestashop>everblock_2a05a1cb0f6f03113cf6e2f0f7dc7eb0'] = 'Stap beschrijving';
+$_MODULE['<{everblock}prestashop>everblock_de0ad6b7a678e57fabc12bce050c79dc'] = 'Icoonklasse';
+$_MODULE['<{everblock}prestashop>everblock_abbd64f40c34c537d3a571af068fce29'] = 'Oriëntatie';
+$_MODULE['<{everblock}prestashop>everblock_a70367aa7cb74e510f4f9413ccf059d3'] = 'Rij';
+$_MODULE['<{everblock}prestashop>everblock_1976d7f704de389d9fe064e08ea35b2d'] = 'Kolom';

--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -95,3 +95,21 @@
     content: '\25BC';
 }
 
+/* Steps block styles */
+.everblock-steps {
+    display: flex;
+    gap: 1rem;
+}
+.everblock-steps.column {
+    flex-direction: column;
+}
+.everblock-steps.row {
+    flex-direction: row;
+}
+.everblock-step {
+    text-align: center;
+}
+.everblock-step-icon {
+    font-size: 2rem;
+}
+

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -316,4 +316,12 @@ $(document).ready(function(){
         });
     }
 
+    $('.everblock-steps').each(function() {
+        var \$container = $(this);
+        \$container.find('.everblock-step').on('click', function() {
+            \$container.find('.everblock-step').removeClass('active');
+            $(this).addClass('active');
+        });
+    });
+
 });

--- a/views/templates/hook/prettyblocks/prettyblock_steps.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_steps.tpl
@@ -1,0 +1,47 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+<div class="{if $block.settings.default.container}container{/if}"  style="{if isset($block.settings.padding_left) && $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_right) && $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_top) && $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_bottom) && $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_left) && $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_right) && $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_top) && $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_bottom) && $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    {if $block.settings.default.container}
+        <div class="row">
+    {/if}
+    <div class="everblock-steps {$block.settings.orientation|escape:'htmlall':'UTF-8'}">
+        {foreach from=$block.states item=state key=key}
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="everblock-step {if isset($state.css_class) && $state.css_class}{$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}">
+                {if $state.icon}<div class="everblock-step-icon"><i class="{$state.icon|escape:'htmlall':'UTF-8'}"></i></div>{/if}
+                {if $state.step_number}<div class="everblock-step-number">{$state.step_number|escape:'htmlall':'UTF-8'}</div>{/if}
+                {if $state.title}<div class="everblock-step-title">{$state.title|escape:'htmlall':'UTF-8'}</div>{/if}
+                {if $state.description}<div class="everblock-step-description">{$state.description nofilter}</div>{/if}
+            </div>
+        {/foreach}
+    </div>
+    {if $block.settings.default.container}
+        </div>
+    {/if}
+</div>
+
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+


### PR DESCRIPTION
## Summary
- add `everblock_steps` prettyblock with repeater and orientation option
- render steps via new Smarty template
- style steps layout and add interactive JS
- include new template in allowed files and translations

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `php -l translations/gb.php`
- `php -l translations/fr.php`
- `php -l translations/it.php`
- `php -l translations/nl.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9daff3c8322a05aaf6610c5c7d7