### PR TITLE
Remove unused PrettyBlocks and Shortcode autoload mappings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,7 @@
   ],
   "autoload": {
     "psr-4": {
-      "Everblock\\Tools\\": "src/",
-      "Everblock\\PrettyBlocks\\": "src/PrettyBlocks/",
-      "Everblock\\Shortcode\\": "src/Shortcode/"
+      "Everblock\\Tools\\": "src/"
     },
     "exclude-from-classmap": []
   },
@@ -21,6 +19,6 @@
     "prepend-autoloader": false
   },
   "require": {
-      "php": ">=7.1"
+    "php": ">=7.1"
   }
 }


### PR DESCRIPTION
## Summary
- remove PrettyBlocks and Shortcode PSR-4 namespaces from Composer autoload configuration to retire those directories

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd12e25868832288ba3d3de10cda83