### PR TITLE
Enforce single wheel play per household

### DIFF
--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -4127,6 +4127,7 @@ class EverblockTools extends ObjectModel
         $columnsToAdd = [
             'id_prettyblocks' => 'int(10) unsigned NOT NULL',
             'id_customer' => 'int(10) unsigned NOT NULL',
+            'ip_address' => 'varchar(45) DEFAULT NULL',
             'result' => 'varchar(255) DEFAULT NULL',
             'is_winner' => 'TINYINT(1) NOT NULL DEFAULT 0',
             'date_add' => 'DATETIME DEFAULT NULL',

--- a/sql/install.php
+++ b/sql/install.php
@@ -155,6 +155,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_game_play` (
         `id_everblock_game_play` int(10) unsigned NOT NULL auto_increment,
         `id_prettyblocks` int(10) unsigned NOT NULL,
         `id_customer` int(10) unsigned NOT NULL,
+        `ip_address` varchar(45) DEFAULT NULL,
         `result` varchar(255) DEFAULT NULL,
         `is_winner` TINYINT(1) NOT NULL DEFAULT 0,
         `date_add` DATETIME DEFAULT NULL,


### PR DESCRIPTION
## Summary
- record the player IP when running the wheel game and reject further attempts from the same IP with a single-household message
- extend the everblock_game_play table definition and migration helper to store the recorded IP address

## Testing
- php -l controllers/front/wheel.php
- php -l models/EverblockTools.php
- php -l sql/install.php

------
https://chatgpt.com/codex/tasks/task_e_68c942f721408322b2bf78d8ac2e4b39