### PR TITLE
Add customizable messages to Wheel of Fortune block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4850,6 +4850,21 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Button label'),
                             'default' => $module->l('Spin'),
                         ],
+                        'login_text' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Text above login form'),
+                            'default' => '',
+                        ],
+                        'top_text' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Text above the wheel'),
+                            'default' => '',
+                        ],
+                        'bottom_text' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Text below the wheel'),
+                            'default' => '',
+                        ],
                         'coupon_name' => [
                             'type' => 'text',
                             'label' => $module->l('Coupon name'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -797,3 +797,12 @@
     transform-origin: 50% 50%;
     display: block;
 }
+.ever-wheel-top-text,
+.ever-wheel-bottom-text,
+.ever-wheel-login-text {
+    margin-bottom: 1rem;
+}
+
+.ever-wheel-bottom-text {
+    margin-top: 1rem;
+}

--- a/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
@@ -35,11 +35,14 @@
         <div class="ever-wheel-of-fortune text-center" data-block-id="{$block.id_prettyblocks}" data-config="{$wheelConfig|json_encode|base64_encode|escape:'htmlall':'UTF-8'}">
             {if $block.settings.title}<h3>{$block.settings.title|escape:'htmlall':'UTF-8'}</h3>{/if}
             {if $customer.is_logged}
+                {if $block.settings.top_text}<div class="ever-wheel-top-text">{$block.settings.top_text nofilter}</div>{/if}
                 <canvas class="ever-wheel-canvas mb-3" style="width:100%;height:auto;"></canvas>
                 <button class="btn btn-primary ever-wheel-spin">{$block.settings.button_label|escape:'htmlall':'UTF-8'}</button>
+                {if $block.settings.bottom_text}<div class="ever-wheel-bottom-text">{$block.settings.bottom_text nofilter}</div>{/if}
             {else}
                 <div class="ever-wheel-forms mt-2 row justify-content-center">
                     <div class="col-md-5">
+                        {if $block.settings.login_text}<div class="ever-wheel-login-text mb-3">{$block.settings.login_text nofilter}</div>{/if}
                         <form action="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?back={$urls.current_url|escape:'htmlall':'UTF-8'}" method="post" class="card card-block ever-wheel-login-form">
                             <h4 class="card-title">{l s='Sign in to play' mod='everblock'}</h4>
                             <div class="card-body">


### PR DESCRIPTION
## Summary
- allow custom text above login form when user not connected
- add optional top/bottom messages around wheel when user is logged in
- style new message areas with basic margins
- switch custom texts to editor fields and render without escaping

## Testing
- `php -l models/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7c9895d508322a86a60797641f58d