### PR TITLE
Add winner limit handling to wheel of fortune block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4795,6 +4795,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Coupon validity in days'),
                             'default' => '30',
                         ],
+                        'max_winners' => [
+                            'type' => 'number',
+                            'label' => $module->l('Maximum winners (0 for unlimited)'),
+                            'default' => '0',
+                        ],
                         'coupon_type' => [
                             'type' => 'select',
                             'label' => $module->l('Discount type'),

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -4110,6 +4110,25 @@ class EverblockTools extends ObjectModel
                 }
             }
         }
+        // Ajoute les colonnes manquantes à la table everblock_game_play
+        $columnsToAdd = [
+            'id_prettyblocks' => 'int(10) unsigned NOT NULL',
+            'id_customer' => 'int(10) unsigned NOT NULL',
+            'result' => 'varchar(255) DEFAULT NULL',
+            'is_winner' => 'TINYINT(1) NOT NULL DEFAULT 0',
+            'date_add' => 'DATETIME DEFAULT NULL',
+        ];
+        foreach ($columnsToAdd as $columnName => $columnDefinition) {
+            $columnExists = $db->ExecuteS('DESCRIBE `' . _DB_PREFIX_ . 'everblock_game_play` `' . pSQL($columnName) . '`');
+            if (!$columnExists) {
+                try {
+                    $query = 'ALTER TABLE `' . _DB_PREFIX_ . 'everblock_game_play` ADD `' . pSQL($columnName) . '` ' . $columnDefinition;
+                    $db->execute($query);
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('Unable to update Ever Block game play database');
+                }
+            }
+        }
         static::cleanObsoleteFiles();
     }
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -156,6 +156,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_game_play` (
         `id_prettyblocks` int(10) unsigned NOT NULL,
         `id_customer` int(10) unsigned NOT NULL,
         `result` varchar(255) DEFAULT NULL,
+        `is_winner` TINYINT(1) NOT NULL DEFAULT 0,
         `date_add` DATETIME DEFAULT NULL,
         PRIMARY KEY (`id_everblock_game_play`))
         ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';


### PR DESCRIPTION
## Summary
- add a max_winners configuration option to the wheel of fortune block
- track winner plays in the database and prevent voucher creation once the cap is reached

## Testing
- php -l models/EverblockPrettyBlocks.php
- php -l sql/install.php
- php -l models/EverblockTools.php
- php -l controllers/front/wheel.php

------
https://chatgpt.com/codex/tasks/task_e_68c925f0b24c8322ae4a890fec17cf2e