### PR TITLE
fix grid layout for image block

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -80,9 +80,9 @@
       {/foreach}
     </div>
   {else}
-    <div class="mt-4 d-flex flex-wrap gap-3 justify-content-center">
+    <div class="row mt-4 g-3 justify-content-center">
       {foreach from=$block.states item=state key=key}
-        <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
+        <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden col-12{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
           {if isset($state.padding_left)}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}
           {if isset($state.padding_right)}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}
           {if isset($state.padding_top)}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}


### PR DESCRIPTION
## Summary
- ensure custom Bootstrap column classes work in image block by using row container and default col-12 on items

## Testing
- `php -l views/templates/hook/prettyblocks/prettyblock_img.tpl`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c2c25c631483229ab7599f908d31c7