### PR TITLE
Fix prettyblocks query in wheel controller

### DIFF
--- a/controllers/front/wheel.php
+++ b/controllers/front/wheel.php
@@ -56,7 +56,9 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 'message' => $this->module->l('You have already played', 'wheel'),
             ]));
         }
-        $row = Db::getInstance()->getRow('SELECT config, state FROM ' . _DB_PREFIX_ . 'prettyblocks WHERE id_prettyblocks = ' . $idBlock);
+        $idShop = (int) $this->context->shop->id;
+        $idLang = (int) $this->context->language->id;
+        $row = Db::getInstance()->getRow('SELECT config, state FROM ' . _DB_PREFIX_ . 'prettyblocks WHERE id_prettyblocks = ' . $idBlock . ' AND id_shop = ' . $idShop . ' AND id_lang = ' . $idLang);
         if (!$row) {
             die(json_encode([
                 'status' => false,

--- a/controllers/front/wheel.php
+++ b/controllers/front/wheel.php
@@ -56,14 +56,14 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 'message' => $this->module->l('You have already played', 'wheel'),
             ]));
         }
-        $row = Db::getInstance()->getRow('SELECT settings, state FROM ' . _DB_PREFIX_ . 'prettyblocks WHERE id_prettyblocks = ' . $idBlock);
+        $row = Db::getInstance()->getRow('SELECT config, state FROM ' . _DB_PREFIX_ . 'prettyblocks WHERE id_prettyblocks = ' . $idBlock);
         if (!$row) {
             die(json_encode([
                 'status' => false,
                 'message' => $this->module->l('Configuration not found', 'wheel'),
             ]));
         }
-        $settings = json_decode($row['settings'], true);
+        $settings = json_decode($row['config'], true);
         if (!is_array($settings)) {
             $settings = [];
         }


### PR DESCRIPTION
## Summary
- use `config` column instead of nonexistent `settings` in prettyblocks query

## Testing
- `php -l controllers/front/wheel.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c7cb4c05b88322aa893e80b72fc9a4