### PR TITLE
Adjust wheel pointer alignment offset

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -1250,7 +1250,7 @@ $(document).ready(function(){
                                 center = 0;
                             }
                             var normalizedRotation = ((currentRotation % 360) + 360) % 360;
-                            var desiredAlignment = (POINTER_ANGLE - center + 360) % 360;
+                            var desiredAlignment = (POINTER_ANGLE - center - 90 + 360) % 360;
                             console.log('[Wheel Debug] Desired alignment:', desiredAlignment, 'Pointer angle:', POINTER_ANGLE);
                             var rotationDelta = (desiredAlignment - normalizedRotation + 360) % 360;
                             currentRotation += 360 * 5 + rotationDelta;


### PR DESCRIPTION
## Summary
- subtract 90 degrees when computing desired wheel alignment so the pointer at the top matches canvas orientation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca7e7fc67083228930188da84db1ca