### PR TITLE
Make simple image block fully clickable

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -61,13 +61,10 @@
               {if $state.text_highlight_2}
                 <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
               {/if}
-              {if $state.url}
-                </a> {* close <a> before button to avoid nested links *}
-                <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="btn btn-primary mt-1">
-                  {$state.alt|escape:'htmlall':'UTF-8'}
-                </a>
-              {/if}
             </div>
+          {if isset($state.url) && $state.url}
+            </a>
+          {/if}
         </div>
         {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
           <style>
@@ -121,13 +118,10 @@
               {if $state.text_highlight_2}
                 <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
               {/if}
-              {if $state.url}
-                </a> {* close <a> before button to avoid nested links *}
-                <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="btn btn-primary mt-1">
-                  {$state.alt|escape:'htmlall':'UTF-8'}
-                </a>
-              {/if}
             </div>
+          {if isset($state.url) && $state.url}
+            </a>
+          {/if}
         </div>
         {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
           <style>


### PR DESCRIPTION
## Summary
- remove extra button in simple image block when a URL is set
- wrap image and overlay text in a single link so whole image is clickable

## Testing
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c296d1247c8322ad1035fbc78247d3