### PR TITLE
Improve Lookbook block with CTA overlay

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -27,12 +27,24 @@
       {foreach from=$block.states item=state key=key}
         <div class="mb-4 {if $state.css_class}{$state.css_class}{/if}"
              style="{if $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
-          <div class="lookbook-image mb-3">
+          <div class="lookbook-image position-relative mb-3">
             <img src="{$state.image.url}" alt="{$state.title|escape:'htmlall':'UTF-8'}" class="img-fluid w-100" loading="lazy">
+            {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
+              <a class="btn btn-primary position-absolute top-50 start-50 translate-middle"
+                 data-bs-toggle="collapse"
+                 href="#lookbook-products-{$block.id_prettyblocks}-{$key}"
+                 role="button"
+                 aria-expanded="false"
+                 aria-controls="lookbook-products-{$block.id_prettyblocks}-{$key}">
+                {l s='Shop the look' mod='everblock'}
+              </a>
+            {/if}
           </div>
           {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-            {assign var='useCarousel' value=count($block.extra.products[$key]) > 4}
-            {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=$useCarousel shortcodeClass='lookbook-products'}
+            <div class="collapse" id="lookbook-products-{$block.id_prettyblocks}-{$key}">
+              {assign var='useCarousel' value=count($block.extra.products[$key]) > 4}
+              {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=$useCarousel shortcodeClass='lookbook-products'}
+            </div>
           {/if}
         </div>
       {/foreach}


### PR DESCRIPTION
## Summary
- add "Shop the look" call-to-action overlay to Lookbook images
- reveal products with collapsible section for clearer shopping path

## Testing
- `php ./vendor/bin/php-cs-fixer fix --diff --dry-run` *(fails: Could not open input file)*
- `curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/latest/download/php-cs-fixer.phar -o /tmp/php-cs-fixer.phar && php /tmp/php-cs-fixer.phar --version` *(fails: CONNECT tunnel failed, response 403)*
- `curl -L https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar -o /tmp/phpstan.phar && php /tmp/phpstan.phar --version` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68baced337a88322a80fcb85cf3fbcd2