### PR TITLE
Adjust brand carousel arrow spacing

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -665,3 +665,12 @@
     max-width: 100%;
     height: auto;
 }
+
+/* Brand carousel arrows */
+.featured-brands .carousel-control-prev {
+    left: 1rem;
+}
+
+.featured-brands .carousel-control-next {
+    right: 1rem;
+}


### PR DESCRIPTION
## Summary
- shift brand carousel controls 1rem away from edges to keep arrows off brand images

## Testing
- `composer validate --quiet`
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_68c19a38dc4c8322b495b1660d08ed19