### PR TITLE
Add text color option to heading block

### DIFF
--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -490,6 +490,11 @@ class EverblockPrettyBlocks extends ObjectModel
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
+                        'text_color' => [
+                            'type' => 'color',
+                            'label' => $module->l('Text color'),
+                            'default' => '',
+                        ],
                         'padding_left' => [
                             'type' => 'text',
                             'label' => $module->l('Padding left (Please specify the unit of measurement)'),

--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -26,7 +26,7 @@
     {if $block.settings.default.container}
         <div class="row">
     {/if}
-        <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading {$block.settings.css_class|escape:'htmlall':'UTF-8'}">{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
+        <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if isset($block.settings.text_color) && $block.settings.text_color} style="color:{$block.settings.text_color|escape:'htmlall':'UTF-8'};"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
     {if $block.settings.default.container}
         </div>
     {/if}


### PR DESCRIPTION
## Summary
- add a text color configuration field to the Title block definition
- render the selected color on the heading element in the block template

## Testing
- php -l models/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68cd77ec81c08322a15cfbaa5a6c6226