### PR TITLE
Add subcategory option to PrettyBlocks category products block

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -4022,7 +4022,14 @@ class Everblock extends Module
                     continue;
                 }
                 $limit = !empty($state['product_limit']) ? (int) $state['product_limit'] : 4;
-                $categoryProducts = EverblockTools::getProductsByCategoryId($idCategory, $limit);
+                $includeSub = !empty($state['include_subcategories']);
+                $categoryProducts = EverblockTools::getProductsByCategoryId(
+                    $idCategory,
+                    $limit,
+                    'id_product',
+                    'ASC',
+                    $includeSub
+                );
                 if (!empty($categoryProducts)) {
                     $ids = array_column($categoryProducts, 'id_product');
                     $presented = EverblockTools::everPresentProducts($ids, $this->context);

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4124,6 +4124,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Number of products to display'),
                             'default' => '4',
                         ],
+                        'include_subcategories' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Include products from subcategories'),
+                            'default' => 0,
+                        ],
                         'slider' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Enable slider'),

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -651,6 +651,7 @@ $_MODULE['<{everblock}prestashop>everblock_21f59a9a3e796f0e797ad7736028089c'] = 
 $_MODULE['<{everblock}prestashop>everblock_a97e8578c3942df9fc98bb501d385883'] = 'Heure d\'ouverture de %s le %s';
 $_MODULE['<{everblock}prestashop>everblock_5ce749b4b55e9ed91bda1aba920e1ffd'] = 'Heure de fermeture de %s le %s';
 $_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Activer le slider';
+$_MODULE['<{everblock}prestashop>everblock_a281105e9083d836b5a2cca69294e38a'] = 'Afficher les produits des sous-catégories';
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Nombre de marques par slide';
 $_MODULE['<{everblock}prestashop>everblock_5a007b1257a85c32e4c435c60cbad339'] = 'Titre du plan';
 $_MODULE['<{everblock}prestashop>everblock_1d89b70bf1410131de72cef713ef3d20'] = 'Prix du plan';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -25,6 +25,7 @@ $_MODULE['<{everblock}prestashop>everblock_6bad61b9ccbce7b54a971752b6a9e4f6'] = 
 $_MODULE['<{everblock}prestashop>everblock_a071cf4c36ab33786b9eed04502122eb'] = 'CTA URL';
 $_MODULE['<{everblock}prestashop>everblock_0b90582f4589d84be89f5b847d4d1ed1'] = 'Highlight';
 $_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Enable slider';
+$_MODULE['<{everblock}prestashop>everblock_a281105e9083d836b5a2cca69294e38a'] = 'Include products from subcategories';
 $_MODULE['<{everblock}prestashop>everblock_26290d95407771415ff52a22bed4c39c'] = 'Number of plans per slide';
 $_MODULE['<{everblock}prestashop>everblock_downloads_list'] = 'Downloads list';
 $_MODULE['<{everblock}prestashop>everblock_downloads_blockdesc'] = 'Display a list of downloadable resources';

--- a/translations/it.php
+++ b/translations/it.php
@@ -25,6 +25,7 @@ $_MODULE['<{everblock}prestashop>everblock_6bad61b9ccbce7b54a971752b6a9e4f6'] = 
 $_MODULE['<{everblock}prestashop>everblock_a071cf4c36ab33786b9eed04502122eb'] = 'URL CTA';
 $_MODULE['<{everblock}prestashop>everblock_0b90582f4589d84be89f5b847d4d1ed1'] = 'Evidenzia';
 $_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Abilita slider';
+$_MODULE['<{everblock}prestashop>everblock_a281105e9083d836b5a2cca69294e38a'] = 'Includi prodotti dalle sottocategorie';
 $_MODULE['<{everblock}prestashop>everblock_26290d95407771415ff52a22bed4c39c'] = 'Numero di piani per diapositiva';
 $_MODULE['<{everblock}prestashop>everblock_downloads_list'] = 'Lista download';
 $_MODULE['<{everblock}prestashop>everblock_downloads_blockdesc'] = 'Mostra un elenco di risorse scaricabili';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -25,6 +25,7 @@ $_MODULE['<{everblock}prestashop>everblock_6bad61b9ccbce7b54a971752b6a9e4f6'] = 
 $_MODULE['<{everblock}prestashop>everblock_a071cf4c36ab33786b9eed04502122eb'] = 'CTA URL';
 $_MODULE['<{everblock}prestashop>everblock_0b90582f4589d84be89f5b847d4d1ed1'] = 'Markeren';
 $_MODULE['<{everblock}prestashop>everblock_78d5da4bd57ce3e990efd714138339bb'] = 'Schakel slider in';
+$_MODULE['<{everblock}prestashop>everblock_a281105e9083d836b5a2cca69294e38a'] = 'Producten uit subcategorieën opnemen';
 $_MODULE['<{everblock}prestashop>everblock_26290d95407771415ff52a22bed4c39c'] = 'Aantal plannen per dia';
 $_MODULE['<{everblock}prestashop>everblock_downloads_list'] = 'Downloadlijst';
 $_MODULE['<{everblock}prestashop>everblock_downloads_blockdesc'] = 'Toont een lijst met downloadbare bronnen';


### PR DESCRIPTION
## Summary
- add checkbox to include subcategory products in Category products block
- load products from subcategories when option enabled
- provide translations for new setting

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l everblock.php`
- `php -l models/EverblockTools.php`
- `php -l translations/gb.php`
- `php -l translations/fr.php`
- `php -l translations/it.php`
- `php -l translations/nl.php`


------
https://chatgpt.com/codex/tasks/task_e_68be87fc81988322a597c8bcf4fa8f1e