### PR TITLE
Load video products via AJAX

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -41,6 +41,7 @@ return [
     'controllers/front/index.php',
     'controllers/front/lookbook.php',
     'controllers/front/modal.php',
+    'controllers/front/videoproducts.php',
     'controllers/index.php',
     'everblock.php',
     'index.php',

--- a/controllers/front/videoproducts.php
+++ b/controllers/front/videoproducts.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverblockVideoproductsModuleFrontController extends ModuleFrontController
+{
+    public function initContent()
+    {
+        $this->ajax = true;
+        parent::initContent();
+        $token = Tools::getValue('token');
+        if (!$token || $token !== Tools::getToken(false)) {
+            http_response_code(400);
+            exit;
+        }
+        $productIds = Tools::getValue('product_ids');
+        if (!$productIds) {
+            http_response_code(400);
+            exit;
+        }
+        $ids = array_map('intval', explode(',', $productIds));
+        $products = EverblockTools::everPresentProducts($ids, $this->context);
+        if (empty($products)) {
+            http_response_code(404);
+            exit;
+        }
+        $this->context->smarty->assign([
+            'everPresentProducts' => $products,
+            'carousel' => false,
+            'shortcodeClass' => 'video-products',
+        ]);
+        $html = $this->context->smarty->fetch(_PS_MODULE_DIR_ . 'everblock/views/templates/hook/ever_presented_products.tpl');
+        exit($html);
+    }
+}

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -278,15 +278,51 @@ $(document).ready(function(){
     $(document).on('click', '.everblock-video-products img', function () {
         let $img = $(this);
         let blockId = $img.data('block');
-        let key = $img.data('key');
-        let modal = $('#productVideoModal-' + blockId);
-        modal.find('iframe').attr('src', $img.data('video-url'));
-        modal.find('.modal-title').text($img.attr('title'));
-        modal.find('.products-container').html($('#products-' + blockId + '-' + key).html());
-        modal.modal('show');
-        modal.on('hidden.bs.modal', function () {
-            modal.find('iframe').attr('src', '');
-            modal.find('.products-container').html('');
+        let productIds = $img.data('product-ids');
+        let $wrapper = $('#video-products-' + blockId);
+        let fetchUrl = $wrapper.data('fetch-url');
+        let productsLabel = $wrapper.data('products-label');
+
+        $.ajax({
+            url: fetchUrl,
+            type: 'POST',
+            data: {
+                token: prestashop.static_token,
+                product_ids: productIds
+            },
+            success: function (html) {
+                let modalId = 'productVideoModal-' + blockId;
+                let modal = $('<div>', {
+                    'class': 'modal fade everblock-video-product-modal',
+                    'id': modalId,
+                    'tabindex': -1,
+                    'aria-hidden': 'true'
+                }).append(
+                    '<div class="modal-dialog modal-dialog-centered modal-lg">' +
+                    '<div class="modal-content">' +
+                    '<div class="modal-header">' +
+                    '<span class="modal-title h5"></span>' +
+                    '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>' +
+                    '</div>' +
+                    '<div class="modal-body">' +
+                    '<div class="ratio ratio-16x9 mb-3">' +
+                    '<iframe id="productVideoIframe-' + blockId + '" src="" allowfullscreen loading="lazy"></iframe>' +
+                    '</div>' +
+                    '<p class="h5">' + productsLabel + '</p>' +
+                    '<div class="products-container"></div>' +
+                    '</div>' +
+                    '</div>' +
+                    '</div>'
+                );
+                modal.find('.modal-title').text($img.attr('title'));
+                modal.find('.products-container').html(html);
+                modal.find('iframe').attr('src', $img.data('video-url'));
+                $('body').append(modal);
+                modal.modal('show');
+                modal.on('hidden.bs.modal', function () {
+                    modal.remove();
+                });
+            }
         });
     });
 

--- a/views/templates/hook/prettyblocks/prettyblock_video_products.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_video_products.tpl
@@ -27,11 +27,11 @@
         <div class="row">
     {/if}
     {if isset($block.states) && $block.states}
-      <div class="row justify-content-center" id="video-products-{$block.id_prettyblocks}">
+      <div class="row justify-content-center" id="video-products-{$block.id_prettyblocks}" data-fetch-url="{$link->getModuleLink('everblock', 'videoproducts')|escape:'htmlall':'UTF-8'}" data-products-label="{l s='Products featured in this video' mod='everblock'}">
         {foreach from=$block.states item=state key=key}
           <div class="col mb-4 col-md-4" style="{if isset($state.padding_left) && $state.padding_left}padding-left:{$state.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_right) && $state.padding_right}padding-right:{$state.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_top) && $state.padding_top}padding-top:{$state.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.padding_bottom) && $state.padding_bottom}padding-bottom:{$state.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_left) && $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_right) && $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_top) && $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($state.margin_bottom) && $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
             <div class="card {if isset($state.css_class) && $state.css_class}{$state.css_class|escape:'htmlall':'UTF-8'}{/if}">
-              <img src="{$state.thumbnail.url|replace:'.webp':'.jpg'}" class="img-fluid cursor-pointer" alt="{$state.title}" title="{$state.title}" loading="lazy" data-block="{$block.id_prettyblocks}" data-key="{$key}" data-video-url="{$state.video_url|escape:'htmlall':'UTF-8'}" data-description="{$state.description|escape:'htmlall':'UTF-8'}" data-bs-toggle="modal" data-bs-target="#productVideoModal-{$block.id_prettyblocks}">
+              <img src="{$state.thumbnail.url|replace:'.webp':'.jpg'}" class="img-fluid cursor-pointer" alt="{$state.title}" title="{$state.title}" loading="lazy" data-block="{$block.id_prettyblocks}" data-key="{$key}" data-video-url="{$state.video_url|escape:'htmlall':'UTF-8'}" data-description="{$state.description|escape:'htmlall':'UTF-8'}" data-product-ids="{$state.product_ids|escape:'htmlall':'UTF-8'}">
               {if $state.title || $state.description}
               <div class="card-body">
                 {if $state.title}<p class="card-title h5">{$state.title}</p>{/if}
@@ -39,30 +39,8 @@
               </div>
               {/if}
             </div>
-            {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-              <div id="products-{$block.id_prettyblocks}-{$key}" class="d-none">
-                {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] carousel=false shortcodeClass='video-products'}
-              </div>
-            {/if}
           </div>
         {/foreach}
-      </div>
-      <div class="modal fade everblock-video-product-modal" id="productVideoModal-{$block.id_prettyblocks}" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-lg">
-          <div class="modal-content">
-            <div class="modal-header">
-              <span class="modal-title h5"></span>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-              <div class="ratio ratio-16x9 mb-3">
-                <iframe id="productVideoIframe-{$block.id_prettyblocks}" src="" allowfullscreen loading="lazy"></iframe>
-              </div>
-              <p class="h5">{l s='Products featured in this video' mod='everblock'}</p>
-              <div class="products-container"></div>
-            </div>
-          </div>
-        </div>
       </div>
     {/if}
     {if $block.settings.default.container}


### PR DESCRIPTION
## Summary
- Load video products on demand via new `videoproducts` front controller
- Fetch products with jQuery and build modal dynamically for better performance

## Testing
- `php -l controllers/front/videoproducts.php`
- `php -l config/allowed_files.php`
- `node --check views/js/everblock.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3c53501b88322abfae16bdc58bf62