### PR TITLE
Fix store locator day index for correct open status

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3128,7 +3128,7 @@ class EverblockTools extends ObjectModel
                 $timezone = Configuration::get('PS_TIMEZONE');
             }
             $now = new \DateTime('now', new \DateTimeZone($timezone));
-            $todayIndex = (int) $now->format('w'); // 0 = dimanche
+            $todayIndex = (int) $now->format('N') - 1; // 0 = lundi
             $currentTime = $now->format('H:i');
             $todayDate = $now->format('Y-m-d');
             $frenchHolidays = self::getFrenchHolidays((int) $now->format('Y'));


### PR DESCRIPTION
## Summary
- fix store locator showing closed for open stores by aligning day index with Monday-first hours

## Testing
- `php -l models/EverblockTools.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68c54f4c37ec8322899650b3bb0e89e1