### PR TITLE
Move EverblockPrettyBlocks service to PSR-4 namespace

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -73,7 +73,7 @@ return [
     'models/EverblockFaq.php',
     'models/EverblockFlagsClass.php',
     'models/EverblockModal.php',
-    'models/EverblockPrettyBlocks.php',
+    'src/Service/EverblockPrettyBlocks.php',
     'models/EverblockShortcode.php',
     'models/EverblockTabsClass.php',
     'models/EverblockTools.php',

--- a/everblock.php
+++ b/everblock.php
@@ -28,11 +28,11 @@ require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTabsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFlagsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockPrettyBlocks.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockCheckoutStep.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockModal.php';
 
 use \PrestaShop\PrestaShop\Core\Product\ProductPresenter;
+use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockCache;
 use Everblock\Tools\Service\ImportFile;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -17,13 +17,24 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+namespace Everblock\Tools\Service;
+
+use Configuration;
+use EverBlockClass;
 use Everblock\Tools\Service\EverblockCache;
+use EverblockShortcode;
+use EverblockTools;
+use Hook;
+use Module;
+use PrettyBlocksModel;
+use Tools;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class EverblockPrettyBlocks extends ObjectModel
+class EverblockPrettyBlocks
 {
     private const MEDIA_PATH = '$/img/cms/prettyblocks/';
 


### PR DESCRIPTION
## Summary
- move EverblockPrettyBlocks into the PSR-4 Service namespace and drop the ObjectModel inheritance
- import required dependencies and update consumers to rely on the namespaced class
- adjust allowed files configuration to match the new location

## Testing
- composer dump-autoload
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68cfb979c6008322b267461f96fa2744