### PR TITLE
Check all groups by default for new blocks

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -1019,7 +1019,7 @@ class AdminEverBlockController extends ModuleAdminController
             }
             foreach ($groups as $group) {
                 $formValues[] = [
-                    'groupBox_' . $group['id_group'] => Tools::getValue('groupBox_' . $group['id_group'], false)
+                    'groupBox_' . $group['id_group'] => Tools::getValue('groupBox_' . $group['id_group'], true)
                 ];
             }
             $formValues[] = [


### PR DESCRIPTION
## Summary
- check every customer group by default in the block creation form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce6e25dd8883228b90bc877f739d9a