### PR TITLE
Add scheduling controls to Wheel of Fortune block

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3490,10 +3490,22 @@ class Everblock extends Module
                 'modal'
             )
         );
+        $employeeLogged = false;
+        if (isset($this->context->employee) && $this->context->employee) {
+            if (method_exists($this->context->employee, 'isLoggedBack')) {
+                $employeeLogged = (bool) $this->context->employee->isLoggedBack();
+            }
+            if (!$employeeLogged && (int) $this->context->employee->id > 0) {
+                $employeeLogged = true;
+            }
+        }
+        $this->context->smarty->assign('everblock_is_employee', $employeeLogged);
+
         Media::addJsDef([
             'evercontact_link' => $contactLink,
             'evermodal_link' => $modalLink,
             'everblock_token' => Tools::getToken(),
+            'everblock_is_employee' => $employeeLogged,
         ]);
         $filePath = _PS_MODULE_DIR_ . $this->name . '/views/js/header-scripts-' . $this->context->shop->id . '.js';
         if (file_exists($filePath) && filesize($filePath) > 0) {

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -4780,6 +4780,26 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Text below the wheel'),
                             'default' => '',
                         ],
+                        'start_date' => [
+                            'type' => 'text',
+                            'label' => $module->l('Game start date (YYYY-MM-DD HH:MM:SS)'),
+                            'default' => '',
+                        ],
+                        'end_date' => [
+                            'type' => 'text',
+                            'label' => $module->l('Game end date (YYYY-MM-DD HH:MM:SS)'),
+                            'default' => '',
+                        ],
+                        'pre_start_message' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Message before the game starts'),
+                            'default' => '',
+                        ],
+                        'post_end_message' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Message after the game ends'),
+                            'default' => '',
+                        ],
                         'padding_left' => [
                             'type' => 'text',
                             'label' => $module->l('Padding left (Please specify the unit of measurement)'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -830,3 +830,22 @@
 .ever-wheel-bottom-text {
     margin-top: 1rem;
 }
+
+.ever-wheel-status-message {
+    display: none;
+    margin-bottom: 1.5rem;
+}
+
+.ever-wheel-status-text > :last-child {
+    margin-bottom: 0;
+}
+
+.ever-wheel-countdown {
+    display: none;
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+
+.ever-wheel-countdown-label {
+    margin-right: 0.35rem;
+}

--- a/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
@@ -16,6 +16,17 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {assign var=wheelSegments value=$block.states|default:[]}
+{assign var=isEmployee value=false}
+{if isset($everblock_is_employee) && $everblock_is_employee}
+    {assign var=isEmployee value=true}
+{/if}
+{capture assign=preStartMessageHtml}{$block.settings.pre_start_message nofilter}{/capture}
+{capture assign=postEndMessageHtml}{$block.settings.post_end_message nofilter}{/capture}
+{assign var=startDate value=$block.settings.start_date|default:''}
+{assign var=endDate value=$block.settings.end_date|default:''}
+{capture assign=defaultPreStartMessage}{l s='The game has not started yet.' mod='everblock'}{/capture}
+{capture assign=defaultPostEndMessage}{l s='The game is over.' mod='everblock'}{/capture}
+{capture assign=countdownLabel}{l s='Game starts in:' mod='everblock'}{/capture}
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
@@ -30,59 +41,76 @@
         {assign var=wheelConfig value=[
             'segments' => $wheelSegments,
             'spinUrl' => $link->getModuleLink('everblock','wheel'),
-            'token' => $static_token
+            'token' => $static_token,
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+            'preStartMessage' => $preStartMessageHtml,
+            'postEndMessage' => $postEndMessageHtml,
+            'defaultPreStartMessage' => $defaultPreStartMessage,
+            'defaultPostEndMessage' => $defaultPostEndMessage,
+            'countdownLabel' => $countdownLabel,
+            'isEmployee' => $isEmployee
         ]}
         <div class="ever-wheel-of-fortune text-center" data-block-id="{$block.id_prettyblocks}" data-config="{$wheelConfig|json_encode|base64_encode|escape:'htmlall':'UTF-8'}">
             {if $block.settings.title}<h3>{$block.settings.title|escape:'htmlall':'UTF-8'}</h3>{/if}
-            {if $customer.is_logged}
-                {if $block.settings.top_text}<div class="ever-wheel-top-text mb-4">{$block.settings.top_text nofilter}</div>{/if}
-                <div class="ever-wheel-wrapper mb-4 mt-4">
-                    <canvas class="ever-wheel-canvas"></canvas>
-                    <div class="ever-wheel-arrow"></div>
+            <div class="ever-wheel-status-message" style="display:none;">
+                <div class="ever-wheel-status-text"></div>
+                <div class="ever-wheel-countdown" style="display:none;">
+                    <span class="ever-wheel-countdown-label">{$countdownLabel|escape:'htmlall':'UTF-8'}</span>
+                    <span class="ever-wheel-countdown-value"></span>
                 </div>
-                <div class="ever-wheel-spin-container">
-                    <button class="btn btn-primary ever-wheel-spin">{$block.settings.button_label|escape:'htmlall':'UTF-8'}</button>
-                </div>
-                {if $block.settings.bottom_text}<div class="ever-wheel-bottom-text">{$block.settings.bottom_text nofilter}</div>{/if}
-            {else}
-                {if $block.settings.top_text}<div class="ever-wheel-top-text mb-4">{$block.settings.top_text nofilter}</div>{/if}
-                <div class="ever-wheel-wrapper mb-4 mt-4 ever-wheel-disabled" style="filter: grayscale(100%);opacity:0.5;pointer-events:none;">
-                    <canvas class="ever-wheel-canvas"></canvas>
-                    <div class="ever-wheel-arrow"></div>
-                </div>
-                <div class="ever-wheel-spin-container">
-                    <button class="btn btn-primary ever-wheel-login-btn">{l s='Connectez-vous pour jouer' mod='everblock'}</button>
-                </div>
-                {if $block.settings.bottom_text}<div class="ever-wheel-bottom-text">{$block.settings.bottom_text nofilter}</div>{/if}
-                <div class="modal fade" id="everWheelLoginModal" tabindex="-1" aria-hidden="true">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title">{l s='Connexion' mod='everblock'}</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' mod='everblock'}"></button>
-                            </div>
-                            <div class="modal-body">
-                                <form action="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?back={$urls.current_url|escape:'htmlall':'UTF-8'}" method="post" class="ever-wheel-login-form">
-                                    <div class="form-group">
-                                        <label for="ever-wheel-login-email">{l s='Email' mod='everblock'}</label>
-                                        <input id="ever-wheel-login-email" class="form-control" type="email" name="email" required>
+            </div>
+            <div class="ever-wheel-content">
+                {if $customer.is_logged}
+                    {if $block.settings.top_text}<div class="ever-wheel-top-text mb-4">{$block.settings.top_text nofilter}</div>{/if}
+                    <div class="ever-wheel-wrapper mb-4 mt-4">
+                        <canvas class="ever-wheel-canvas"></canvas>
+                        <div class="ever-wheel-arrow"></div>
+                    </div>
+                    <div class="ever-wheel-spin-container">
+                        <button class="btn btn-primary ever-wheel-spin">{$block.settings.button_label|escape:'htmlall':'UTF-8'}</button>
+                    </div>
+                    {if $block.settings.bottom_text}<div class="ever-wheel-bottom-text">{$block.settings.bottom_text nofilter}</div>{/if}
+                {else}
+                    {if $block.settings.top_text}<div class="ever-wheel-top-text mb-4">{$block.settings.top_text nofilter}</div>{/if}
+                    <div class="ever-wheel-wrapper mb-4 mt-4 ever-wheel-disabled" style="filter: grayscale(100%);opacity:0.5;pointer-events:none;">
+                        <canvas class="ever-wheel-canvas"></canvas>
+                        <div class="ever-wheel-arrow"></div>
+                    </div>
+                    <div class="ever-wheel-spin-container">
+                        <button class="btn btn-primary ever-wheel-login-btn">{l s='Connectez-vous pour jouer' mod='everblock'}</button>
+                    </div>
+                    {if $block.settings.bottom_text}<div class="ever-wheel-bottom-text">{$block.settings.bottom_text nofilter}</div>{/if}
+                    <div class="modal fade" id="everWheelLoginModal" tabindex="-1" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title">{l s='Connexion' mod='everblock'}</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' mod='everblock'}"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <form action="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?back={$urls.current_url|escape:'htmlall':'UTF-8'}" method="post" class="ever-wheel-login-form">
+                                        <div class="form-group">
+                                            <label for="ever-wheel-login-email">{l s='Email' mod='everblock'}</label>
+                                            <input id="ever-wheel-login-email" class="form-control" type="email" name="email" required>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="ever-wheel-login-password">{l s='Password' mod='everblock'}</label>
+                                            <input id="ever-wheel-login-password" class="form-control js-visible-password" type="password" name="password" required>
+                                        </div>
+                                        <input type="hidden" name="submitLogin" value="1">
+                                        <input type="hidden" name="back" value="{$urls.current_url|escape:'htmlall':'UTF-8'}">
+                                        <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
+                                    </form>
+                                    <div class="text-center mt-3">
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
-                                    <div class="form-group">
-                                        <label for="ever-wheel-login-password">{l s='Password' mod='everblock'}</label>
-                                        <input id="ever-wheel-login-password" class="form-control js-visible-password" type="password" name="password" required>
-                                    </div>
-                                    <input type="hidden" name="submitLogin" value="1">
-                                    <input type="hidden" name="back" value="{$urls.current_url|escape:'htmlall':'UTF-8'}">
-                                    <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
-                                </form>
-                                <div class="text-center mt-3">
-                                    <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            {/if}
+                {/if}
+            </div>
         </div>
     {if $block.settings.default.container}
         </div>


### PR DESCRIPTION
## Summary
- add start/end date and messaging fields to the wheel of fortune block configuration
- gate wheel access server- and client-side with employee bypass, countdown and status messaging
- surface employee status to templates and polish wheel status UI styles

## Testing
- php -l controllers/front/wheel.php
- php -l models/EverblockPrettyBlocks.php
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68c94484f1e48322b4fb1407d8105039