### PR TITLE
feat(text_and_image): align text only

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -34,7 +34,7 @@
             {/if}
             
             {* Row responsive, image à gauche ou à droite selon ordre *}
-            <div class="row align-items-{$state.text_position_mobile|default:'center'} align-items-md-{$state.text_position_desktop|default:'center'} {if $state.order == 'First text, then image'}flex-md-row-reverse{/if}">
+            <div class="row {if $state.order == 'First text, then image'}flex-md-row-reverse{/if}">
                 
                 {* IMAGE *}
                 <div class="col-md-6 mb-3 mb-md-0 text-center">
@@ -84,7 +84,7 @@
                 </div>
 
                 {* CONTENU *}
-                <div class="col-md-6">
+                <div class="col-md-6 d-flex align-items-{$state.text_position_mobile|default:'center'|lower|escape:'htmlall'} align-items-md-{$state.text_position_desktop|default:'center'|lower|escape:'htmlall'}">
                     <div class="state-content px-3">
                         {$state.content nofilter}
                     </div>


### PR DESCRIPTION
## Summary
- apply mobile/desktop text alignment classes on content only
- lowercase position values in smarty template

## Testing
- `php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff` *(fails: Could not open input file)*
- `composer global require friendsofphp/php-cs-fixer` *(fails: CONNECT tunnel failed: 403)*
- `php ./vendor/bin/phpstan analyse` *(fails: Could not open input file)*
- `composer global require phpstan/phpstan` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e26803483229acdcf6d5f377fdf