### PR TITLE
Use bootstrapFiles for PHPStan autoloader

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,5 +6,5 @@ parameters:
         - models
         - everblock.php
         - index.php
-    autoload_files:
+    bootstrapFiles:
         - vendor/autoload.php


### PR DESCRIPTION
## Summary
- replace the deprecated `autoload_files` setting in `phpstan.neon` with the modern `bootstrapFiles` key pointing to `vendor/autoload.php`

## Testing
- `php phpstan.phar analyse --no-progress --configuration=phpstan.neon` *(fails: Could not open input file: phpstan.phar)*

------
https://chatgpt.com/codex/tasks/task_e_68cd05e3dccc8322bbcc7ab42396ba27