### PR TITLE
Fix wheel win detection for string values

### DIFF
--- a/controllers/front/wheel.php
+++ b/controllers/front/wheel.php
@@ -101,7 +101,7 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
             $segment['probability'] = $prob;
             $segment['discount'] = isset($segment['discount']) ? (float) $segment['discount'] : 0;
             $segment['id_categories'] = array_map('intval', (array) ($segment['id_categories'] ?? []));
-            $segment['isWinning'] = isset($segment['isWinning']) ? (bool) $segment['isWinning'] : false;
+            $segment['isWinning'] = filter_var($segment['isWinning'] ?? false, FILTER_VALIDATE_BOOLEAN);
             $total += $prob;
         }
         unset($segment);
@@ -133,7 +133,7 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 $resultLabel = (string) $result['label'];
             }
         }
-        $isWinning = !empty($result['isWinning']);
+        $isWinning = filter_var($result['isWinning'] ?? false, FILTER_VALIDATE_BOOLEAN);
         $code = null;
         if ($isWinning) {
             $code = $prefix . Tools::strtoupper(Tools::passwdGen(8));


### PR DESCRIPTION
## Summary
- normalise wheel segment configuration so `isWinning` honours boolean string values like "false"
- ensure win detection reuses the boolean parsing to avoid awarding prizes to losing segments

## Testing
- php -l controllers/front/wheel.php

------
https://chatgpt.com/codex/tasks/task_e_68c8458d1bc483229515ca404300a69f