### PR TITLE
fix: hide empty lookbook zones

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -18,9 +18,11 @@
 {assign var=columns value=$block.settings.columns|default:'1'}
 {capture name=lookbook_before}{prettyblocks_zone zone_name="block-lookbook-{$block.id_prettyblocks}-before"}{/capture}
 {capture name=lookbook_after}{prettyblocks_zone zone_name="block-lookbook-{$block.id_prettyblocks}-after"}{/capture}
+{assign var=lookbook_before_content value=$smarty.capture.lookbook_before}
+{assign var=lookbook_after_content value=$smarty.capture.lookbook_after}
 <div class="prettyblock-lookbook columns-{$columns}">
-  {if $smarty.capture.lookbook_before|trim}
-    <div class="lookbook-item">{$smarty.capture.lookbook_before}</div>
+  {if $lookbook_before_content|strip_tags|trim}
+    <div class="lookbook-item">{$lookbook_before_content nofilter}</div>
   {/if}
   <div class="lookbook-item">
     <div id="block-{$block.id_prettyblocks}" data-lookbook-url="{$link->getModuleLink('everblock', 'lookbook', ['token' => $static_token])|escape:'html':'UTF-8'}" class="{if $block.settings.default.force_full_width|default:false}container-fluid px-0 mx-0{elseif $block.settings.default.container|default:false}container{/if}">
@@ -58,8 +60,8 @@
       {/if}
     </div>
   </div>
-  {if $smarty.capture.lookbook_after|trim}
-    <div class="lookbook-item">{$smarty.capture.lookbook_after}</div>
+  {if $lookbook_after_content|strip_tags|trim}
+    <div class="lookbook-item">{$lookbook_after_content nofilter}</div>
   {/if}
 </div>
 


### PR DESCRIPTION
## Summary
- avoid rendering empty prettyblocks zones in lookbook

## Testing
- `composer validate`
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c273ae4a0c8322916dcdfa364b1d23