### PR TITLE
feat: handle winning state for wheel segments

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4965,6 +4965,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Category ID'),
                             'default' => '',
                         ],
+                        'isWinning' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Winning segment'),
+                            'default' => false,
+                        ],
                     ],
                 ],
             ];

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -680,18 +680,22 @@ $(document).ready(function(){
                                 }
                             }
                             var anglePerSegment = 360 / segments.length;
-                            var targetAngle = 270 - (idx * anglePerSegment + anglePerSegment / 2);
+                            var targetAngle = -90 - (idx * anglePerSegment + anglePerSegment / 2);
                             if (targetAngle < 0) {
                                 targetAngle += 360;
                             }
                             currentRotation += 360 * 5 + targetAngle;
                             $canvas.css('transform', 'rotate(' + currentRotation + 'deg)');
                             $canvas.one('transitionend', function () {
-                                showWheelModal(msg, res.code);
+                                var isWinning = res.result && (res.result.isWinning || res.result.is_winning);
+                                var code = isWinning ? res.code : null;
+                                showWheelModal(msg, code);
                                 $btn.prop('disabled', false);
                             });
                         } else {
-                            showWheelModal(msg, res.code);
+                            var isWinning = res.result && (res.result.isWinning || res.result.is_winning);
+                            var code = isWinning ? res.code : null;
+                            showWheelModal(msg, code);
                             $btn.prop('disabled', false);
                         }
                     },


### PR DESCRIPTION
## Summary
- allow wheel segments to specify `isWinning`
- validate probability sum and generate coupon only for winning draws
- compute wheel rotation from a fixed top pointer and hide codes when losing

## Testing
- `php -l controllers/front/wheel.php`
- `php -l models/EverblockPrettyBlocks.php`
- `node --check views/js/everblock.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7d842d8ac8322a4016692819fd735