### PR TITLE
fix: restore lookbook block widths for columns

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -34,13 +34,16 @@
 }
 .prettyblock-lookbook {
   width: 100%;
-  display: grid;
+  display: inline-grid;
   gap: 1rem;
+  vertical-align: top;
 }
 .prettyblock-lookbook.columns-2 {
+  width: 50%;
   grid-template-columns: repeat(2, 1fr);
 }
 .prettyblock-lookbook.columns-3 {
+  width: 33.3333333%;
   grid-template-columns: repeat(3, 1fr);
 }
 @media (max-width: 767.98px) {


### PR DESCRIPTION
## Summary
- ensure `.prettyblock-lookbook` uses inline-grid and restores width for `columns-2` and `columns-3`

## Testing
- `php -l views/templates/hook/prettyblocks/prettyblock_lookbook.tpl`
- `php -l everblock.php`
- `composer validate --no-check-all --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_68c177bc3b208322a122b9589d93e7f8