### PR TITLE
feat: add text position option to text and image block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1981,6 +1981,26 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Open in new tab (only if not obfuscated)'),
                             'default' => '0',
                         ],
+                        'text_position_desktop' => [
+                            'type' => 'select',
+                            'label' => $module->l('Text position (desktop)'),
+                            'choices' => [
+                                'start' => $module->l('Top'),
+                                'center' => $module->l('Center'),
+                                'end' => $module->l('Bottom'),
+                            ],
+                            'default' => 'center',
+                        ],
+                        'text_position_mobile' => [
+                            'type' => 'select',
+                            'label' => $module->l('Text position (mobile)'),
+                            'choices' => [
+                                'start' => $module->l('Top'),
+                                'center' => $module->l('Center'),
+                                'end' => $module->l('Bottom'),
+                            ],
+                            'default' => 'center',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -34,7 +34,7 @@
             {/if}
             
             {* Row responsive, image à gauche ou à droite selon ordre *}
-            <div class="row align-items-center {if $state.order == 'First text, then image'}flex-md-row-reverse{/if}">
+            <div class="row align-items-{$state.text_position_mobile|default:'center'} align-items-md-{$state.text_position_desktop|default:'center'} {if $state.order == 'First text, then image'}flex-md-row-reverse{/if}">
                 
                 {* IMAGE *}
                 <div class="col-md-6 mb-3 mb-md-0 text-center">


### PR DESCRIPTION
## Summary
- allow configuring vertical text alignment in Prettyblock Text and Image
- apply responsive Bootstrap alignment classes in template

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba98f93594832297b1122ea006ccfa