### PR TITLE
Add recently viewed products shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[evermap]`: Display a Google Map centered on the shop address when a Google Maps API key is configured.
 - `[subcategories id="2" nb="8"]`: Display subcategories of category 2. Parameters `id` and `nb` are required.
 - `[last-products nb="4" carousel=true]`: Display the last products listed in the store. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
+- `[recently_viewed nb="4" carousel=true]`: Display the recently viewed products for the current visitor. Optional parameters: `nb`, `carousel`.
 - `[best-sales nb="4" carousel=true]`: Display best-selling products. Optional parameters: `nb`, `limit`, `days`, `carousel`, `orderby`, `orderway`.
 - `[evercart]`: Display dropdown cart.
 - `[cart_total]`: Display the total value of the current cart.
@@ -230,6 +231,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 | `[featurebestsales]` | id | nb, limit, days, carousel, orderby, orderway |
 | `[featurevaluebestsales]` | id | nb, limit, days, carousel, orderby, orderway |
 | `[last-products]` | — | nb, limit, carousel, orderby, orderway |
+| `[recently_viewed]` | — | nb, carousel |
 | `[promo-products]` | — | nb, limit, carousel, orderby, orderway |
 | `[products_by_tag]` | tag or tag_id | match, limit, offset, order, way, cols, visibility |
 | `[low_stock]` | — | limit, offset, threshold, match, order, way, days, id_category, id_manufacturer, visibility, available_only, cols, by |

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -123,6 +123,7 @@
                 <li><p>[storelocator] {l s='to show a store locator on any CMS page' mod='everblock'}</p></li>
                 <li><p>[subcategories id="2" nb="8"] {l s='to display 8 subcategories (name, image and link) of category 2' mod='everblock'}</p></li>
                 <li><p>[last-products nb="4"] {l s='to display the last products listed in the store' mod='everblock'}</p></li>
+                <li><p>[recently_viewed nb="4"] {l s='to display recently viewed products' mod='everblock'}</p></li>
                 <li><p>[best-sales nb="4"] {l s='to display the best-selling products in your store' mod='everblock'}</p></li>
                 <li><p>[evercart] {l s='to display dropdown cart' mod='everblock'}</p></li>
                 <li><p>[nativecontact] {l s='to display Prestashop native contact form' mod='everblock'}</p></li>


### PR DESCRIPTION
## Summary
- add `[recently_viewed]` shortcode to display the visitor's recently viewed products
- document the shortcode usage and parameters
- expose shortcode example in admin configuration panel

## Testing
- `php -l models/EverblockTools.php`
- `php -l views/templates/admin/configure.tpl`


------
https://chatgpt.com/codex/tasks/task_e_68c3e41696748322a2e3efb408743dc3