### PR TITLE
Allow admin to bypass wheel IP restriction

### DIFF
--- a/controllers/front/wheel.php
+++ b/controllers/front/wheel.php
@@ -98,6 +98,10 @@ class EverblockWheelModuleFrontController extends ModuleFrontController
         $defaultPreStartMessage = $this->module->l('The game has not started yet.', 'wheel');
         $defaultPostEndMessage = $this->module->l('The game is over.', 'wheel');
         $employeeLogged = $this->isAdmin();
+        if ($employeeLogged) {
+            $already = false;
+            $ipAlready = false;
+        }
         $now = time();
         $startTimestamp = $this->parseDateTime($startDateValue);
         $endTimestamp = $this->parseDateTime($endDateValue);


### PR DESCRIPTION
## Summary
- allow employees logged into the back office to bypass duplicate play detection on the wheel by resetting prior play checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca84b0591883229101e6c36e5f7e11