### PR TITLE
Place tab documentation sections at bottom

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -406,7 +406,7 @@ class AdminEverBlockController extends ModuleAdminController
                         'title' => $this->l('Save & stay'),
                     ],
                 ],
-                'input' => array_merge($docInputs, [
+                'input' => array_merge([
                     [
                         'type' => 'hidden',
                         'name' => $this->identifier,
@@ -881,7 +881,7 @@ class AdminEverBlockController extends ModuleAdminController
                         'name' => 'date_end',
                         'tab' => 'schedule',
                     ],
-                ]),
+                ], $docInputs),
             ],
         ];
         $helper = new HelperForm();


### PR DESCRIPTION
## Summary
- append tab-specific documentation blocks after the rest of the form fields so they render at the bottom of each tab in the module configuration

## Testing
- php -l controllers/admin/AdminEverBlockController.php

------
https://chatgpt.com/codex/tasks/task_e_68d251148ae083228350572501579672