### PR TITLE
Ensure slot machine vouchers have a name

### DIFF
--- a/controllers/front/slotmachine.php
+++ b/controllers/front/slotmachine.php
@@ -290,6 +290,10 @@ class EverblockSlotmachineModuleFrontController extends ModuleFrontController
                 $segmentMaxWinners = 0;
             }
             $segmentCouponName = (string) ($matchedCombination['coupon_name'] ?? $defaultCouponName);
+            $segmentCouponName = trim($segmentCouponName);
+            if ($segmentCouponName === '') {
+                $segmentCouponName = $defaultCouponName;
+            }
             $segmentCouponPrefix = (string) ($matchedCombination['coupon_prefix'] ?? $defaultCouponPrefix);
             $segmentCouponPrefix = preg_replace('/[^A-Z0-9]/', '', Tools::strtoupper($segmentCouponPrefix));
             if ($segmentCouponPrefix === null) {


### PR DESCRIPTION
## Summary
- trim slot machine combination coupon names and fall back to the default label when empty

## Testing
- php -l controllers/front/slotmachine.php

------
https://chatgpt.com/codex/tasks/task_e_68cbbbe66e008322a560751c13508c57