### PR TITLE
Make wheel coupon settings segment-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This module is compatible with the Pretty Blocks page builder. [Find this free m
 ### Wheel of fortune segments
 Segments for the wheel now accept an array of category IDs through the `id_categories` field. Use this to restrict generated coupons to one or more categories. The former `id_category` field is deprecated.
 
+Each segment also includes its own promo-code settings (name, prefix, validity, discount type and winner cap). Legacy blocks that only defined these values at the block level keep working because the segment settings fall back to the parent configuration when left empty.
+
 In the PrettyBlocks cover block, you can choose Bootstrap button classes, including outline variants:
 
 <button type="button" class="btn btn-outline-primary">Primary</button> 

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4780,35 +4780,6 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Text below the wheel'),
                             'default' => '',
                         ],
-                        'coupon_name' => [
-                            'type' => 'text',
-                            'label' => $module->l('Coupon name'),
-                            'default' => $module->l('Wheel reward'),
-                        ],
-                        'coupon_prefix' => [
-                            'type' => 'text',
-                            'label' => $module->l('Coupon code prefix'),
-                            'default' => 'WHEEL',
-                        ],
-                        'coupon_validity' => [
-                            'type' => 'number',
-                            'label' => $module->l('Coupon validity in days'),
-                            'default' => '30',
-                        ],
-                        'max_winners' => [
-                            'type' => 'number',
-                            'label' => $module->l('Maximum winners (0 for unlimited)'),
-                            'default' => '0',
-                        ],
-                        'coupon_type' => [
-                            'type' => 'select',
-                            'label' => $module->l('Discount type'),
-                            'default' => 'percent',
-                            'choices' => [
-                                'percent' => $module->l('Percent'),
-                                'amount' => $module->l('Amount'),
-                            ],
-                        ],
                         'padding_left' => [
                             'type' => 'text',
                             'label' => $module->l('Padding left (Please specify the unit of measurement)'),
@@ -4879,6 +4850,35 @@ class EverblockPrettyBlocks extends ObjectModel
                             'type' => 'text',
                             'label' => $module->l('Discount value'),
                             'default' => '10',
+                        ],
+                        'coupon_name' => [
+                            'type' => 'text',
+                            'label' => $module->l('Coupon name'),
+                            'default' => $module->l('Wheel reward'),
+                        ],
+                        'coupon_prefix' => [
+                            'type' => 'text',
+                            'label' => $module->l('Coupon code prefix'),
+                            'default' => 'WHEEL',
+                        ],
+                        'coupon_validity' => [
+                            'type' => 'number',
+                            'label' => $module->l('Coupon validity in days'),
+                            'default' => '30',
+                        ],
+                        'max_winners' => [
+                            'type' => 'number',
+                            'label' => $module->l('Maximum winners for this segment (0 for unlimited)'),
+                            'default' => '0',
+                        ],
+                        'coupon_type' => [
+                            'type' => 'select',
+                            'label' => $module->l('Discount type'),
+                            'default' => 'percent',
+                            'choices' => [
+                                'percent' => $module->l('Percent'),
+                                'amount' => $module->l('Amount'),
+                            ],
                         ],
                         'id_categories' => [
                             'type' => 'selector',


### PR DESCRIPTION
## Summary
- move the Wheel of fortune coupon configuration from the block-level fields to each segment repeater entry
- adjust the wheel controller so every spin uses the segment-specific coupon settings with legacy block values as fallbacks, including per-segment winner limits
- document the new per-segment promo configuration in the README

## Testing
- php -l controllers/front/wheel.php
- php -l models/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68c93567b6e48322acd3dab5c85e1352