### PR TITLE
Handle store hours without spaces around hyphen

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3139,7 +3139,9 @@ class EverblockTools extends ObjectModel
                         $hoursFormatted[] = trim($subSlot);
 
                         if (($i === $todayIndex) && (!$isHoliday || $todayStoreHolidaySlot) && strpos($subSlot, '-') !== false) {
-                            [$startRaw, $endRaw] = explode(' - ', $subSlot);
+                            $parts = preg_split('/\s*-\s*/', $subSlot);
+                            $startRaw = $parts[0] ?? '';
+                            $endRaw = $parts[1] ?? '';
                             $start = self::normalizeTime($startRaw);
                             $end = self::normalizeTime($endRaw);
                             if ($start && $end) {


### PR DESCRIPTION
## Summary
- fix parsing of hour slots like `10h00-20h00` so stores aren't wrongly marked closed

## Testing
- `php -l models/EverblockTools.php`
- `composer require --dev friendsofphp/php-cs-fixer phpstan/phpstan` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be9702ba4083228d5ef6bb041045d0