### PR TITLE
Restructure admin configuration into requested tabs

### DIFF
--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -16,7 +16,21 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 
-<div class="alert alert-info">
+{include file='module:everblock/views/templates/admin/header.tpl'}
+
+{if isset($everblock_notifications) && $everblock_notifications}
+    {$everblock_notifications nofilter}
+{/if}
+
+{if isset($display_upgrade) && $display_upgrade}
+    {include file='module:everblock/views/templates/admin/upgrade.tpl'}
+{/if}
+
+{if isset($everblock_form)}
+    {$everblock_form nofilter}
+{/if}
+
+<div class="alert alert-info mt-4">
     <button class="btn btn-primary btn-lg mb-2" type="button" data-toggle="collapse" data-target="#instructionsContent" aria-expanded="false" aria-controls="instructionsContent">
         <i class="icon-info-circle"></i> {l s='Instructions' mod='everblock'}
     </button>
@@ -291,3 +305,5 @@
     <p>{l s='If you don\'t see your content or your content hasn\'t changed, make sure to clear your store\'s cache.' mod='everblock'}</p>
     <br>
 </div>
+
+{include file='module:everblock/views/templates/admin/footer.tpl'}

--- a/views/templates/admin/footer.tpl
+++ b/views/templates/admin/footer.tpl
@@ -35,15 +35,4 @@
             </a>
         {/if}
     </p>
-    {if isset($cron_links) && $cron_links}
-    <div class="panel">
-        <div class="row">
-            <div class="col-md-12 mt-3">
-                {foreach from=$cron_links key=action item=cron}
-                <a href="{$cron|escape:'htmlall':'UTF-8'}" class="btn btn-lg btn-info" target="_blank">{l s='Cron for' mod='everblock'} {$action}</a>
-                {/foreach}
-            </div>
-        </div>
-    </div>
-    {/if}
 </div>

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -25,18 +25,6 @@
             <img id="everlogotop" class="img-fluid" src="{$everblock_dir|escape:'htmlall':'UTF-8'}logo.png" alt="{l s='Ever Block logo' mod='everblock'}" style="max-width: 120px;" />
         </a>
         <p class="mt-2">{l s='Thanks for using Team Ever\'s modules' mod='everblock'}<br /></p>
-        {if isset($modules_list_link)}
-            <div class="everblock-anchor-links mt-2">
-                <a href="#everblock_tools" class="btn btn-default btn-sm">{l s='Tools' mod='everblock'}</a>
-                <a href="#everblock_settings" class="btn btn-default btn-sm">{l s='Settings' mod='everblock'}</a>
-                <a href="#everblock_instagram" class="btn btn-default btn-sm">{l s='Instagram' mod='everblock'}</a>
-                <a href="#everblock_file_management" class="btn btn-default btn-sm">{l s='File management' mod='everblock'}</a>
-                <a href="#everblock_import_html" class="btn btn-default btn-sm">{l s='Import HTML blocks' mod='everblock'}</a>
-                <a href="#everblock_feature_colors" class="btn btn-default btn-sm">{l s='Features colors' mod='everblock'}</a>
-                <a href="#everblock_soldout_colors" class="btn btn-default btn-sm">{l s='Sold out colors' mod='everblock'}</a>
-                <a href="#everblock_holiday" class="btn btn-default btn-sm">{l s='Holiday hours' mod='everblock'}</a>
-            </div>
-        {/if}
     </div>
     <div class="col-md-4 text-right mt-3">
         {if isset($modules_list_link)}


### PR DESCRIPTION
## Summary
- render the module configuration through the main template so header, upgrade panel and form share the same tabbed layout
- reorganize the helper form tabs into Réglages, Outils, Gestionnaire de fichiers, Flags, Prettyblock, Holiday opening hours and Tâches crons, trimming the HTML blocks import and surfacing cron links inside the form
- clean up legacy anchor buttons in the admin header and remove duplicated cron links from the footer

## Testing
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68ce6bbcfb5483228cb2bc5acf99a209