### PR TITLE
Allow store locator hours to accept long dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can create your own shortcodes from the "Shortcodes" tab accessible in the "
 - `[category id="8" nb="8"]`: Display products from category ID 8. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
 - `[manufacturer id="2" nb="8"]`: Display products from manufacturer ID 2. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
 - `[brands nb="8" carousel=true]`: Display brand names with logos. Required parameter: `nb`. Optional parameter: `carousel`.
- - `[storelocator]`: Show a store locator on any CMS page when a Google Maps API key is configured. Opening and holiday hours accept patterns such as "10h - 12h / 14h - 18h" or "10h / 16h".
+- `[storelocator]`: Show a store locator on any CMS page when a Google Maps API key is configured. Opening and holiday hours accept patterns such as "10h - 12h / 14h - 18h" (simple hyphen) or "10h – 12h / 14h – 18h" (en dash), as well as "10h / 16h".
 - `[evermap]`: Display a Google Map centered on the shop address when a Google Maps API key is configured.
 - `[subcategories id="2" nb="8"]`: Display subcategories of category 2. Parameters `id` and `nb` are required.
 - `[last-products nb="4" carousel=true]`: Display the last products listed in the store. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -3174,10 +3174,12 @@ class EverblockTools extends ObjectModel
 
                     // Plusieurs créneaux ? → on découpe
                     // Patterns autorisés :
-                    //   - "10h - 12h" (plage unique)
+                    //   - "10h - 12h" ou "10h – 12h" (plage unique)
                     //   - "10h - 12h / 14h - 18h" (plages multiples)
                     //   - "10h / 16h" (début et fin séparés par un slash)
+                    $normalizedSlot = self::normalizeDashes($slot);
                     $subSlots = explode(' / ', $slot);
+                    $normalizedSubSlots = explode(' / ', $normalizedSlot);
 
                     foreach ($subSlots as $subSlot) {
                         $hoursFormatted[] = trim($subSlot);
@@ -3185,9 +3187,9 @@ class EverblockTools extends ObjectModel
 
                     if (($i === $todayIndex) && (!$isHoliday || $todayStoreHolidaySlot)) {
                         $rangeHandled = false;
-                        foreach ($subSlots as $subSlot) {
-                            if (strpos($subSlot, '-') !== false) {
-                                $parts = preg_split('/\s*-\s*/', $subSlot);
+                        foreach ($normalizedSubSlots as $normalizedSubSlot) {
+                            if (strpos($normalizedSubSlot, '-') !== false) {
+                                $parts = preg_split('/\s*-\s*/', $normalizedSubSlot);
                                 $startRaw = $parts[0] ?? '';
                                 $endRaw = $parts[1] ?? '';
                                 $start = self::normalizeTime($startRaw);
@@ -3206,9 +3208,9 @@ class EverblockTools extends ObjectModel
                             }
                         }
 
-                        if (!$rangeHandled && count($subSlots) === 2) {
-                            $start = self::normalizeTime($subSlots[0]);
-                            $end = self::normalizeTime($subSlots[1]);
+                        if (!$rangeHandled && count($normalizedSubSlots) === 2) {
+                            $start = self::normalizeTime($normalizedSubSlots[0]);
+                            $end = self::normalizeTime($normalizedSubSlots[1]);
                             if ($start && $end) {
                                 if ($currentTime >= $start && $currentTime <= $end) {
                                     $store['is_open'] = true;
@@ -3270,6 +3272,17 @@ class EverblockTools extends ObjectModel
         }
 
         return null;
+    }
+
+    protected static function normalizeDashes($value)
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        $result = preg_replace('/[\x{2010}-\x{2015}\x{2212}]/u', '-', $value);
+
+        return is_string($result) ? $result : $value;
     }
 
 


### PR DESCRIPTION
## Summary
- normalize store locator hour slots so unicode dash characters are treated like simple hyphens
- use the normalized values when computing store opening status for the locator
- document that store locator hours accept either hyphen-minus or en dash separators

## Testing
- php -l models/EverblockTools.php

------
https://chatgpt.com/codex/tasks/task_e_68c9277d57c48322b950038eb06bb6b8