### PR TITLE
Add CMS page link to store locator list

### DIFF
--- a/translations/fr.php
+++ b/translations/fr.php
@@ -631,6 +631,7 @@ $_MODULE['<{everblock}prestashop>storelocator_047a1dd66c6e4d29b5f45cd776a42992']
 $_MODULE['<{everblock}prestashop>storelocator_0987be375bb6cdd954eb90e2b023ced4'] = 'Horaires à %s';
 $_MODULE['<{everblock}prestashop>storelocator_d3d2e617335f08df83599665eef8a418'] = 'Fermer';
 $_MODULE['<{everblock}prestashop>storelocator_a9407a9201ef1b64f0c567ed291574ba'] = 'S\'y rendre';
+$_MODULE['<{everblock}prestashop>storelocator_d59048f21fd887ad520398ce677be586'] = 'En savoir plus';
 $_MODULE['<{everblock}prestashop>everblocktools_465bdb56b331fa5d1b1e3bab14bc6c41'] = 'Veuillez renseigner la clé Google Maps dans la configuration du module.';
 $_MODULE['<{everblock}prestashop>everblocktools_d6f69704e815d4fa6fd548878c6f9d1e'] = 'Veuillez renseigner l\'adresse postale de la boutique.';
 $_MODULE['<{everblock}prestashop>everblocktools_8a46c2c7448b0db1b1ddc0d5e44629da'] = 'Impossible de géocoder l\'adresse de la boutique.';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -60,3 +60,4 @@ $_MODULE['<{everblock}prestashop>everblock_podcasts_episode_title'] = 'Episode t
 $_MODULE['<{everblock}prestashop>everblock_podcasts_audio_url'] = 'Audio URL';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_duration'] = 'Duration';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_description'] = 'Description';
+$_MODULE['<{everblock}prestashop>storelocator_d59048f21fd887ad520398ce677be586'] = 'Learn more';

--- a/translations/it.php
+++ b/translations/it.php
@@ -60,3 +60,4 @@ $_MODULE['<{everblock}prestashop>everblock_podcasts_episode_title'] = 'Titolo de
 $_MODULE['<{everblock}prestashop>everblock_podcasts_audio_url'] = 'URL audio';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_duration'] = 'Durata';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_description'] = 'Descrizione';
+$_MODULE['<{everblock}prestashop>storelocator_d59048f21fd887ad520398ce677be586'] = 'Per saperne di più';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -60,3 +60,4 @@ $_MODULE['<{everblock}prestashop>everblock_podcasts_episode_title'] = 'Titel van
 $_MODULE['<{everblock}prestashop>everblock_podcasts_audio_url'] = 'Audiourl';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_duration'] = 'Duur';
 $_MODULE['<{everblock}prestashop>everblock_podcasts_description'] = 'Beschrijving';
+$_MODULE['<{everblock}prestashop>storelocator_d59048f21fd887ad520398ce677be586'] = 'Meer informatie';

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -90,6 +90,13 @@
                   <u>{l s='See hours' mod='everblock'}</u> &gt;
                 </a>
               </p>
+              {if $item.cms_link}
+                <p class="mb-0 small">
+                  <a href="{$item.cms_link|escape:'htmlall':'UTF-8'}" class="text-decoration-none">
+                    {l s='Learn more' mod='everblock'}
+                  </a>
+                </p>
+              {/if}
             </div>
           </div>
           {hook h='displayAfterLocatorStore' store=$item}


### PR DESCRIPTION
## Summary
- show "Learn more" link to store CMS page in store locator list
- translate new link text in English, French, Italian and Dutch

## Testing
- `php -l translations/fr.php`
- `php -l translations/gb.php`
- `php -l translations/it.php`
- `php -l translations/nl.php`


------
https://chatgpt.com/codex/tasks/task_e_68be8bd7f7108322aeb0cc5bd511084b