### PR TITLE
Fix Lookbook AJAX token validation

### DIFF
--- a/controllers/front/lookbook.php
+++ b/controllers/front/lookbook.php
@@ -27,8 +27,12 @@ class EverblockLookbookModuleFrontController extends ModuleFrontController
     {
         $this->ajax = true;
         parent::initContent();
+        // Front-office AJAX calls use the static token available in Smarty as
+        // {$static_token}.  Tools::getToken() may generate a different value
+        // depending on context, which caused legitimate requests to be rejected
+        // with a 400 error.  Use the same static token to validate the request.
         $token = Tools::getValue('token');
-        if (!$token || $token !== Tools::getToken()) {
+        if (!$token || $token !== Tools::getToken(false)) {
             http_response_code(400);
             exit;
         }


### PR DESCRIPTION
## Summary
- ensure lookbook AJAX calls use static token from front office

## Testing
- `php -l controllers/front/lookbook.php`


------
https://chatgpt.com/codex/tasks/task_e_68bff82b78848322bcc9ebc3e90a9af0