### PR TITLE
Refactor guided selector block

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -4205,6 +4205,37 @@ class Everblock extends Module
         return ['deals' => $deals];
     }
 
+    public function hookBeforeRenderingEverblockGuidedSelector($params)
+    {
+        $states = $params['block']['states'] ?? [];
+
+        foreach ($states as &$state) {
+            $question = isset($state['question']) ? trim($state['question']) : '';
+            $state['question'] = $question;
+            $state['key'] = Tools::link_rewrite($question);
+
+            $answers = [];
+            $lines = preg_split("/(\r\n|\r|\n)/", $state['answers'] ?? '');
+            foreach ($lines as $line) {
+                $parts = explode('|', $line);
+                $text = trim($parts[0] ?? '');
+                if ($text === '') {
+                    continue;
+                }
+                $link = trim($parts[1] ?? '');
+                $answers[] = [
+                    'text' => $text,
+                    'link' => $link,
+                    'value' => Tools::link_rewrite($text),
+                ];
+            }
+            $state['answers'] = $answers;
+        }
+        unset($state);
+
+        return ['states' => $states];
+    }
+
     public function hookBeforeRenderingEverblockLookbook($params)
     {
         return [];

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4352,6 +4352,15 @@ class EverblockPrettyBlocks extends ObjectModel
                 'templates' => [
                     'default' => $guidedSelectorTemplate,
                 ],
+                'config' => [
+                    'fields' => [
+                        'fallback_shortcode' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Fallback content (shortcodes allowed)'),
+                            'default' => '[evercontactform_open][evercontact type="text" label="' . $module->l('Your name') . '"][evercontact type="email" label="' . $module->l('Your email') . '"][evercontact type="textarea" label="' . $module->l('Message') . '"][evercontact type="submit" label="' . $module->l('Send') . '"][evercontactform_close]',
+                        ],
+                    ],
+                ],
                 'repeater' => [
                     'name' => 'Question',
                     'nameFrom' => 'question',
@@ -4362,21 +4371,9 @@ class EverblockPrettyBlocks extends ObjectModel
                             'default' => '',
                         ],
                         'answers' => [
-                            'type' => 'repeater',
-                            'name' => 'Answer',
-                            'nameFrom' => 'text',
-                            'groups' => [
-                                'text' => [
-                                    'type' => 'text',
-                                    'label' => $module->l('Answer label'),
-                                    'default' => '',
-                                ],
-                                'link' => [
-                                    'type' => 'text',
-                                    'label' => $module->l('Answer link'),
-                                    'default' => '',
-                                ],
-                            ],
+                            'type' => 'textarea',
+                            'label' => $module->l('Answers (one per line: "Answer label|Answer link")'),
+                            'default' => '',
                         ],
                     ],
                 ],

--- a/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
@@ -22,20 +22,37 @@
     <div class="row">
   {/if}
     <div class="{if $block.settings.default.container}container{/if}">
-      {foreach from=$block.states item=state name=questions}
-        {assign var=questionKey value=$state.question|link_rewrite}
-        <div id="guided-step-{$block.id_prettyblocks}-{$smarty.foreach.questions.index}" class="everblock-guided-step{if !$smarty.foreach.questions.first} d-none{/if}" data-question="{$questionKey|escape:'htmlall':'UTF-8'}">
+      {assign var=totalSteps value=$block.extra.states|@count}
+      {if $totalSteps}
+      <div class="everblock-guided-progress mb-3">
+        <div class="progress">
+          <div class="progress-bar" role="progressbar" style="width:0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="{$totalSteps}"></div>
+        </div>
+        <div class="progress-counter text-end mt-1">0/{$totalSteps}</div>
+      </div>
+      {/if}
+      {foreach from=$block.extra.states item=state name=questions}
+        <div id="guided-step-{$block.id_prettyblocks}-{$smarty.foreach.questions.index}" class="everblock-guided-step{if !$smarty.foreach.questions.first} d-none{/if}" data-question="{$state.key|escape:'htmlall':'UTF-8'}">
           <p class="guided-question">{$state.question|escape:'htmlall':'UTF-8'}</p>
           <div class="guided-answers">
             {foreach from=$state.answers item=answer}
-              {if $answer.text}
-                {assign var=answerValue value=$answer.text|link_rewrite}
-                <button type="button" class="btn btn-primary guided-answer" data-value="{$answerValue|escape:'htmlall':'UTF-8'}"{if $answer.link} data-url="{$answer.link|escape:'htmlall':'UTF-8'}"{/if}>{$answer.text|escape:'htmlall':'UTF-8'}</button>
-              {/if}
+              <button type="button" class="btn btn-primary guided-answer" data-value="{$answer.value|escape:'htmlall':'UTF-8'}"{if $answer.link} data-url="{$answer.link|escape:'htmlall':'UTF-8'}"{/if}>{$answer.text|escape:'htmlall':'UTF-8'}</button>
             {/foreach}
+          </div>
+          <div class="guided-nav mt-3">
+            <button type="button" class="btn btn-secondary guided-back d-none">{l s='Back' mod='everblock'}</button>
+            <button type="button" class="btn btn-link guided-restart">{l s='Restart' mod='everblock'}</button>
           </div>
         </div>
       {/foreach}
+      {if $block.settings.fallback_shortcode}
+        <div class="everblock-guided-fallback d-none">
+          {$block.settings.fallback_shortcode nofilter}
+          <div class="guided-nav mt-3">
+            <button type="button" class="btn btn-link guided-restart">{l s='Restart' mod='everblock'}</button>
+          </div>
+        </div>
+      {/if}
     </div>
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>


### PR DESCRIPTION
## Summary
- avoid nested repeaters in guided selector configuration
- generate URL-friendly keys without `link_rewrite` modifier
- remove unused guided selector action hook
- show contact form fallback when no answer links to a URL
- add progress indicator, back and restart navigation for guided selector
- display contact form fallback when the questionnaire has no steps or answers
- hide progress bar and skip division by zero when no steps exist

## Testing
- `composer validate --quiet`
- `php -l everblock.php`
- `php -l models/EverblockPrettyBlocks.php`
- `vendor/bin/phpstan analyse --no-progress --level 0` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4454c24c48322bb039dd95860b5bc