### PR TITLE
Fix padding in store locator marker modal

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3316,7 +3316,7 @@ class EverblockTools extends ObjectModel
                     var directions = `<a href="https://www.google.com/maps/dir/?api=1&destination=${marker.lat},${marker.lng}" target="_blank" rel="noopener noreferrer" class="btn btn-primary w-100">${marker.directions_label}</a>`;
                     var title = marker.cms_link ? `<a href="${marker.cms_link}" class="text-dark text-decoration-none">${marker.title}</a>` : marker.title;
                     return `
-                        <div class="everblock-marker-info row g-3">
+                        <div class="everblock-marker-info row g-3 mx-0">
                             <div class="col-4">
                                 <img src="${marker.img}" alt="${marker.title}" style="width:80px;height:80px;object-fit:cover;" class="rounded w-100 ms-2">
                             </div>


### PR DESCRIPTION
## Summary
- ensure marker info windows have right-side padding by removing Bootstrap row negative margins

## Testing
- `php -l models/EverblockTools.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68beeb3374e0832280e20ad97fffabd6