### PR TITLE
Respect server-provided wheel index

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -1209,20 +1209,8 @@ $(document).ready(function(){
                                 if (!isNaN(parsedIndex)) {
                                     if (parsedIndex >= 0 && parsedIndex < segments.length) {
                                         idx = parsedIndex;
-                                        if (normalizedSegments[idx] !== normalizedResult) {
-                                            if (parsedIndex > 0 && normalizedSegments[parsedIndex - 1] === normalizedResult) {
-                                                idx = parsedIndex - 1;
-                                            } else if (parsedIndex + 1 < normalizedSegments.length && normalizedSegments[parsedIndex + 1] === normalizedResult) {
-                                                idx = parsedIndex + 1;
-                                            } else {
-                                                idx = -1;
-                                            }
-                                        }
                                     } else if (parsedIndex > 0 && parsedIndex <= segments.length) {
-                                        var zeroBased = parsedIndex - 1;
-                                        if (normalizedSegments[zeroBased] === normalizedResult) {
-                                            idx = zeroBased;
-                                        }
+                                        idx = parsedIndex - 1;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- honor the server-provided wheel index when determining the wheel's final position
- fall back to the previous normalized segment lookup only if the provided index is invalid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5e767c488322ac5c351649504653