### PR TITLE
Move checkout step to PSR-4 namespace

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -68,7 +68,7 @@ return [
     'mails/uk/evercontact.txt',
     'mails/uk/index.php',
     'src/Service/EverblockCache.php',
-    'models/EverblockCheckoutStep.php',
+    'src/Checkout/EverblockCheckoutStep.php',
     'models/EverblockClass.php',
     'models/EverblockFaq.php',
     'models/EverblockFlagsClass.php',

--- a/everblock.php
+++ b/everblock.php
@@ -28,10 +28,10 @@ require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTabsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFlagsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockCheckoutStep.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockModal.php';
 
 use \PrestaShop\PrestaShop\Core\Product\ProductPresenter;
+use Everblock\Tools\Checkout\EverblockCheckoutStep;
 use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockCache;
 use Everblock\Tools\Service\ImportFile;

--- a/src/Checkout/EverblockCheckoutStep.php
+++ b/src/Checkout/EverblockCheckoutStep.php
@@ -1,8 +1,5 @@
 <?php
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
 /**
  * 2019-2025 Team Ever
  *
@@ -21,7 +18,18 @@ if (!defined('_PS_VERSION_')) {
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
+namespace Everblock\Tools\Checkout;
+
+use Context;
+use Configuration;
+use Everblock;
+use Hook;
+use PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep;
 use Symfony\Component\Translation\TranslatorInterface;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
 
 class EverblockCheckoutStep extends AbstractCheckoutStep
 {


### PR DESCRIPTION
## Summary
- move EverblockCheckoutStep class into the PSR-4 `src/Checkout` namespace and add required imports
- reference the namespaced checkout step from the module bootstrap and update allowed files configuration

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_e_68cfcf334b8883229021f3ece73afad0