### PR TITLE
fix: prevent store locator overlay on footer

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3376,7 +3376,6 @@ class EverblockTools extends ObjectModel
                     });
 
                     document.getElementById("everblock-storelocator").style.height = "500px";
-                    document.getElementById("everblock-storelocator").style.position = "absolute";
                 }
 
                 function initAutocomplete() {


### PR DESCRIPTION
## Summary
- remove absolute positioning from map container

## Testing
- `php -l models/EverblockTools.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68ba9017015c8322ab699f78744af308