### PR TITLE
Fix newsletter shortcode handling in modals

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -2024,8 +2024,14 @@ class EverblockTools extends ObjectModel
 
                 // Force the newsletter form to submit to the current page instead
                 // of the homepage, otherwise inserting the shortcode in a page
-                // (e.g. contact form) breaks the form action.
-                $currentUrl = Tools::getHttpHost(true) . $_SERVER['REQUEST_URI'];
+                // (e.g. contact form) breaks the form action. When the form is
+                // loaded via AJAX (e.g. inside a modal), the request URI points to
+                // the AJAX controller. In that case, rely on the origin URL sent
+                // from JavaScript.
+                $currentUrl = Tools::getValue('everblock_origin_url');
+                if (!$currentUrl || !Validate::isUrl($currentUrl)) {
+                    $currentUrl = Tools::getHttpHost(true) . $_SERVER['REQUEST_URI'];
+                }
                 $replacement = preg_replace(
                     '@(<form[^>]*action=")[^"]*#blockEmailSubscription_displayFooter(")@',
                     '$1' . htmlspecialchars($currentUrl, ENT_QUOTES) . '#blockEmailSubscription_displayFooter$2',

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -121,7 +121,7 @@ $(document).ready(function(){
         $.ajax({
             url: atob(evermodal_link),
             type: 'POST',
-            data: { id_everblock: blockId, token: everblock_token },
+            data: { id_everblock: blockId, token: everblock_token, everblock_origin_url: window.location.href },
             success: function(modal) {
                 $(modal).insertAfter($('body'));
                 let $modal = $('#everblockModal');
@@ -161,7 +161,7 @@ $(document).ready(function(){
         if (!blockId && !cmsId && !productModalId) {
             return;
         }
-        let data = { token: everblock_token, force: 1 };
+        let data = { token: everblock_token, force: 1, everblock_origin_url: window.location.href };
         if (blockId) {
             data.id_everblock = blockId;
         }


### PR DESCRIPTION
## Summary
- ensure newsletter shortcode uses originating page URL so modal submissions hit correct controller
- send page URL with modal AJAX requests so newsletter hook triggers

## Testing
- `php -l models/EverblockTools.php`
- `node --check views/js/everblock.js`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c009c18f708322a4035dd8c31f626a