### PR TITLE
Add maintenance actions to Everblock console command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,18 @@ Run `php bin/console everblock:tools:execute --list` to display the maintenance 
 | `removeinlinecsstags` | Strip inline CSS | Removes inline style attributes from product descriptions. | `idshop` (optional) |
 | `droplogs` | Purge PrestaShop logs | Clears the native PrestaShop logs table. | — |
 | `refreshtokens` | Refresh Instagram token | Renews the Instagram token and clears the related cache. | — |
+| `fetchinstagramimages` | Download Instagram medias | Downloads configured Instagram media files and stores them locally. | — |
 | `securewithapache` | Protect module folders | Adds Apache rules to protect the module folders. | — |
 | `saveproducts` | Resave all products | Re-saves every product in the shop. | `idshop` (optional) |
+| `generateproducts` | Generate demo products | Creates dummy products with images for the selected shop. | `idshop` (optional) |
 | `webpprettyblock` | Convert Prettyblocks images to WebP | Converts every Prettyblock image to WebP. | — |
 | `removehn` | Replace Hn tags | Replaces Hn tags with paragraph elements carrying CSS classes. | `idshop` (optional) |
 | `duplicateblockslang` | Duplicate blocks between languages | Copies block content and custom code from one language to another. | `idshop` (optional), `fromlang` (required), `tolang` (required) |
 | `fetchwordpressposts` | Fetch WordPress posts | Fetches the configured WordPress posts. | — |
+| `checkdatabase` | Check module database | Installs missing tables and columns, removes obsolete files. | — |
+| `dropunusedlangs` | Drop unused languages | Removes orphan translations from core multilingual tables. | — |
+| `clearcache` | Clear PrestaShop cache | Flushes all native caches (Smarty, XML, filesystem). | — |
+| `warmup` | Warm front-office pages | Preloads the storefront for every active language. | `--url` (optional) |
 
 ## Shortcodes
 The module allows you to use many shortcodes anywhere in your store. However, restrictions may be in place, such as not allowing a hook shortcode or store locator to be used in a modal.
@@ -467,12 +473,18 @@ Exécutez `php bin/console everblock:tools:execute --list` pour afficher les act
 | `removeinlinecsstags` | Nettoyer le CSS inline | Supprime les attributs style des descriptions produit. | `idshop` (optionnel) |
 | `droplogs` | Purger les logs PrestaShop | Vide la table native des logs PrestaShop. | — |
 | `refreshtokens` | Rafraîchir le jeton Instagram | Renouvelle le jeton Instagram et vide le cache associé. | — |
+| `fetchinstagramimages` | Télécharger les médias Instagram | Télécharge les médias Instagram configurés et les stocke localement. | — |
 | `securewithapache` | Protéger les dossiers du module | Ajoute des règles Apache pour sécuriser les dossiers du module. | — |
 | `saveproducts` | Réenregistrer tous les produits | Réenregistre chaque produit de la boutique. | `idshop` (optionnel) |
+| `generateproducts` | Générer des produits de démonstration | Crée des produits factices avec images pour la boutique sélectionnée. | `idshop` (optionnel) |
 | `webpprettyblock` | Convertir les images Prettyblocks en WebP | Convertit toutes les images Prettyblock en WebP. | — |
 | `removehn` | Remplacer les balises Hn | Remplace les balises Hn par des paragraphes avec classes CSS. | `idshop` (optionnel) |
 | `duplicateblockslang` | Dupliquer les blocs entre langues | Copie le contenu et le code personnalisé d'une langue à l'autre. | `idshop` (optionnel), `fromlang` (obligatoire), `tolang` (obligatoire) |
 | `fetchwordpressposts` | Récupérer les articles WordPress | Récupère les articles WordPress configurés. | — |
+| `checkdatabase` | Vérifier la base du module | Installe les tables/colonnes manquantes et supprime les fichiers obsolètes. | — |
+| `dropunusedlangs` | Supprimer les langues inutilisées | Retire les traductions orphelines des tables multilingues natives. | — |
+| `clearcache` | Vider le cache PrestaShop | Vide tous les caches natifs (Smarty, XML, fichiers). | — |
+| `warmup` | Chauffer les pages front-office | Précharge le front-office pour chaque langue active. | `--url` (optionnel) |
 
 ## Shortcodes
 Le module vous permet d'utiliser de nombreux shortcodes partout dans votre boutique. Certaines restrictions peuvent s'appliquer, par exemple un hook ou un store locator ne peuvent pas être utilisés dans une modale.
@@ -686,12 +698,18 @@ Ejecuta `php bin/console everblock:tools:execute --list` para mostrar las accion
 | `removeinlinecsstags` | Limpiar CSS inline | Elimina los atributos style de las descripciones de producto. | `idshop` (opcional) |
 | `droplogs` | Purgar logs de PrestaShop | Vacía la tabla nativa de logs de PrestaShop. | — |
 | `refreshtokens` | Renovar token de Instagram | Renueva el token de Instagram y limpia la caché relacionada. | — |
+| `fetchinstagramimages` | Descargar medios de Instagram | Descarga los medios de Instagram configurados y los almacena localmente. | — |
 | `securewithapache` | Proteger carpetas del módulo | Añade reglas de Apache para proteger las carpetas del módulo. | — |
 | `saveproducts` | Volver a guardar todos los productos | Vuelve a guardar cada producto de la tienda. | `idshop` (opcional) |
+| `generateproducts` | Generar productos de demostración | Crea productos ficticios con imágenes para la tienda seleccionada. | `idshop` (opcional) |
 | `webpprettyblock` | Convertir imágenes Prettyblocks a WebP | Convierte todas las imágenes Prettyblock a WebP. | — |
 | `removehn` | Sustituir etiquetas Hn | Sustituye las etiquetas Hn por párrafos con clases CSS. | `idshop` (opcional) |
 | `duplicateblockslang` | Duplicar bloques entre idiomas | Copia el contenido y el código personalizado de un idioma a otro. | `idshop` (opcional), `fromlang` (obligatorio), `tolang` (obligatorio) |
 | `fetchwordpressposts` | Obtener entradas de WordPress | Recupera las entradas de WordPress configuradas. | — |
+| `checkdatabase` | Comprobar la base de datos del módulo | Instala tablas y columnas faltantes y elimina archivos obsoletos. | — |
+| `dropunusedlangs` | Eliminar idiomas sin uso | Elimina traducciones huérfanas de las tablas multilingües nativas. | — |
+| `clearcache` | Vaciar la caché de PrestaShop | Limpia todas las cachés nativas (Smarty, XML, archivos). | — |
+| `warmup` | Calentar páginas del front-office | Precarga el escaparate para cada idioma activo. | `--url` (opcional) |
 
 ## Shortcodes
 El módulo permite usar muchos shortcodes en cualquier lugar de la tienda. Pueden existir restricciones, por ejemplo un hook o un store locator no pueden usarse en una modal.
@@ -904,12 +922,18 @@ Esegui `php bin/console everblock:tools:execute --list` per visualizzare le azio
 | `removeinlinecsstags` | Pulire il CSS inline | Rimuove gli attributi style dalle descrizioni prodotto. | `idshop` (opzionale) |
 | `droplogs` | Svuotare i log di PrestaShop | Svuota la tabella nativa dei log di PrestaShop. | — |
 | `refreshtokens` | Rinnovare il token Instagram | Rinnova il token Instagram e svuota la cache collegata. | — |
+| `fetchinstagramimages` | Scaricare i media Instagram | Scarica i media Instagram configurati e li salva localmente. | — |
 | `securewithapache` | Proteggere le cartelle del modulo | Aggiunge regole Apache per proteggere le cartelle del modulo. | — |
 | `saveproducts` | Risalvare tutti i prodotti | Riesegue il salvataggio di ogni prodotto del negozio. | `idshop` (opzionale) |
+| `generateproducts` | Generare prodotti dimostrativi | Crea prodotti fittizi con immagini per il negozio selezionato. | `idshop` (opzionale) |
 | `webpprettyblock` | Convertire immagini Prettyblocks in WebP | Converte tutte le immagini Prettyblock in WebP. | — |
 | `removehn` | Sostituire i tag Hn | Sostituisce i tag Hn con paragrafi dotati di classi CSS. | `idshop` (opzionale) |
 | `duplicateblockslang` | Duplicare blocchi tra lingue | Copia contenuto e codice personalizzato da una lingua all'altra. | `idshop` (opzionale), `fromlang` (obbligatorio), `tolang` (obbligatorio) |
 | `fetchwordpressposts` | Recuperare articoli WordPress | Recupera gli articoli WordPress configurati. | — |
+| `checkdatabase` | Controllare il database del modulo | Installa tabelle e colonne mancanti ed elimina i file obsoleti. | — |
+| `dropunusedlangs` | Eliminare lingue inutilizzate | Rimuove le traduzioni orfane dalle tabelle multilingue native. | — |
+| `clearcache` | Svuotare la cache di PrestaShop | Svuota tutte le cache native (Smarty, XML, file). | — |
+| `warmup` | Scaldare le pagine del front-office | Precarica il front-office per ogni lingua attiva. | `--url` (opzionale) |
 
 ## Shortcode
 Il modulo consente di utilizzare molti shortcode in qualsiasi parte del negozio. Possono esserci restrizioni, ad esempio un hook o uno store locator non possono essere usati in una modale.


### PR DESCRIPTION
## Summary
- expose additional maintenance helpers through everblock:tools:execute, including database check, cache flush, language cleanup, Instagram sync, product generation, and front warmup
- add an optional --url flag for warmup and surface the new actions in the command help output
- document the extended action list in every README locale table

## Testing
- php -l src/Command/ExecuteAction.php

------
https://chatgpt.com/codex/tasks/task_e_68cc3a6dcfb88322813f5ccb5468178c