### PR TITLE
fix: improve store locator UI

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3318,7 +3318,7 @@ class EverblockTools extends ObjectModel
                     return `
                         <div class="everblock-marker-info row g-2">
                             <div class="col-4">
-                                <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;" class="rounded w-100">
+                                <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;" class="rounded w-100 ms-2">
                             </div>
                             <div class="col-8">
                                 <strong>${title}</strong><br>

--- a/views/templates/hook/storelocator.tpl
+++ b/views/templates/hook/storelocator.tpl
@@ -17,7 +17,7 @@
 *}
 <div id="store-search-block" class="mb-3 text-center mx-auto" style="max-width:600px;">
   <div class="d-flex flex-column flex-md-row align-items-center justify-content-center">
-    <label for="store_search" class="me-md-2 mb-2 mb-md-0 fw-bold">{l s='Find a store' mod='everblock'}</label>
+    <label for="store_search" class="me-md-2 mb-2 mb-md-0 fw-bold text-nowrap">{l s='Find a store' mod='everblock'}</label>
     <div class="input-group mb-2 mb-md-0 w-100">
       <input type="text" class="form-control" name="store_search" id="store_search" placeholder="{l s='Search for a store' mod='everblock'}" autocomplete="on">
       <button type="button" class="btn btn-primary" id="store_search_btn">{l s='Search' mod='everblock'}</button>


### PR DESCRIPTION
## Summary
- keep store locator title on one line
- add left margin to marker modal image

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedac2d0e88322afc21da54fbc64fa