### PR TITLE
feat: add minimum purchase requirement to wheel rewards

### DIFF
--- a/controllers/front/wheel.php
+++ b/controllers/front/wheel.php
@@ -159,6 +159,10 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
             $prob = isset($segment['probability']) ? (float) $segment['probability'] : 1;
             $segment['probability'] = $prob;
             $segment['discount'] = isset($segment['discount']) ? (float) $segment['discount'] : 0;
+            $segment['minimum_purchase'] = isset($segment['minimum_purchase']) ? (float) $segment['minimum_purchase'] : 0;
+            if ($segment['minimum_purchase'] < 0) {
+                $segment['minimum_purchase'] = 0;
+            }
             $segment['id_categories'] = array_map('intval', (array) ($segment['id_categories'] ?? []));
             $segment['isWinning'] = filter_var($segment['isWinning'] ?? false, FILTER_VALIDATE_BOOLEAN);
             $total += $prob;
@@ -250,6 +254,11 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 $segmentMaxWinners = 0;
             }
         }
+        $segmentMinimumPurchase = isset($result['minimum_purchase']) ? (float) $result['minimum_purchase'] : 0;
+        if ($segmentMinimumPurchase < 0) {
+            $segmentMinimumPurchase = 0;
+        }
+        $segmentMinimumPurchase = (float) Tools::ps_round($segmentMinimumPurchase, 2);
         $useSegmentLimit = $segmentMaxWinners !== null;
         $maxWinners = $useSegmentLimit ? $segmentMaxWinners : $defaultMaxWinners;
         if ($maxWinners < 0) {
@@ -279,14 +288,27 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 $rewardsDepleted = true;
             }
         }
+        $currency = $this->context->currency;
+        if (!Validate::isLoadedObject($currency)) {
+            $defaultCurrencyId = (int) Configuration::get('PS_CURRENCY_DEFAULT', null, null, $idShop);
+            if (!$defaultCurrencyId) {
+                $defaultCurrencyId = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+            }
+            if ($defaultCurrencyId) {
+                $currency = new Currency($defaultCurrencyId);
+            }
+        }
+        $isCurrencyValid = Validate::isLoadedObject($currency);
+        $currencyId = $isCurrencyValid ? (int) $currency->id : 0;
+        $priceCurrency = $isCurrencyValid ? $currency : null;
         $result['isWinning'] = $isWinning;
         $code = null;
-        $categoryNames = [];
+        $displayCategoryNames = [];
         if ($isWinning) {
             $code = $prefix . Tools::strtoupper(Tools::passwdGen(8));
             $voucher = new CartRule();
-            foreach (Language::getIDs(false) as $idLang) {
-                $voucher->name[(int) $idLang] = $couponName;
+            foreach (Language::getIDs(false) as $langId) {
+                $voucher->name[(int) $langId] = $couponName;
             }
             $voucher->code = $code;
             $voucher->id_customer = (int) $this->context->customer->id;
@@ -300,17 +322,49 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
             } else {
                 $voucher->reduction_percent = isset($result['discount']) ? (float) $result['discount'] : 10;
             }
+            $voucher->minimum_amount = $segmentMinimumPurchase;
+            $voucher->minimum_amount_tax = $segmentMinimumPurchase > 0 ? 1 : 0;
+            $voucher->minimum_amount_currency = $currencyId;
+            $voucher->minimum_amount_shipping = 0;
             $voucher->active = 1;
             $voucher->add();
             $idCategories = array_map('intval', (array) ($result['id_categories'] ?? []));
-            $categoryNames = [];
             if (!empty($idCategories)) {
                 $validCategoryIds = [];
+                $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY', null, null, $idShop);
+                if (!$rootCategoryId) {
+                    $rootCategoryId = 1;
+                }
+                $groupRestrictionsActive = method_exists('Group', 'isFeatureActive') ? Group::isFeatureActive() : false;
+                $customerGroupIds = [];
+                if ($groupRestrictionsActive && method_exists('Group', 'getCustomerGroups')) {
+                    $customerGroupIds = Group::getCustomerGroups($idCustomer);
+                    if (!is_array($customerGroupIds)) {
+                        $customerGroupIds = [];
+                    }
+                }
+                $groupIdList = implode(',', array_map('intval', $customerGroupIds));
                 foreach ($idCategories as $idCategory) {
                     $category = new Category($idCategory, $idLang, $idShop);
                     if (Validate::isLoadedObject($category) && $category->active && $category->isAssociatedToShop($idShop)) {
                         $validCategoryIds[] = $idCategory;
-                        $categoryNames[] = $category->name;
+                        $isRootCategory = (int) $category->id_parent === 0 || (int) $category->id === $rootCategoryId;
+                        if (!$isRootCategory) {
+                            $hasAccess = true;
+                            if ($groupRestrictionsActive) {
+                                if (method_exists($category, 'checkAccess')) {
+                                    $hasAccess = (bool) $category->checkAccess($idCustomer);
+                                } elseif (!empty($groupIdList)) {
+                                    $hasAccess = (bool) Db::getInstance()->getValue(
+                                        'SELECT 1 FROM ' . _DB_PREFIX_ . 'category_group WHERE id_category = ' . (int) $idCategory
+                                        . ' AND id_group IN (' . $groupIdList . ')'
+                                    );
+                                }
+                            }
+                            if ($hasAccess) {
+                                $displayCategoryNames[] = $category->name;
+                            }
+                        }
                     }
                 }
                 if (!empty($validCategoryIds)) {
@@ -348,8 +402,14 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
                 : $this->module->l('You lost:', 'wheel') . ' ' . htmlspecialchars($resultLabel, ENT_QUOTES, 'UTF-8');
         }
         $categoriesMessage = '';
-        if (!empty($categoryNames)) {
-            $categoriesMessage = $this->module->l('Valid for categories:', 'wheel') . ' ' . implode(', ', $categoryNames);
+        if (!empty($displayCategoryNames)) {
+            $uniqueCategoryNames = array_values(array_unique($displayCategoryNames));
+            $categoriesMessage = $this->module->l('Valid for categories:', 'wheel') . ' ' . implode(', ', $uniqueCategoryNames);
+        }
+        $minimumPurchaseMessage = '';
+        if ($segmentMinimumPurchase > 0) {
+            $minimumPurchaseMessage = $this->module->l('Minimum purchase (tax incl.):', 'wheel') . ' '
+                . Tools::displayPrice($segmentMinimumPurchase, $priceCurrency);
         }
         die(json_encode([
             'status' => true,
@@ -358,6 +418,7 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
             'code' => $code,
             'message' => $message,
             'categories_message' => $categoriesMessage,
+            'minimum_purchase_message' => $minimumPurchaseMessage,
         ]));
     }
 

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4866,6 +4866,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Coupon validity in days'),
                             'default' => '30',
                         ],
+                        'minimum_purchase' => [
+                            'type' => 'text',
+                            'label' => $module->l('Minimum purchase amount (tax incl.)'),
+                            'default' => '',
+                        ],
                         'max_winners' => [
                             'type' => 'number',
                             'label' => $module->l('Maximum winners for this segment (0 for unlimited)'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -820,7 +820,7 @@ $(document).ready(function(){
                 return;
             }
 
-            function showWheelModal(msg, code, categories) {
+            function showWheelModal(msg, code, details) {
                 var codeHtml = '';
                 if (code) {
                     codeHtml = '<div class="ever-wheel-code-wrapper">'
@@ -829,9 +829,18 @@ $(document).ready(function(){
                         + '<span class="ever-wheel-copy-feedback ms-2 text-success" style="display:none;"></span>'
                         + '</div>';
                 }
-                var categoriesHtml = '';
-                if (categories) {
-                    categoriesHtml = '<p class="ever-wheel-categories">' + categories + '</p>';
+                var detailsHtml = '';
+                if (Array.isArray(details)) {
+                    var filteredDetails = details.filter(function (item) {
+                        return typeof item === 'string' && item.trim().length;
+                    });
+                    if (filteredDetails.length) {
+                        detailsHtml = filteredDetails.map(function (item) {
+                            return '<p class="ever-wheel-detail">' + item + '</p>';
+                        }).join('');
+                    }
+                } else if (details) {
+                    detailsHtml = '<p class="ever-wheel-detail">' + details + '</p>';
                 }
                 $('#everWheelModal').remove();
                 var modal = '<div class="modal fade" id="everWheelModal" tabindex="-1" role="dialog">'
@@ -843,7 +852,7 @@ $(document).ready(function(){
                     + '</button>'
                     + '</div>'
                     + '<div class="modal-body text-center">'
-                    + '<p>' + msg + '</p>' + codeHtml + categoriesHtml
+                    + '<p>' + msg + '</p>' + codeHtml + detailsHtml
                     + '<button type="button" class="btn btn-primary mt-3" data-dismiss="modal" data-bs-dismiss="modal">OK</button>'
                     + '</div></div></div></div>';
                 $('body').append(modal);
@@ -898,15 +907,31 @@ $(document).ready(function(){
                             $canvas.one('transitionend', function () {
                                 var isWinning = res.result && (res.result.isWinning || res.result.is_winning);
                                 var code = isWinning ? res.code : null;
-                                var categories = isWinning ? res.categories_message : '';
-                                showWheelModal(msg, code, categories);
+                                var details = [];
+                                if (isWinning) {
+                                    if (res.categories_message) {
+                                        details.push(res.categories_message);
+                                    }
+                                    if (res.minimum_purchase_message) {
+                                        details.push(res.minimum_purchase_message);
+                                    }
+                                }
+                                showWheelModal(msg, code, details);
                                 $btn.prop('disabled', false);
                             });
                         } else {
                             var isWinning = res.result && (res.result.isWinning || res.result.is_winning);
                             var code = isWinning ? res.code : null;
-                            var categories = isWinning ? res.categories_message : '';
-                            showWheelModal(msg, code, categories);
+                            var details = [];
+                            if (isWinning) {
+                                if (res.categories_message) {
+                                    details.push(res.categories_message);
+                                }
+                                if (res.minimum_purchase_message) {
+                                    details.push(res.minimum_purchase_message);
+                                }
+                            }
+                            showWheelModal(msg, code, details);
                             $btn.prop('disabled', false);
                         }
                     },


### PR DESCRIPTION
## Summary
- allow configuring a minimum purchase amount per wheel segment in PrettyBlocks
- enforce the configured minimum on generated vouchers and surface it in the confirmation modal
- show only accessible category restrictions in the modal alongside the minimum purchase reminder

## Testing
- php -l controllers/front/wheel.php
- php -l models/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68c93eae39b88322a3071e7926c26a51