### PR TITLE
Refactor EverblockCache into namespaced service

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -67,7 +67,7 @@ return [
     'mails/uk/evercontact.html',
     'mails/uk/evercontact.txt',
     'mails/uk/index.php',
-    'models/EverblockCache.php',
+    'src/Service/EverblockCache.php',
     'models/EverblockCheckoutStep.php',
     'models/EverblockClass.php',
     'models/EverblockFaq.php',

--- a/everblock.php
+++ b/everblock.php
@@ -29,11 +29,11 @@ require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTabsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFlagsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockPrettyBlocks.php';
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockCache.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockCheckoutStep.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockModal.php';
 
 use \PrestaShop\PrestaShop\Core\Product\ProductPresenter;
+use Everblock\Tools\Service\EverblockCache;
 use Everblock\Tools\Service\ImportFile;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;

--- a/models/EverblockClass.php
+++ b/models/EverblockClass.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/models/EverblockFlagsClass.php
+++ b/models/EverblockFlagsClass.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/models/EverblockPrettyBlocks.php
+++ b/models/EverblockPrettyBlocks.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/models/EverblockShortcode.php
+++ b/models/EverblockShortcode.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -17,6 +17,8 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverblockCache;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }

--- a/src/Command/ExecuteAction.php
+++ b/src/Command/ExecuteAction.php
@@ -29,7 +29,7 @@ use Currency;
 use Db;
 use DbQuery;
 use Everblock\Tools\Service\ImportFile;
-use EverblockCache;
+use Everblock\Tools\Service\EverblockCache;
 use EverblockTools;
 use Language;
 use Module;

--- a/src/Service/EverblockCache.php
+++ b/src/Service/EverblockCache.php
@@ -17,11 +17,21 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+namespace Everblock\Tools\Service;
+
+use Cache;
+use Configuration;
+use Context;
+use Exception;
+use PrestaShopLogger;
+use Tools;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class EverblockCache extends ObjectModel
+class EverblockCache
 {
     protected const TTL = 86400; // 24 hours
     protected static function useNativeCache(): bool


### PR DESCRIPTION
## Summary
- move EverblockCache into the src/Service namespace and drop the ObjectModel inheritance
- update module, models, and command classes to import the namespaced EverblockCache service
- adjust configuration to allow the new file path and refresh Composer autoload metadata

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_e_68cfb58332cc8322a5a10ddb1b67b85f