### PR TITLE
Allow configurable wheel pointer angle

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -896,7 +896,11 @@ $(document).ready(function(){
             }
             wheelInitialized = true;
             var currentRotation = 0;
-            var POINTER_ANGLE = 270;
+            var POINTER_ANGLE = parseInt($container.data('pointer-angle'), 10);
+            if (isNaN(POINTER_ANGLE)) {
+                POINTER_ANGLE = 270;
+            }
+            console.log('[Wheel Debug] Pointer angle used:', POINTER_ANGLE);
             var segmentCenters = [];
 
             function normalizeSegmentForComparison(value) {


### PR DESCRIPTION
## Summary
- read the pointer angle offset from the wheel container data attribute
- default the pointer angle to 270 degrees when the attribute is missing
- log the pointer angle used for easier debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca6ab362d08322bf868576f41315bb