### PR TITLE
feat: show wheel labels with custom text color

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4950,6 +4950,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Color'),
                             'default' => '#ff0000',
                         ],
+                        'text_color' => [
+                            'type' => 'color',
+                            'label' => $module->l('Text color'),
+                            'default' => '#ffffff',
+                        ],
                         'discount' => [
                             'type' => 'text',
                             'label' => $module->l('Discount value'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -612,6 +612,21 @@ $(document).ready(function(){
                     ctx.arc(size, size, size, start, start + step);
                     ctx.lineTo(size, size);
                     ctx.fill();
+                    var textAngle = start + step / 2;
+                    var textRadius = size * 0.65;
+                    var textX = size + Math.cos(textAngle) * textRadius;
+                    var textY = size + Math.sin(textAngle) * textRadius;
+                    ctx.save();
+                    ctx.fillStyle = seg.text_color || '#ffffff';
+                    ctx.font = Math.max(12, size / 10) + 'px sans-serif';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    var label = seg.label;
+                    if (typeof label === 'object') {
+                        label = Object.values(label)[0] || '';
+                    }
+                    ctx.fillText(label || '', textX, textY);
+                    ctx.restore();
                     start += step;
                 });
             }


### PR DESCRIPTION
## Summary
- display segment labels on wheel of fortune
- allow per-segment label text color selection

## Testing
- `php -l models/EverblockPrettyBlocks.php`
- `node --check views/js/everblock.js`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0bb85d48322851b9c71ef44336d