### PR TITLE
Simplify holiday hours configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[category id="8" nb="8"]`: Display products from category ID 8. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
 - `[manufacturer id="2" nb="8"]`: Display products from manufacturer ID 2. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
 - `[brands nb="8" carousel=true]`: Display brand names with logos. Required parameter: `nb`. Optional parameter: `carousel`.
-- `[storelocator]`: Show a store locator on any CMS page when a Google Maps API key is configured. Opening hours accept patterns such as "10h - 12h / 14h - 18h" or "10h / 16h".
+ - `[storelocator]`: Show a store locator on any CMS page when a Google Maps API key is configured. Opening and holiday hours accept patterns such as "10h - 12h / 14h - 18h" or "10h / 16h".
 - `[evermap]`: Display a Google Map centered on the shop address when a Google Maps API key is configured.
 - `[subcategories id="2" nb="8"]`: Display subcategories of category 2. Parameters `id` and `nb` are required.
 - `[last-products nb="4" carousel=true]`: Display the last products listed in the store. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.

--- a/everblock.php
+++ b/everblock.php
@@ -1471,13 +1471,12 @@ class Everblock extends Module
                 foreach ($holidays as $date) {
                     $holidayInputs[] = [
                         'type' => 'text',
-                        'label' => sprintf($this->l('Opening hour for %s on %s'), $store['name'], $date),
-                        'name' => 'EVERBLOCK_OPEN_' . (int) $store['id_store'] . '_' . $date,
-                    ];
-                    $holidayInputs[] = [
-                        'type' => 'text',
-                        'label' => sprintf($this->l('Closing hour for %s on %s'), $store['name'], $date),
-                        'name' => 'EVERBLOCK_CLOSE_' . (int) $store['id_store'] . '_' . $date,
+                        'label' => sprintf(
+                            $this->l('Holiday hours for %s on %s'),
+                            $store['name'],
+                            $date
+                        ),
+                        'name' => 'EVERBLOCK_HOLIDAY_HOURS_' . (int) $store['id_store'] . '_' . $date,
                     ];
                 }
             }
@@ -1579,10 +1578,8 @@ class Everblock extends Module
         $holidays = EverblockTools::getFrenchHolidays((int) date('Y'));
         foreach ($stores as $store) {
             foreach ($holidays as $date) {
-                $openKey = 'EVERBLOCK_OPEN_' . (int) $store['id_store'] . '_' . $date;
-                $closeKey = 'EVERBLOCK_CLOSE_' . (int) $store['id_store'] . '_' . $date;
-                $configData[$openKey] = Configuration::get($openKey);
-                $configData[$closeKey] = Configuration::get($closeKey);
+                $hoursKey = 'EVERBLOCK_HOLIDAY_HOURS_' . (int) $store['id_store'] . '_' . $date;
+                $configData[$hoursKey] = Configuration::get($hoursKey);
             }
         }
         $configData = array_merge($configData, $bannedFeaturesColors);
@@ -1845,10 +1842,8 @@ class Everblock extends Module
         $holidays = EverblockTools::getFrenchHolidays((int) date('Y'));
         foreach ($stores as $store) {
             foreach ($holidays as $date) {
-                $openKey = 'EVERBLOCK_OPEN_' . (int) $store['id_store'] . '_' . $date;
-                $closeKey = 'EVERBLOCK_CLOSE_' . (int) $store['id_store'] . '_' . $date;
-                Configuration::updateValue($openKey, Tools::getValue($openKey));
-                Configuration::updateValue($closeKey, Tools::getValue($closeKey));
+                $hoursKey = 'EVERBLOCK_HOLIDAY_HOURS_' . (int) $store['id_store'] . '_' . $date;
+                Configuration::updateValue($hoursKey, Tools::getValue($hoursKey));
             }
         }
         Configuration::updateValue(

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3139,6 +3139,9 @@ class EverblockTools extends ObjectModel
             $cms_link = null;
             $storeHolidayHours = self::getStoreHolidayHoursConfig($id_store);
             $todayStoreHolidaySlot = $storeHolidayHours[$todayDate] ?? null;
+            if ($todayStoreHolidaySlot) {
+                $todayStoreHolidaySlot = trim($todayStoreHolidaySlot);
+            }
 
             if ($cms_id > 0) {
                 $cms = new CMS($cms_id, $id_lang, $storeShopId);
@@ -3299,12 +3302,10 @@ class EverblockTools extends ObjectModel
         $result = [];
         $holidays = self::getFrenchHolidays((int) date('Y'));
         foreach ($holidays as $date) {
-            $openKey = 'EVERBLOCK_OPEN_' . (int) $storeId . '_' . $date;
-            $closeKey = 'EVERBLOCK_CLOSE_' . (int) $storeId . '_' . $date;
-            $open = Configuration::get($openKey);
-            $close = Configuration::get($closeKey);
-            if ($open && $close) {
-                $result[$date] = trim($open) . ' - ' . trim($close);
+            $hoursKey = 'EVERBLOCK_HOLIDAY_HOURS_' . (int) $storeId . '_' . $date;
+            $hours = Configuration::get($hoursKey);
+            if ($hours) {
+                $result[$date] = trim($hours);
             }
         }
         return $result;


### PR DESCRIPTION
## Summary
- consolidate holiday opening and closing fields into single `EVERBLOCK_HOLIDAY_HOURS_*`
- read unified field in `getStoreHolidayHoursConfig`
- trim holiday slot patterns when building store locator data
- document that opening and holiday hours accept complex patterns

## Testing
- `php -l everblock.php`
- `php -l models/EverblockTools.php`
- `vendor/bin/phpstan analyse everblock.php models/EverblockTools.php` *(fails: vendor/bin/phpstan: No such file or directory)*
- `composer global require phpstan/phpstan` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2912324832280121ac6bf413b0a