### PR TITLE
Track recently viewed products via header hook

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3296,6 +3296,22 @@ class Everblock extends Module
                 (int) Tools::getValue('qty')
             );
         }
+        if (isset($this->context->controller->php_self)
+            && $this->context->controller->php_self === 'product'
+            && ($idProduct = (int) Tools::getValue('id_product'))
+        ) {
+            $cookie = $this->context->cookie;
+            $viewed = $cookie->__isset('viewed')
+                ? (string) $cookie->__get('viewed')
+                : '';
+            $viewedArray = array_filter(array_map('intval', explode(',', $viewed)));
+            $viewedArray = array_diff($viewedArray, [$idProduct]);
+            $viewedArray[] = $idProduct;
+            if (count($viewedArray) > 20) {
+                $viewedArray = array_slice($viewedArray, -20);
+            }
+            $cookie->__set('viewed', implode(',', $viewedArray));
+        }
         // Google Shopping hack
         $modelId = (int) Tools::getValue('model_id');
         if ($modelId) {


### PR DESCRIPTION
## Summary
- track product page visits in PrestaShop native `viewed` cookie for [recently_viewed] shortcode
- use Cookie magic methods to manage the `viewed` list

## Testing
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_68c3fe079bc08322b4e08ae7bf0ddab9