### PR TITLE
Fix wheel segment iteration when configuration isn't array

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -589,7 +589,8 @@ $(document).ready(function(){
                 config = {};
             }
         }
-        var segments = config.segments || [];
+        var segmentsData = config.segments || [];
+        var segments = Array.isArray(segmentsData) ? segmentsData : Object.values(segmentsData);
         var spinUrl = config.spinUrl || '';
         var token = config.token || '';
         var blockId = $container.data('block-id') || 0;


### PR DESCRIPTION
## Summary
- ensure Wheel of Fortune segments are converted to an array before drawing

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run` *(fails: No such file or directory)*
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f61f5ff483228631fdb82c27c5d0