### PR TITLE
feat: add product lookbook image map

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -39,6 +39,7 @@ return [
     'controllers/front/cron.php',
     'controllers/front/everlogin.php',
     'controllers/front/index.php',
+    'controllers/front/lookbook.php',
     'controllers/front/modal.php',
     'controllers/index.php',
     'everblock.php',

--- a/controllers/front/lookbook.php
+++ b/controllers/front/lookbook.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverblockLookbookModuleFrontController extends ModuleFrontController
+{
+    public function initContent()
+    {
+        $this->ajax = true;
+        parent::initContent();
+        $token = Tools::getValue('token');
+        if (!$token || $token !== Tools::getToken()) {
+            die();
+        }
+        $idProduct = (int) Tools::getValue('id_product');
+        if (!$idProduct) {
+            die();
+        }
+        $presented = EverblockTools::everPresentProducts([$idProduct], $this->context);
+        if (empty($presented)) {
+            die();
+        }
+        $product = reset($presented);
+        $this->context->smarty->assign([
+            'everPresentProducts' => [$product],
+            'carousel' => false,
+            'shortcodeClass' => 'lookbook-modal',
+        ]);
+        $html = $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/hook/ever_presented_products.tpl');
+        die($html);
+    }
+}

--- a/everblock.php
+++ b/everblock.php
@@ -4039,25 +4039,7 @@ class Everblock extends Module
 
     public function hookBeforeRenderingEverblockLookbook($params)
     {
-        $products = [];
-        if (!empty($params['block']['states']) && is_array($params['block']['states'])) {
-            foreach ($params['block']['states'] as $key => $state) {
-                if (empty($state['product_ids'])) {
-                    continue;
-                }
-                $ids = array_filter(array_map('intval', explode(',', $state['product_ids'])));
-                $ids = array_slice($ids, 0, 8);
-                if (!$ids) {
-                    continue;
-                }
-                $presented = EverblockTools::everPresentProducts($ids, $this->context);
-                if (!empty($presented)) {
-                    $products[$key] = $presented;
-                }
-            }
-        }
-
-        return ['products' => $products];
+        return [];
     }
 
     public function hookBeforeRenderingEverblockCategoryProducts($params)

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4311,10 +4311,8 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $lookbookTemplate,
                 ],
-                'repeater' => [
-                    'name' => 'Look',
-                    'nameFrom' => 'title',
-                    'groups' => [
+                'config' => [
+                    'fields' => [
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Look title'),
@@ -4327,67 +4325,28 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'url' => '',
                             ],
                         ],
-                        'product_ids' => [
+                    ],
+                ],
+                'repeater' => [
+                    'name' => 'Product',
+                    'nameFrom' => 'product',
+                    'groups' => [
+                        'product' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Choose a product'),
+                            'collection' => 'Product',
+                            'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                        'top' => [
                             'type' => 'text',
-                            'label' => $module->l('Associated product IDs (comma-separated)'),
-                            'default' => '',
+                            'label' => $module->l('Top position (e.g., 50%)'),
+                            'default' => '0%',
                         ],
-                        'background_color' => [
-                            'tab' => 'design',
-                            'type' => 'color',
-                            'default' => '',
-                            'label' => $module->l('Block background color'),
-                        ],
-                        'text_color' => [
-                            'tab' => 'design',
-                            'type' => 'color',
-                            'default' => '',
-                            'label' => $module->l('Block text color'),
-                        ],
-                        'css_class' => [
+                        'left' => [
                             'type' => 'text',
-                            'label' => $module->l('Custom CSS class'),
-                            'default' => '',
-                        ],
-                        'padding_left' => [
-                            'type' => 'text',
-                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'padding_right' => [
-                            'type' => 'text',
-                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'padding_top' => [
-                            'type' => 'text',
-                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'padding_bottom' => [
-                            'type' => 'text',
-                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_left' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_right' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_top' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_bottom' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
-                            'default' => '',
+                            'label' => $module->l('Left position (e.g., 50%)'),
+                            'default' => '0%',
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -22,36 +22,60 @@
     <div class="row">
   {/if}
 
-  {if isset($block.states) && $block.states}
-    <div class="{if $block.settings.default.container}container{/if}">
-      {foreach from=$block.states item=state key=key}
-        <div class="mb-4 {if $state.css_class}{$state.css_class}{/if}"
-             style="{if $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
-          <div class="lookbook-image position-relative mb-3">
-            <img src="{$state.image.url}" alt="{$state.title|escape:'htmlall':'UTF-8'}" class="img-fluid w-100" loading="lazy">
-            {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-              <a class="btn btn-primary position-absolute top-50 start-50 translate-middle"
-                 data-bs-toggle="collapse"
-                 href="#lookbook-products-{$block.id_prettyblocks}-{$key}"
-                 role="button"
-                 aria-expanded="false"
-                 aria-controls="lookbook-products-{$block.id_prettyblocks}-{$key}">
-                {l s='Shop the look' mod='everblock'}
-              </a>
-            {/if}
-          </div>
-          {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-            <div class="collapse" id="lookbook-products-{$block.id_prettyblocks}-{$key}">
-              {assign var='useCarousel' value=count($block.extra.products[$key]) > 4}
-              {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=$useCarousel shortcodeClass='lookbook-products'}
-            </div>
+  <div class="{if $block.settings.default.container}container{/if} text-center">
+    {if $block.settings.title}
+      <h2 class="mb-3">{$block.settings.title|escape:'htmlall':'UTF-8'}</h2>
+    {/if}
+    <div class="lookbook-image position-relative mb-3 d-inline-block">
+      {if isset($block.settings.image.url) && $block.settings.image.url}
+        <img src="{$block.settings.image.url}" alt="{$block.settings.title|escape:'htmlall':'UTF-8'}" class="img-fluid w-100" loading="lazy">
+      {/if}
+      {if isset($block.states) && $block.states}
+        {foreach from=$block.states item=state}
+          {if isset($state.product.id) && $state.product.id}
+            <button type="button" class="btn btn-light rounded-circle lookbook-marker position-absolute" style="top:{$state.top|escape:'htmlall'};left:{$state.left|escape:'htmlall'};transform:translate(-50%,-50%);" data-product-id="{$state.product.id}">
+              <span class="visually-hidden">{l s='View product' mod='everblock'}</span>
+            </button>
           {/if}
-        </div>
-      {/foreach}
+        {/foreach}
+      {/if}
     </div>
-  {/if}
+    <div class="mt-3">
+      <small class="text-muted">{l s='Cliquez sur un point pour voir le produit' mod='everblock'}</small>
+    </div>
+  </div>
 
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>
   {/if}
 </div>
+
+<div class="modal fade" id="lookbook-modal-{$block.id_prettyblocks}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-body"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  var markers = document.querySelectorAll('#block-{$block.id_prettyblocks} .lookbook-marker');
+  var modalEl = document.getElementById('lookbook-modal-{$block.id_prettyblocks}');
+  var modalBody = modalEl.querySelector('.modal-body');
+  var modal = new bootstrap.Modal(modalEl);
+  var ajaxUrl = "{$link->getModuleLink('everblock', 'lookbook', ['token' => $static_token])}";
+  markers.forEach(function(marker) {
+    marker.addEventListener('click', function (e) {
+      e.preventDefault();
+      var productId = this.getAttribute('data-product-id');
+      fetch(ajaxUrl + '&id_product=' + productId)
+        .then(function(resp){ return resp.text(); })
+        .then(function(html){
+          modalBody.innerHTML = html;
+          modal.show();
+        });
+    });
+  });
+});
+</script>


### PR DESCRIPTION
## Summary
- refactor lookbook block configuration for single image and product markers
- add AJAX controller to render presented product in Bootstrap modal
- display interactive markers on lookbook image and load product via modal

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l everblock.php`
- `php -l controllers/front/lookbook.php`
- `php -l config/allowed_files.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68beea94c7b48322a70d5246de4a1e8a