### PR TITLE
feat: add overlay and loop options to scroll video block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1190,6 +1190,41 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Video height (e.g., 360px)'),
                             'default' => '360px',
                         ],
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Title'),
+                            'default' => '',
+                        ],
+                        'content' => [
+                            'type' => 'textarea',
+                            'label' => $module->l('Text'),
+                            'default' => '',
+                        ],
+                        'button_label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button label'),
+                            'default' => '',
+                        ],
+                        'button_url' => [
+                            'type' => 'text',
+                            'label' => $module->l('Button URL'),
+                            'default' => '',
+                        ],
+                        'overlay_color' => [
+                            'type' => 'text',
+                            'label' => $module->l('Overlay color'),
+                            'default' => '#000000',
+                        ],
+                        'overlay_opacity' => [
+                            'type' => 'text',
+                            'label' => $module->l('Overlay opacity (0-1)'),
+                            'default' => '0.5',
+                        ],
+                        'loop' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Infinite loop'),
+                            'default' => false,
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -322,6 +322,31 @@
     display: block;
 }
 
+.everblock-scroll-video {
+    position: relative;
+}
+
+.everblock-scroll-video-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+
+.everblock-scroll-video-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+    text-align: center;
+    color: #fff;
+    width: 100%;
+    padding: 1rem;
+}
+
 /* Cover block */
 .prettyblock-cover-item {
     position: relative;

--- a/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
@@ -28,9 +28,15 @@
     {foreach from=$block.states item=state key=key}
         <div id="block-{$block.id_prettyblocks}-{$key}" class="everblock-scroll-video {if isset($state.css_class) && $state.css_class}{$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{if isset($state.padding_left)}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_right)}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_top)}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_bottom)}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_left)}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_right)}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_top)}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_bottom)}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
             <img src="{$state.thumbnail.url|replace:'.webp':'.jpg'}" class="img-fluid everblock-video-thumb" alt="" loading="lazy" data-video-src="{$state.video_url|escape:'htmlall':'UTF-8'}" {if isset($state.width)}style="max-width:{$state.width|escape:'htmlall':'UTF-8'};"{/if}>
-            <video class="everblock-video d-none" playsinline muted {if isset($state.width)}style="max-width:{$state.width|escape:'htmlall':'UTF-8'};"{/if} {if isset($state.height)}height="{$state.height|escape:'htmlall':'UTF-8'}"{/if}>
+            <video class="everblock-video d-none" playsinline muted {if $state.loop}loop {/if}{if isset($state.width)}style="max-width:{$state.width|escape:'htmlall':'UTF-8'};"{/if} {if isset($state.height)}height="{$state.height|escape:'htmlall':'UTF-8'}"{/if}>
                 <source src="{$state.video_url|escape:'htmlall':'UTF-8'}" type="video/mp4">
             </video>
+            <div class="everblock-scroll-video-overlay" style="{if isset($state.overlay_color)}background-color:{$state.overlay_color|escape:'htmlall':'UTF-8'};{/if}{if isset($state.overlay_opacity)}opacity:{$state.overlay_opacity|escape:'htmlall':'UTF-8'};{/if}"></div>
+            <div class="everblock-scroll-video-content">
+                {if isset($state.title) && $state.title}<h3>{$state.title|escape:'htmlall':'UTF-8'}</h3>{/if}
+                {if isset($state.content) && $state.content}<p>{$state.content|escape:'htmlall':'UTF-8'}</p>{/if}
+                {if isset($state.button_label) && $state.button_label && isset($state.button_url) && $state.button_url}<a href="{$state.button_url|escape:'htmlall':'UTF-8'}" class="btn btn-primary">{$state.button_label|escape:'htmlall':'UTF-8'}</a>{/if}
+            </div>
         </div>
     {/foreach}
     {if $block.settings.default.container}


### PR DESCRIPTION
## Summary
- allow setting overlay color, content and button for scroll videos
- support infinite loop playback on scroll videos

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c05aaad30c8322bcaa1da77a79b495