### PR TITLE
Secure mail recipients for shortcode forms

### DIFF
--- a/views/templates/hook/contact_field.tpl
+++ b/views/templates/hook/contact_field.tpl
@@ -25,7 +25,9 @@
 {assign var="class" value=$field.class}
 
 {if $type == 'sento'}
-  <input type="hidden" name="everHide" value="{$label|base64_encode}">
+  {assign var="secureValue" value=$field.secure_value|default:''}
+  {assign var="rawLabel" value=$field.raw_label|default:''}
+  <input type="hidden" name="everHide" value="{if $secureValue}{$secureValue|escape:'htmlall':'UTF-8'}{else}{$rawLabel|base64_encode}{/if}">
 {elseif in_array($type, ['password','tel','email','datetime-local','date','text','number'])}
   <div class="form-group mb-4{if $class} {$class|escape:'htmlall':'UTF-8'}{/if}">
     <label for="{$id}" class="d-none">{$label nofilter}</label>


### PR DESCRIPTION
## Summary
- sign evercontact recipient email lists when rendering shortcode forms
- validate the signed token before sending mails and ignore tampered recipients
- keep legacy base64 behaviour only as a fallback to the shop email

## Testing
- php -l controllers/front/contact.php
- php -l models/EverblockTools.php

------
https://chatgpt.com/codex/tasks/task_e_68d035e7079c83229e06bea307aaa5ea