### PR TITLE
Fix visible slider navigation text in Prettyblock image block

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -565,6 +565,11 @@
     background: transparent;
     border: 0;
     color: #fff;
+    font-size: 0;
+    line-height: 0;
+}
+.ever-cover-carousel .slick-prev:before,
+.ever-cover-carousel .slick-next:before {
     font-size: 2rem;
 }
 .ever-cover-carousel .slick-prev {


### PR DESCRIPTION
## Summary
- hide default "Previous" and "Next" slider text in Prettyblock image block

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68c2b9d541ac8322becdfc3cf7277867