### PR TITLE
feat: allow custom marker icon for store locator

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3402,11 +3402,15 @@ class EverblockTools extends ObjectModel
                     infoWindow = new google.maps.InfoWindow();
 
                     markers.forEach(function (marker) {
-                        var markerObj = new google.maps.Marker({
+                        var markerOptions = {
                             position: { lat: marker.lat, lng: marker.lng },
                             map: map,
                             title: marker.title
-                        });
+                        };
+                        if (marker.icon) {
+                            markerOptions.icon = marker.icon;
+                        }
+                        var markerObj = new google.maps.Marker(markerOptions);
                         markerMap[marker.id] = markerObj;
                         markerObj.addListener("click", function () {
                             infoWindow.setContent(renderContent(marker));


### PR DESCRIPTION
## Summary
- allow uploading SVG marker icon for store locator
- render uploaded icon on Google Maps markers
- preview uploaded marker icon in configuration and enable removal

## Testing
- `php -l everblock.php`
- `php -l models/EverblockTools.php`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bed6ffac3c8322903c9474ef3ad488