### PR TITLE
Allow Special Event block to render products by IDs

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4382,9 +4382,9 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Target date (YYYY-MM-DD HH:MM:SS)'),
                             'default' => '',
                         ],
-                        'products_shortcode' => [
-                            'type' => 'editor',
-                            'label' => $module->l('Products shortcode'),
+                        'product_ids' => [
+                            'type' => 'text',
+                            'label' => $module->l('Product IDs'),
                             'default' => '',
                         ],
                         'background_color' => [

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -691,6 +691,7 @@ $_MODULE['<{everblock}prestashop>everblock_video_description'] = 'Description';
 $_MODULE['<{everblock}prestashop>everblock_video_products'] = 'Vidéos produits';
 $_MODULE['<{everblock}prestashop>everblock_video_products_desc'] = 'Afficher des vidéos avec les produits associés';
 $_MODULE['<{everblock}prestashop>everblock_video_product_ids'] = 'IDs produits';
+$_MODULE['<{everblock}prestashop>everblock_special_event_product_ids'] = 'IDs produits';
 $_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Compteurs';
 $_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Afficher des compteurs animés';
 $_MODULE['<{everblock}prestashop>everblock_689202409e48743b914713f96d93947c'] = 'Valeur';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -43,6 +43,7 @@ $_MODULE['<{everblock}prestashop>everblock_video_description'] = 'Description';
 $_MODULE['<{everblock}prestashop>everblock_video_products'] = 'Product video gallery';
 $_MODULE['<{everblock}prestashop>everblock_video_products_desc'] = 'Display videos with related products';
 $_MODULE['<{everblock}prestashop>everblock_video_product_ids'] = 'Product IDs';
+$_MODULE['<{everblock}prestashop>everblock_special_event_product_ids'] = 'Product IDs';
 $_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Counters';
 $_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Display animated counters';
 $_MODULE['<{everblock}prestashop>everblock_689202409e48743b914713f96d93947c'] = 'Value';

--- a/translations/it.php
+++ b/translations/it.php
@@ -43,6 +43,7 @@ $_MODULE['<{everblock}prestashop>everblock_video_description'] = 'Descrizione';
 $_MODULE['<{everblock}prestashop>everblock_video_products'] = 'Galleria video prodotti';
 $_MODULE['<{everblock}prestashop>everblock_video_products_desc'] = 'Mostra video con prodotti correlati';
 $_MODULE['<{everblock}prestashop>everblock_video_product_ids'] = 'ID prodotto';
+$_MODULE['<{everblock}prestashop>everblock_special_event_product_ids'] = 'ID prodotto';
 $_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Contatori';
 $_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Visualizza contatori animati';
 $_MODULE['<{everblock}prestashop>everblock_689202409e48743b914713f96d93947c'] = 'Valore';

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -43,6 +43,7 @@ $_MODULE['<{everblock}prestashop>everblock_video_description'] = 'Beschrijving';
 $_MODULE['<{everblock}prestashop>everblock_video_products'] = 'Productvideogalerij';
 $_MODULE['<{everblock}prestashop>everblock_video_products_desc'] = 'Toon video\'s met gerelateerde producten';
 $_MODULE['<{everblock}prestashop>everblock_video_product_ids'] = 'Product-ID\'s';
+$_MODULE['<{everblock}prestashop>everblock_special_event_product_ids'] = 'Product-ID\'s';
 $_MODULE['<{everblock}prestashop>everblock_6d934d434a35ece59d870a44263a20d6'] = 'Tellers';
 $_MODULE['<{everblock}prestashop>everblock_799eb0fc8f8786f7e3bb9b8228d19eca'] = 'Geanimeerde tellers weergeven';
 $_MODULE['<{everblock}prestashop>everblock_689202409e48743b914713f96d93947c'] = 'Waarde';

--- a/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
@@ -51,9 +51,9 @@
               </div>
             </div>
           {/if}
-          {if $state.products_shortcode}
+          {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
             <div class="mt-3 w-100">
-              {$state.products_shortcode nofilter}
+              {include file="module:everblock/views/templates/hook/ever_presented_products.tpl" everPresentProducts=$block.extra.products[$key] shortcodeClass='special-event-products'}
             </div>
           {/if}
         </div>


### PR DESCRIPTION
## Summary
- replace Special Event block shortcode field with product IDs input
- render event products via new hook using presented products
- add translation entries for product ID label
- register module to new `beforeRenderingEverblockSpecialEvent` hook during install and hook checks

## Testing
- `php -l everblock.php`


------
https://chatgpt.com/codex/tasks/task_e_68c432cfba208322abbd601cb6b5b010