### PR TITLE
feat: add special event prettyblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Ever Block includes a library of PrettyBlock blocks ready to use:
 - Downloads
 - Everblock content
 - Flash deals
+- Special event
 - Category products
 - Gallery
 - Google map

--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -222,6 +222,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_shortcode.tpl',
     'views/templates/hook/prettyblocks/prettyblock_social_links.tpl',
     'views/templates/hook/prettyblocks/prettyblock_spacer.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_special_event.tpl',
     'views/templates/hook/prettyblocks/prettyblock_tab.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial.tpl',
     'views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -91,6 +91,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $pricingTableTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl';
             $podcastsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_podcasts.tpl';
             $exitIntentTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl';
+            $specialEventTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_special_event.tpl';
             $defaultLogo = Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/' . $module->name . '/logo.png';
             $blocks = [];
             $allShortcodes = EverblockShortcode::getAllShortcodes(
@@ -4335,6 +4336,112 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Choose a product'),
                             'collection' => 'Product',
                             'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Special event'),
+                'description' => $module->l('Display a special event with countdown and CTA'),
+                'code' => 'everblock_special_event',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $specialEventTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Event',
+                    'nameFrom' => 'title',
+                    'groups' => [
+                        'title' => [
+                            'type' => 'editor',
+                            'label' => 'Title',
+                            'default' => $module->l('Winter sale'),
+                        ],
+                        'background_image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Background image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'cta_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('CTA Button Text'),
+                            'default' => $module->l('Shop now'),
+                        ],
+                        'cta_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('CTA Link'),
+                            'default' => '#',
+                        ],
+                        'target_date' => [
+                            'type' => 'text',
+                            'label' => $module->l('Target date (YYYY-MM-DD HH:MM:SS)'),
+                            'default' => '',
+                        ],
+                        'products_shortcode' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Products shortcode'),
+                            'default' => '',
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block background color'),
+                        ],
+                        'text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block text color'),
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                        'padding_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'padding_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Padding bottom (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_left' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_right' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_top' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
+                            'default' => '',
+                        ],
+                        'margin_bottom' => [
+                            'type' => 'text',
+                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
                             'default' => '',
                         ],
                     ],

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -467,6 +467,8 @@ $_MODULE['<{everblock}prestashop>everblockprettyblocks_e807d3ccf8d24c8c1a3d86db5
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_6a7e73161603d87b26a8eac49dab0a9c'] = 'Heures';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_f670ea66cfb0e90bd6090472ad692694'] = 'Minutes';
 $_MODULE['<{everblock}prestashop>everblockprettyblocks_8f19a8c7566af54ea8981029730e5465'] = 'Secondes';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_92fc8f3bed5eaf9a21d6854f189d7101'] = 'Événement spécial';
+$_MODULE['<{everblock}prestashop>everblockprettyblocks_6d4a459395e0afa84de9b398f128d130'] = 'Affiche un événement spécial avec compte à rebours et bouton d\'appel à l\'action';
 $_MODULE['<{everblock}prestashop>configure_621886d5d907cadfb35840e0bc9688d3'] = 'Qu\'est-ce qu\'un hook ?';
 $_MODULE['<{everblock}prestashop>configure_714f82bdd35410e27b403a7ed10fa67e'] = 'Un hook est un endroit où vous pouvez « greffer » un module. Très nombreux sur Prestashop, ils sont enregistrés dans votre base de données, et affichés par votre thème et vos modules.';
 $_MODULE['<{everblock}prestashop>configure_6c9cc2811d8dd20065be04ab58bbcaa7'] = 'Ces hooks sont disponibles à la fois sur votre site, mais aussi dans l\'administration de votre boutique.';

--- a/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
@@ -1,0 +1,66 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  {if isset($block.states) && $block.states}
+    {foreach from=$block.states item=state key=key}
+      <div id="block-{$block.id_prettyblocks}-{$key}" class="block-special-event col-12{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{if $state.padding_left}padding-left:{$state.padding_left};{/if}{if $state.padding_right}padding-right:{$state.padding_right};{/if}{if $state.padding_top}padding-top:{$state.padding_top};{/if}{if $state.padding_bottom}padding-bottom:{$state.padding_bottom};{/if}{if $state.margin_left}margin-left:{$state.margin_left};{/if}{if $state.margin_right}margin-right:{$state.margin_right};{/if}{if $state.margin_top}margin-top:{$state.margin_top};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom};{/if}{if isset($state.background_image.url) && $state.background_image.url}background-image:url('{$state.background_image.url|escape:'htmlall'}');background-size:cover;background-position:center;{/if}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+        <div class="d-flex flex-column align-items-center justify-content-center text-center h-100 w-100" style="z-index:1;">
+          {if $state.title}
+            <h2 class="mb-3" style="{if $state.text_color}color:{$state.text_color}!important;{/if}">{$state.title nofilter}</h2>
+          {/if}
+          {if $state.cta_link && $state.cta_text}
+            <a href="{$state.cta_link|escape:'htmlall'}" class="btn btn-primary mb-3">{$state.cta_text nofilter}</a>
+          {/if}
+          {if $state.target_date}
+            <div class="everblock-countdown d-flex justify-content-center" data-target="{$state.target_date|escape:'htmlall'}">
+              <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="days">00</span>
+                <span class="everblock-countdown-label">{l s='Days' mod='everblock'}</span>
+              </div>
+              <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="hours">00</span>
+                <span class="everblock-countdown-label">{l s='Hours' mod='everblock'}</span>
+              </div>
+              <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="minutes">00</span>
+                <span class="everblock-countdown-label">{l s='Minutes' mod='everblock'}</span>
+              </div>
+              <div class="mx-2 text-center">
+                <span class="everblock-countdown-value" data-type="seconds">00</span>
+                <span class="everblock-countdown-label">{l s='Seconds' mod='everblock'}</span>
+              </div>
+            </div>
+          {/if}
+          {if $state.products_shortcode}
+            <div class="mt-3 w-100">
+              {$state.products_shortcode nofilter}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/foreach}
+  {/if}
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add special event PrettyBlocks template with image, countdown, CTA and optional products
- register special event block and translations

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `php -l translations/fr.php`


------
https://chatgpt.com/codex/tasks/task_e_68c42f281ef08322abda0792378a7ea5