### PR TITLE
Add guided selector PrettyBlock

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -214,6 +214,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_podcasts.tpl',
     'views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl',
     'views/templates/hook/prettyblocks/prettyblock_product_selector.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl',
     'views/templates/hook/prettyblocks/prettyblock_progressbar.tpl',
     'views/templates/hook/prettyblocks/prettyblock_reassurance.tpl',
     'views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl',

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -75,6 +75,7 @@ class EverblockPrettyBlocks extends ObjectModel
             $brandListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_brands.tpl';
             $productHighlightTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl';
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
+            $guidedSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl';
             $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
             $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
             $progressbarTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_progressbar.tpl';
@@ -4337,6 +4338,45 @@ class EverblockPrettyBlocks extends ObjectModel
                             'collection' => 'Product',
                             'selector' => '{id} - {name}',
                             'default' => '',
+                        ],
+                    ],
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Guided product selector'),
+                'description' => $module->l('Ask a few questions and redirect to a matching category'),
+                'code' => 'everblock_guided_selector',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $guidedSelectorTemplate,
+                ],
+                'repeater' => [
+                    'name' => 'Question',
+                    'nameFrom' => 'question',
+                    'groups' => [
+                        'question' => [
+                            'type' => 'text',
+                            'label' => $module->l('Question'),
+                            'default' => '',
+                        ],
+                        'answers' => [
+                            'type' => 'repeater',
+                            'name' => 'Answer',
+                            'nameFrom' => 'text',
+                            'groups' => [
+                                'text' => [
+                                    'type' => 'text',
+                                    'label' => $module->l('Answer label'),
+                                    'default' => '',
+                                ],
+                                'link' => [
+                                    'type' => 'text',
+                                    'label' => $module->l('Answer link'),
+                                    'default' => '',
+                                ],
+                            ],
                         ],
                     ],
                 ],

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -341,6 +341,30 @@ $(document).ready(function(){
         });
     });
 
+    // Guided product selector
+    var guidedSelections = {};
+    $(document).on('click', '.everblock-guided-step .guided-answer', function () {
+        var $btn = $(this);
+        var $step = $btn.closest('.everblock-guided-step');
+        var key = $step.data('question');
+        var value = $btn.data('value');
+        if (key && value) {
+            guidedSelections[key] = value;
+        }
+        var url = $btn.data('url');
+        if (url) {
+            var query = $.param(guidedSelections);
+            var separator = url.indexOf('?') === -1 ? '?' : '&';
+            window.location.href = url + (query ? separator + query : '');
+            return;
+        }
+        var $next = $step.nextAll('.everblock-guided-step').first();
+        if ($next.length) {
+            $step.addClass('d-none');
+            $next.removeClass('d-none');
+        }
+    });
+
     // Flash deals countdown
     $('.flash-deals-wrapper').each(function() {
         var $wrapper = $(this);

--- a/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
@@ -1,0 +1,43 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+    <div class="{if $block.settings.default.container}container{/if}">
+      {foreach from=$block.states item=state name=questions}
+        {assign var=questionKey value=$state.question|link_rewrite}
+        <div id="guided-step-{$block.id_prettyblocks}-{$smarty.foreach.questions.index}" class="everblock-guided-step{if !$smarty.foreach.questions.first} d-none{/if}" data-question="{$questionKey|escape:'htmlall':'UTF-8'}">
+          <p class="guided-question">{$state.question|escape:'htmlall':'UTF-8'}</p>
+          <div class="guided-answers">
+            {foreach from=$state.answers item=answer}
+              {if $answer.text}
+                {assign var=answerValue value=$answer.text|link_rewrite}
+                <button type="button" class="btn btn-primary guided-answer" data-value="{$answerValue|escape:'htmlall':'UTF-8'}"{if $answer.link} data-url="{$answer.link|escape:'htmlall':'UTF-8'}"{/if}>{$answer.text|escape:'htmlall':'UTF-8'}</button>
+              {/if}
+            {/foreach}
+          </div>
+        </div>
+      {/foreach}
+    </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add guided product selector PrettyBlock with nested repeater for unlimited questions and answers
- allow new template in configuration
- move guided selector logic to jQuery in everblock.js instead of inline script
- build final redirect URL from selected answers

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `php -l config/allowed_files.php`
- `node --check views/js/everblock.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c43627d16483228666cd7e4435b8de