### PR TITLE
Add responsive column option to lookbook block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4386,6 +4386,25 @@ class EverblockPrettyBlocks extends ObjectModel
                                 'url' => '',
                             ],
                         ],
+                        'columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns on desktop'),
+                            'default' => '1',
+                            'options' => [
+                                [
+                                    'label' => '1',
+                                    'value' => '1',
+                                ],
+                                [
+                                    'label' => '2',
+                                    'value' => '2',
+                                ],
+                                [
+                                    'label' => '3',
+                                    'value' => '3',
+                                ],
+                            ],
+                        ],
                     ],
                 ],
                 'repeater' => [

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -32,6 +32,22 @@
   align-items: center;
   justify-content: center;
 }
+.prettyblock-lookbook {
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .prettyblock-lookbook.columns-2,
+  .prettyblock-lookbook.columns-3 {
+    display: inline-block;
+    vertical-align: top;
+  }
+  .prettyblock-lookbook.columns-2 {
+    width: 50%;
+  }
+  .prettyblock-lookbook.columns-3 {
+    width: 33.3333%;
+  }
+}
 /* Style pour le panier déroulant */
 .ever-shopping-cart .dropdown-menu.cart-dropdown-content {
   padding: 15px;

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -15,6 +15,8 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{assign var=columns value=$block.settings.columns|default:'1'}
+<div class="prettyblock-lookbook columns-{$columns}">
 <div id="block-{$block.id_prettyblocks}" data-lookbook-url="{$link->getModuleLink('everblock', 'lookbook', ['token' => $static_token])|escape:'html':'UTF-8'}" class="{if $block.settings.default.force_full_width|default:false}container-fluid px-0 mx-0{elseif $block.settings.default.container|default:false}container{/if}">
   {if $block.settings.default.force_full_width|default:false}
     <div class="row gx-0 no-gutters">
@@ -48,6 +50,8 @@
   {if $block.settings.default.force_full_width|default:false || $block.settings.default.container|default:false}
     </div>
   {/if}
+</div>
+
 </div>
 
 <div class="modal fade" id="lookbook-modal-{$block.id_prettyblocks}" tabindex="-1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- allow selecting number of columns for the lookbook block
- wrap lookbook markup with responsive container
- add CSS to display two or three lookbooks side by side on desktop

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c05b4d9e64832296f104076554fba8