### PR TITLE
Show completion message when countdown ends

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -3665,6 +3665,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Target date (YYYY-MM-DD HH:MM:SS)'),
                             'default' => '',
                         ],
+                        'completion_message' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Message displayed when the countdown ends'),
+                            'default' => '',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -546,12 +546,52 @@ $(document).ready(function(){
         if (!target) {
             return;
         }
-        function updateCountdown() {
-            var distance = new Date(target).getTime() - new Date().getTime();
-            if (distance <= 0) {
-                $block.find('.everblock-countdown-value').text('00');
+        var targetDate = new Date(target);
+        if (isNaN(targetDate.getTime())) {
+            return;
+        }
+        var $wrapper = $block.closest('.everblock-countdown-wrapper');
+        var $message = $wrapper.length ? $wrapper.find('.everblock-countdown-finished-message') : $();
+        var timerId = null;
+        var completionShown = false;
+
+        function showCompletion() {
+            if (completionShown) {
                 return;
             }
+            completionShown = true;
+            if ($message.length) {
+                $block.hide();
+                $message.removeClass('d-none').show();
+            }
+        }
+
+        function hideCompletion() {
+            if ($message.length) {
+                $block.show();
+                $message.addClass('d-none').hide();
+            }
+            completionShown = false;
+        }
+
+        function updateCountdown() {
+            var now = new Date();
+            var distance = targetDate.getTime() - now.getTime();
+            if (distance <= 0) {
+                $block.find('[data-type="days"]').text('00');
+                $block.find('[data-type="hours"]').text('00');
+                $block.find('[data-type="minutes"]').text('00');
+                $block.find('[data-type="seconds"]').text('00');
+                if (timerId !== null) {
+                    clearInterval(timerId);
+                    timerId = null;
+                }
+                showCompletion();
+                return false;
+            }
+
+            hideCompletion();
+
             var days = Math.floor(distance / (1000 * 60 * 60 * 24));
             var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
             var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
@@ -560,9 +600,14 @@ $(document).ready(function(){
             $block.find('[data-type="hours"]').text(('0' + hours).slice(-2));
             $block.find('[data-type="minutes"]').text(('0' + minutes).slice(-2));
             $block.find('[data-type="seconds"]').text(('0' + seconds).slice(-2));
+
+            return true;
         }
-        updateCountdown();
-        setInterval(updateCountdown, 1000);
+
+        var shouldContinue = updateCountdown();
+        if (shouldContinue !== false) {
+            timerId = setInterval(updateCountdown, 1000);
+        }
     });
 
     // Podcasts player

--- a/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
@@ -26,23 +26,30 @@
     {if $block.settings.default.container}
         <div class="row">
     {/if}
-        <div class="everblock-countdown d-flex justify-content-center {if $block.settings.css_class}{$block.settings.css_class|escape:'htmlall':'UTF-8'}{/if}" data-target="{$block.settings.target_date|escape:'htmlall':'UTF-8'}">
-            <div class="mx-2 text-center">
-                <span class="everblock-countdown-value" data-type="days">00</span>
-                <span class="everblock-countdown-label">{l s='Days' mod='everblock'}</span>
+        <div class="everblock-countdown-wrapper">
+            <div class="everblock-countdown d-flex justify-content-center {if $block.settings.css_class}{$block.settings.css_class|escape:'htmlall':'UTF-8'}{/if}" data-target="{$block.settings.target_date|escape:'htmlall':'UTF-8'}">
+                <div class="mx-2 text-center">
+                    <span class="everblock-countdown-value" data-type="days">00</span>
+                    <span class="everblock-countdown-label">{l s='Days' mod='everblock'}</span>
+                </div>
+                <div class="mx-2 text-center">
+                    <span class="everblock-countdown-value" data-type="hours">00</span>
+                    <span class="everblock-countdown-label">{l s='Hours' mod='everblock'}</span>
+                </div>
+                <div class="mx-2 text-center">
+                    <span class="everblock-countdown-value" data-type="minutes">00</span>
+                    <span class="everblock-countdown-label">{l s='Minutes' mod='everblock'}</span>
+                </div>
+                <div class="mx-2 text-center">
+                    <span class="everblock-countdown-value" data-type="seconds">00</span>
+                    <span class="everblock-countdown-label">{l s='Seconds' mod='everblock'}</span>
+                </div>
             </div>
-            <div class="mx-2 text-center">
-                <span class="everblock-countdown-value" data-type="hours">00</span>
-                <span class="everblock-countdown-label">{l s='Hours' mod='everblock'}</span>
-            </div>
-            <div class="mx-2 text-center">
-                <span class="everblock-countdown-value" data-type="minutes">00</span>
-                <span class="everblock-countdown-label">{l s='Minutes' mod='everblock'}</span>
-            </div>
-            <div class="mx-2 text-center">
-                <span class="everblock-countdown-value" data-type="seconds">00</span>
-                <span class="everblock-countdown-label">{l s='Seconds' mod='everblock'}</span>
-            </div>
+            {if $block.settings.completion_message}
+                <div class="everblock-countdown-finished-message d-none">
+                    {$block.settings.completion_message nofilter}
+                </div>
+            {/if}
         </div>
     {if $block.settings.default.container}
         </div>


### PR DESCRIPTION
## Summary
- add an editor-based completion message field to the countdown prettyblock
- render the optional completion message container in the countdown template
- update the countdown javascript to toggle the message when the timer finishes

## Testing
- php -l models/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68ca865d96dc8322b279562b18b350aa