### PR TITLE
feat: center bootstrap cards

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -867,7 +867,7 @@ class EverblockPrettyBlocks extends ObjectModel
                 'settings' => [
                     'default' => [
                         'display_inline' => [
-                            'type' => 'switch',
+                            'type' => 'checkbox',
                             'label' => $module->l('Display reassurances side by side'),
                             'default' => false,
                         ],
@@ -3643,6 +3643,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'need_reload' => true,
                 'templates' => [
                     'default' => $cardTemplate,
+                ],
+                'settings' => [
+                    'default' => [
+                        'center_cards' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Center cards in container'),
+                            'default' => false,
+                        ],
+                    ],
                 ],
                 'repeater' => [
                     'name' => 'Card',

--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -17,8 +17,8 @@
 *}
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
   {if isset($block.states) && $block.states}
-    <div class="overflow-auto px-2 px-md-0 pb-2">
-      <div class="d-flex flex-nowrap gap-3 pe-1">
+    <div class="{if $block.settings.default.center_cards}px-2 px-md-0 pb-2{else}overflow-auto px-2 px-md-0 pb-2{/if}">
+      <div class="d-flex gap-3 pe-1{if $block.settings.default.center_cards} flex-wrap justify-content-center{else} flex-nowrap{/if}">
         {foreach from=$block.states item=state}
           <div class="flex-shrink-0 prettyblocks-card-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="width:90%;max-width:90%;">
             <div class="card h-100 mb-3 border border-light-subtle rounded-4 shadow-sm">


### PR DESCRIPTION
## Summary
- add `center_cards` setting to Bootstrap cards block
- conditionally wrap and center cards when option enabled
- replace `switch` type with `checkbox` for card and reassurance settings

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c19a31f27c8322b96bde2656dcc18d