### PR TITLE
feat: support mobile margins for featured category

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -304,6 +304,26 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
+                        'margin_left_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
                     ],
                 ],
             ];
@@ -1507,6 +1527,26 @@ class EverblockPrettyBlocks extends ObjectModel
                         'margin_bottom' => [
                             'type' => 'text',
                             'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Mobile margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
                     ],

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -71,6 +71,18 @@
         {/if}
       </div>
     </div>
+    {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+      <style>
+        @media (max-width: 767px) {
+          #block-{$block.id_prettyblocks}-{$key} .position-relative {
+            {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+            {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+            {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+            {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+          }
+        }
+      </style>
+    {/if}
   {/foreach}
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>


### PR DESCRIPTION
## Summary
- allow setting separate mobile/desktop margins for Featured Category blocks
- apply mobile-specific margin styles in the category highlight template

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c04e7a17c883228feeb5eca4671f5b