### PR TITLE
Fix Bootstrap close buttons for wheel modals

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -652,13 +652,13 @@ $(document).ready(function(){
                             + '<div class="modal-dialog" role="document">'
                             + '<div class="modal-content">'
                             + '<div class="modal-header border-0">'
-                            + '<button type="button" class="close" data-dismiss="modal" aria-label="Close">'
+                            + '<button type="button" class="close btn-close" data-dismiss="modal" data-bs-dismiss="modal" aria-label="Close">'
                             + '<span aria-hidden="true">&times;</span>'
                             + '</button>'
                             + '</div>'
                             + '<div class="modal-body text-center">'
                             + '<p>' + msg + '</p>' + codeHtml
-                            + '<button type="button" class="btn btn-primary mt-3" data-dismiss="modal">OK</button>'
+                            + '<button type="button" class="btn btn-primary mt-3" data-dismiss="modal" data-bs-dismiss="modal">OK</button>'
                             + '</div></div></div></div>';
                         $('body').append(modal);
                         $('#everWheelModal').modal('show');


### PR DESCRIPTION
## Summary
- make wheel of fortune modal close button Bootstrap compliant

## Testing
- `node --check views/js/everblock.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d35a3ec88322953d654bfd006d72