### PR TITLE
feat: add mobile margin options for simple image block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -224,6 +224,26 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
+                        'margin_left_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
                     ],
                 ],
             ];

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -64,6 +64,18 @@
             {/if}
           </div>
       </div>
+      {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+        <style>
+          @media (max-width: 767px) {
+            #block-{$block.id_prettyblocks}-{$key} {
+              {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall':'UTF-8'};{/if}
+              {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall':'UTF-8'};{/if}
+              {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall':'UTF-8'};{/if}
+              {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall':'UTF-8'};{/if}
+            }
+          }
+        </style>
+      {/if}
     {/foreach}
   </div>
 {/if}


### PR DESCRIPTION
## Summary
- allow Simple Image block to define mobile-specific margins
- apply responsive styles in Simple Image template to use mobile margins

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_68c04cf785048322ba37b011a41aa1d6