### PR TITLE
Make wheel of fortune labels vertical

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -662,15 +662,14 @@ $(document).ready(function(){
                     }
                     label = label || '';
                     ctx.translate(textX, textY);
-                    ctx.rotate(textAngle + Math.PI / 2);
-                    if (textAngle > Math.PI / 2 && textAngle < 3 * Math.PI / 2) {
-                        ctx.rotate(Math.PI);
-                    }
                     var letters = label.split('');
-                    var startY = -((letters.length - 1) * fontSize) / 2;
-                    letters.forEach(function (ch, idx) {
-                        ctx.fillText(ch, 0, startY + idx * fontSize);
-                    });
+                    if (letters.length) {
+                        var lineHeight = fontSize * 1.1;
+                        var startY = -((letters.length - 1) * lineHeight) / 2;
+                        letters.forEach(function (ch, idx) {
+                            ctx.fillText(ch, 0, startY + idx * lineHeight);
+                        });
+                    }
                     ctx.restore();
                     segmentCenters[i] = textAngle * 180 / Math.PI;
                     start += step;


### PR DESCRIPTION
## Summary
- update the wheel drawing script to render segment labels as a vertical column without rotating the text
- ensure each label is spaced using a consistent line height for better readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c929fb00a88322932862bde6ba3dcb