### PR TITLE
Add responsive margin controls to Prettyblock Cover block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -3789,6 +3789,46 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
                     ],
                 ],
             ];

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -27,7 +27,8 @@
     <div class="ever-cover-carousel">
       {foreach from=$block.states item=state key=key}
         <div id="block-{$block.id_prettyblocks}-{$key}"
-             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}">
+             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"
+             {if $state.margin_left || $state.margin_right || $state.margin_top || $state.margin_bottom}style="{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall'};{/if}"{/if}>
             {if isset($state.background_image.url) && $state.background_image.url}
               <picture>
                 {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
@@ -61,11 +62,24 @@
             {/if}
           </div>
         </div>
+        {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+          <style>
+            @media (max-width: 767px) {
+              #block-{$block.id_prettyblocks}-{$key} {
+                {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+                {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+                {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+                {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+              }
+            }
+          </style>
+        {/if}
       {/foreach}
   {else}
     {foreach from=$block.states item=state key=key}
       <div id="block-{$block.id_prettyblocks}-{$key}"
-           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}">
+           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"
+           {if $state.margin_left || $state.margin_right || $state.margin_top || $state.margin_bottom}style="{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall'};{/if}"{/if}>
         {if isset($state.background_image.url) && $state.background_image.url}
           <picture>
             {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
@@ -99,6 +113,18 @@
           {/if}
         </div>
       </div>
+      {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+        <style>
+          @media (max-width: 767px) {
+            #block-{$block.id_prettyblocks}-{$key} {
+              {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+              {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+              {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+              {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+            }
+          }
+        </style>
+      {/if}
     {/foreach}
   {/if}
 {/if}


### PR DESCRIPTION
## Summary
- allow specifying separate desktop and mobile margins for Cover block items
- render margin styles inline and with mobile media queries

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c0470475dc8322bb74f34da70801b2