### PR TITLE
Fix fortune wheel overflow by limiting height

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -795,6 +795,7 @@
     position: relative;
     display: inline-block;
     width: 100%;
+    max-width: 100vh;
 }
 
 .ever-wheel-canvas {
@@ -804,6 +805,8 @@
     display: block;
     width: 100%;
     height: auto;
+    max-width: 100vh;
+    max-height: 100vh;
 }
 
 .ever-wheel-arrow {

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -598,7 +598,7 @@ $(document).ready(function(){
             }
             var currentRotation = 0;
             function drawWheel() {
-                var dimension = $container.width();
+                var dimension = Math.min($container.width(), $(window).height());
                 $canvas.attr('width', dimension).attr('height', dimension);
                 var ctx = $canvas[0].getContext('2d');
                 ctx.clearRect(0, 0, dimension, dimension);


### PR DESCRIPTION
## Summary
- constrain fortune wheel rendering to viewport height
- scale drawing logic to respect screen height

## Testing
- `vendor/bin/phpstan analyse` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d5333aec83228062e3810485dce0