### PR TITLE
Fix fortune wheel arrow and label orientation

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -818,7 +818,7 @@
     height: 0;
     border-left: 15px solid transparent;
     border-right: 15px solid transparent;
-    border-bottom: 30px solid #333;
+    border-top: 30px solid #333;
     z-index: 10;
     pointer-events: none;
 }

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -625,7 +625,12 @@ $(document).ready(function(){
                     if (typeof label === 'object') {
                         label = Object.values(label)[0] || '';
                     }
-                    ctx.fillText(label || '', textX, textY);
+                    ctx.translate(textX, textY);
+                    ctx.rotate(textAngle + Math.PI / 2);
+                    if (textAngle > Math.PI / 2 && textAngle < 3 * Math.PI / 2) {
+                        ctx.rotate(Math.PI);
+                    }
+                    ctx.fillText(label || '', 0, 0);
                     ctx.restore();
                     start += step;
                 });


### PR DESCRIPTION
## Summary
- Correct fortune wheel pointer to face downward
- Rotate wheel-of-fortune labels to match segment orientation

## Testing
- `node --check views/js/everblock.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7db3147b88322ac250733fcee009c