### PR TITLE
style: make lookbook markers circular

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -22,6 +22,16 @@
 [data-obflink] {
   cursor: pointer;
 }
+/* Lookbook product markers */
+.lookbook-marker {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 /* Style pour le panier déroulant */
 .ever-shopping-cart .dropdown-menu.cart-dropdown-content {
   padding: 15px;


### PR DESCRIPTION
## Summary
- add explicit dimensions to Lookbook product markers so they render as perfect circles

## Testing
- `composer validate`
- `php -l controllers/front/lookbook.php`


------
https://chatgpt.com/codex/tasks/task_e_68c045a8649c83229b5ac3fc6d4e223f