### PR TITLE
Fix wheel index normalization in everblock.js

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -1230,8 +1230,12 @@ $(document).ready(function(){
                             var idx = -1;
                             if (typeof res.index !== 'undefined') {
                                 var parsedIndex = parseInt(res.index, 10);
-                                if (!isNaN(parsedIndex) && parsedIndex >= 0 && parsedIndex < segments.length) {
-                                    idx = parsedIndex;
+                                if (!isNaN(parsedIndex)) {
+                                    if (parsedIndex >= 0 && parsedIndex < segments.length) {
+                                        idx = parsedIndex;
+                                    } else if (parsedIndex === segments.length) {
+                                        idx = 0; // correction off-by-one
+                                    }
                                 }
                             }
                             if (idx === -1 && normalizedResult) {


### PR DESCRIPTION
## Summary
- ensure the wheel script normalizes the PHP-provided index and wraps segments.length to zero
- keep the existing debug logs so the corrected index can be validated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca7fcc68308322945bc81254679e50