### PR TITLE
Escape hash in newsletter form regex

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -2027,7 +2027,7 @@ class EverblockTools extends ObjectModel
                 // (e.g. contact form) breaks the form action.
                 $currentUrl = Tools::getHttpHost(true) . $_SERVER['REQUEST_URI'];
                 $replacement = preg_replace(
-                    '#(<form[^>]*action=")[^"]*#blockEmailSubscription_displayFooter(")#',
+                    '@(<form[^>]*action=")[^"]*#blockEmailSubscription_displayFooter(")@',
                     '$1' . htmlspecialchars($currentUrl, ENT_QUOTES) . '#blockEmailSubscription_displayFooter$2',
                     $replacement
                 );


### PR DESCRIPTION
## Summary
- fix preg_replace pattern to avoid unknown modifier 'b'

## Testing
- `php -l models/EverblockTools.php`


------
https://chatgpt.com/codex/tasks/task_e_68bef8fe0c988322acd47e8e69821685