### PR TITLE
feat: configurable image slider items

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -1900,6 +1900,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Enable slider'),
                             'default' => 0,
                         ],
+                        'slider_items' => [
+                            'type' => 'text',
+                            'label' => $module->l('Number of images in slider'),
+                            'default' => 3,
+                        ],
                     ],
                 ],
                 'repeater' => [

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -433,6 +433,7 @@ $_MODULE['<{everblock}prestashop>everblockprettyblocks_11409cf9f3d90e1c7f5f61419
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_5cdcf2315e4ae4c3284559bef9171585'] = 'Titre du shortcode';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_3022a99e31c6c4996b5775c66f941c51'] = 'Images simple';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_31b3f43385eea965b6b6dde5d984a0cb'] = 'Ajoute une image simple';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_925258bd3942934b838168f3535ae1cb'] = 'Nombre d\'images à afficher dans le slider';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_cf82fa946fab5855cd8c6479b0eb95d1'] = 'Titre de l\'image';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_6bbbabc7eb5cf211a14822c4de525b6e'] = 'Texte alternatif de l\'image';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_a5f65cdb85d34151afd967e013a6808d'] = 'Mon texte alternatif';

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -57,6 +57,7 @@ $(document).ready(function(){
         });
         $('.ever-cover-carousel:not(.slick-initialised)').each(function(){
             var $carousel = $(this);
+            var slides = parseInt($carousel.data('items')) || 3;
             $carousel.on('init', function(event, slick){
                 var $center = $(slick.$slides[slick.currentSlide]);
                 $(slick.$prevArrow).appendTo($center);
@@ -68,7 +69,7 @@ $(document).ready(function(){
                 $(slick.$nextArrow).appendTo($center);
             });
             $carousel.slick({
-                slidesToShow: 3,
+                slidesToShow: slides,
                 centerMode: true,
                 arrows: true,
                 dots: false,
@@ -76,7 +77,7 @@ $(document).ready(function(){
                 responsive: [{
                     breakpoint: 768,
                     settings: {
-                        slidesToShow: 1
+                        slidesToShow: Math.min(slides, 1)
                     }
                 }]
             });

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -24,7 +24,7 @@
 {if isset($block.states) && $block.states}
   {assign var='use_slider' value=(isset($block.settings.slider) && $block.settings.slider && $block.states|@count > 1)}
   {if $use_slider}
-    <div class="mt-4 ever-cover-carousel">
+    <div class="mt-4 ever-cover-carousel" data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}">
       {foreach from=$block.states item=state key=key}
         <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden" style="
           {if isset($state.padding_left)}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}


### PR DESCRIPTION
## Summary
- allow Simple image block to define number of slides in the carousel
- read slide count from new setting and wire it to slider JS
- translate and expose French label for new field

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l translations/fr.php`
- `node --check views/js/everblock.js`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68c2b965ed0c8322953d28cb02269abf