### PR TITLE
feat: show 3.5 items in mobile brand slider

### DIFF
--- a/views/templates/hook/ever_brand.tpl
+++ b/views/templates/hook/ever_brand.tpl
@@ -56,9 +56,7 @@
         </button>
       </div>
     </section>
-    {assign var="mobileBrandsPerSlide" value=$numBrandsPerSlide}
-    {if $mobileBrandsPerSlide < 2}{assign var="mobileBrandsPerSlide" value=2}{/if}
-    {if $mobileBrandsPerSlide > 3}{assign var="mobileBrandsPerSlide" value=3}{/if}
+    {assign var="mobileBrandsPerSlide" value=3.5}
     <section class="featured-brands mt-3 d-block d-md-none">
       <div id="everBrandsCarouselMobile" class="overflow-auto" style="scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch;">
         <div class="d-flex flex-nowrap">


### PR DESCRIPTION
## Summary
- show 3.5 items in Prettyblock brand slider on mobile

## Testing
- `composer validate --no-interaction`
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_68babf86fd2083228dcc8a0a4485ee57