### PR TITLE
Add custom class support to Prettyblock spacer

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -360,6 +360,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Space bottom (rem)'),
                             'default' => '0',
                         ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
                     ],
                 ],
             ];

--- a/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
@@ -22,7 +22,7 @@
     <div class="row">
   {/if}
 
-<div id="block-{$block.id_prettyblocks}" class="everblock-spacer" style="{if isset($block.settings.space_top) && $block.settings.space_top}margin-top:{$block.settings.space_top|escape:'htmlall':'UTF-8'}rem;{/if}{if isset($block.settings.space_bottom) && $block.settings.space_bottom}margin-bottom:{$block.settings.space_bottom|escape:'htmlall':'UTF-8'}rem;{/if}height:0;"></div>
+<div id="block-{$block.id_prettyblocks}" class="everblock-spacer {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{if isset($block.settings.space_top) && $block.settings.space_top}margin-top:{$block.settings.space_top|escape:'htmlall':'UTF-8'}rem;{/if}{if isset($block.settings.space_bottom) && $block.settings.space_bottom}margin-bottom:{$block.settings.space_bottom|escape:'htmlall':'UTF-8'}rem;{/if}height:0;"></div>
 
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>


### PR DESCRIPTION
## Summary
- allow specifying custom CSS class for the Prettyblock spacer
- render spacer template with user-defined class

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bac6f330688322b24b07bc0d10455e