### PR TITLE
feat: add countdown prettyblock

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -79,6 +79,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
             $countersTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_counters.tpl';
+            $countdownTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_countdown.tpl';
             $cardTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_card.tpl';
             $coverTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_cover.tpl';
             $headingTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heading.tpl';
@@ -3725,6 +3726,71 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'text',
                             'label' => $module->l('Animation speed (ms)'),
                             'default' => '2000',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Countdown'),
+                'description' => $module->l('Display a countdown timer'),
+                'code' => 'everblock_countdown',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $countdownTemplate,
+                ],
+                'config' => [
+                    'fields' => [
+                        'target_date' => [
+                            'type' => 'text',
+                            'label' => $module->l('Target date (YYYY-MM-DD HH:MM:SS)'),
+                            'default' => '',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
+                            'default' => '',
                         ],
                     ],
                 ],

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -460,6 +460,13 @@ $_MODULE['<{everblock}prestashop>everblockprettyblocks_212f9ac581ccabed469caf2e6
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_46b883ef3f1530fd1c2b28b381800084'] = 'Affiche un carousel d\'images (les images doivent avoir la même taille)';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_84be54bb4bd1b755a27d86388700d097'] = 'Marques';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_8f9eabc1113072d009965c1009eeb5ce'] = 'Affiche une liste de marques sélectionnées';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_e64465da4a42d65847b321045b155602'] = 'Compte à rebours';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_98f446a44692c7e467177f1be5b44963'] = 'Affiche un compte à rebours';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_0ab22329873ec29390070d1ce966c20d'] = 'Date cible (AAAA-MM-JJ HH:MM:SS)';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_e807d3ccf8d24c8c1a3d86db5da78da8'] = 'Jours';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_6a7e73161603d87b26a8eac49dab0a9c'] = 'Heures';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_f670ea66cfb0e90bd6090472ad692694'] = 'Minutes';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_8f19a8c7566af54ea8981029730e5465'] = 'Secondes';
 $_MODULE['<{everblock}prestashop>configure_621886d5d907cadfb35840e0bc9688d3'] = 'Qu\'est-ce qu\'un hook ?';
 $_MODULE['<{everblock}prestashop>configure_714f82bdd35410e27b403a7ed10fa67e'] = 'Un hook est un endroit où vous pouvez « greffer » un module. Très nombreux sur Prestashop, ils sont enregistrés dans votre base de données, et affichés par votre thème et vos modules.';
 $_MODULE['<{everblock}prestashop>configure_6c9cc2811d8dd20065be04ab58bbcaa7'] = 'Ces hooks sont disponibles à la fois sur votre site, mais aussi dans l\'administration de votre boutique.';

--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -154,6 +154,18 @@
     font-weight: 700;
 }
 
+/* Countdown */
+.everblock-countdown-value {
+    display: block;
+    font-size: 3rem;
+    font-weight: 700;
+}
+.everblock-countdown-label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+}
+
 /* Exit intent modal */
 .ever-exit-intent-modal .modal-content {
     text-align: center;

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -760,6 +760,18 @@
     font-weight: 700;
 }
 
+/* Countdown */
+.everblock-countdown-value {
+    display: block;
+    font-size: 3rem;
+    font-weight: 700;
+}
+.everblock-countdown-label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+}
+
 /* Exit intent modal */
 .ever-exit-intent-modal .modal-content {
     text-align: center;

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -430,6 +430,32 @@ $(document).ready(function(){
         });
     });
 
+    // Countdown block
+    $('.everblock-countdown').each(function() {
+        var $block = $(this);
+        var target = $block.data('target');
+        if (!target) {
+            return;
+        }
+        function updateCountdown() {
+            var distance = new Date(target).getTime() - new Date().getTime();
+            if (distance <= 0) {
+                $block.find('.everblock-countdown-value').text('00');
+                return;
+            }
+            var days = Math.floor(distance / (1000 * 60 * 60 * 24));
+            var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+            var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+            var seconds = Math.floor((distance % (1000 * 60)) / 1000);
+            $block.find('[data-type="days"]').text(('0' + days).slice(-2));
+            $block.find('[data-type="hours"]').text(('0' + hours).slice(-2));
+            $block.find('[data-type="minutes"]').text(('0' + minutes).slice(-2));
+            $block.find('[data-type="seconds"]').text(('0' + seconds).slice(-2));
+        }
+        updateCountdown();
+        setInterval(updateCountdown, 1000);
+    });
+
     // Podcasts player
     $('.everblock-podcasts audio').on('play', function () {
         $('.everblock-podcasts audio').not(this).each(function () {

--- a/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
@@ -1,0 +1,55 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  <!-- Module Ever Block -->
+  <div class="{if $block.settings.default.container}container{/if}" style="{if isset($block.settings.padding_left) && $block.settings.padding_left}padding-left:{$block.settings.padding_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_right) && $block.settings.padding_right}padding-right:{$block.settings.padding_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_top) && $block.settings.padding_top}padding-top:{$block.settings.padding_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.padding_bottom) && $block.settings.padding_bottom}padding-bottom:{$block.settings.padding_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_left) && $block.settings.margin_left}margin-left:{$block.settings.margin_left|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_right) && $block.settings.margin_right}margin-right:{$block.settings.margin_right|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_top) && $block.settings.margin_top}margin-top:{$block.settings.margin_top|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.margin_bottom) && $block.settings.margin_bottom}margin-bottom:{$block.settings.margin_bottom|escape:'htmlall':'UTF-8'};{/if}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    {if $block.settings.default.container}
+        <div class="row">
+    {/if}
+        <div class="everblock-countdown d-flex justify-content-center {if $block.settings.css_class}{$block.settings.css_class|escape:'htmlall':'UTF-8'}{/if}" data-target="{$block.settings.target_date|escape:'htmlall':'UTF-8'}">
+            <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="days">00</span>
+                <span class="everblock-countdown-label">{l s='Days' mod='everblock'}</span>
+            </div>
+            <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="hours">00</span>
+                <span class="everblock-countdown-label">{l s='Hours' mod='everblock'}</span>
+            </div>
+            <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="minutes">00</span>
+                <span class="everblock-countdown-label">{l s='Minutes' mod='everblock'}</span>
+            </div>
+            <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="seconds">00</span>
+                <span class="everblock-countdown-label">{l s='Seconds' mod='everblock'}</span>
+            </div>
+        </div>
+    {if $block.settings.default.container}
+        </div>
+    {/if}
+  </div>
+  <!-- /Module Ever Block -->
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add countdown prettyblock with configurable target date
- style countdown display and update with JS
- add translations for countdown labels

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l translations/fr.php`
- `node --check views/js/everblock.js`


------
https://chatgpt.com/codex/tasks/task_e_68c428d2be2083229a611ef8fb978fae