### PR TITLE
chore: allow countdown prettyblock template

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -187,6 +187,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_category_price.tpl',
     'views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl',
     'views/templates/hook/prettyblocks/prettyblock_contact.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_countdown.tpl',
     'views/templates/hook/prettyblocks/prettyblock_counters.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cover.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cta.tpl',


### PR DESCRIPTION
## Summary
- allow prettyblock_countdown.tpl in allowed files list

## Testing
- `php -l config/allowed_files.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_68c42bdd730c83228631c4528866892a