### PR TITLE
Add Meta Tools tab for Instagram and WordPress settings

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -158,7 +158,7 @@ return [
     'views/templates/admin/config/docs/prettyblock.tpl',
     'views/templates/admin/config/docs/settings.tpl',
     'views/templates/admin/config/docs/tools.tpl',
-    'views/templates/admin/config/docs/wordpress.tpl',
+    'views/templates/admin/config/docs/meta_tools.tpl',
     'views/templates/admin/block/docs/display.tpl',
     'views/templates/admin/block/docs/general.tpl',
     'views/templates/admin/block/docs/modal.tpl',

--- a/everblock.php
+++ b/everblock.php
@@ -803,7 +803,7 @@ class Everblock extends Module
 
         $tabs = [
             'settings' => $this->l('Réglages'),
-            'wordpress' => $this->l('WordPress'),
+            'meta_tools' => $this->l('Meta Tools'),
             'google_maps' => $this->l('Google Maps'),
             'migration' => $this->l('Migration des URL'),
             'tools' => $this->l('Outils'),
@@ -836,7 +836,7 @@ class Everblock extends Module
 
         $docTemplates = [
             'settings' => 'settings.tpl',
-            'wordpress' => 'wordpress.tpl',
+            'meta_tools' => 'meta_tools.tpl',
             'google_maps' => 'google_maps.tpl',
             'migration' => 'migration.tpl',
             'tools' => 'tools.tpl',
@@ -955,13 +955,6 @@ class Everblock extends Module
                 'desc' => $this->l('If entered, you will have a password entry form on the maintenance page'),
                 'hint' => $this->l('People with the password will be able to access the store in maintenance mode'),
                 'name' => 'EVERBLOCK_MAINTENANCE_PSSWD',
-            ],
-            [
-                'type' => 'text',
-                'label' => $this->l('Instagram access token'),
-                'desc' => $this->l('Add here your Instagram access token'),
-                'hint' => $this->l('Without access token, you wont be able to show Instagram slider'),
-                'name' => 'EVERINSTA_ACCESS_TOKEN',
             ],
             [
                 'type' => 'switch',
@@ -1090,6 +1083,26 @@ class Everblock extends Module
             $form['form']['input'][] = $input;
         }
 
+        $metaToolsInputs = [
+            [
+                'type' => 'html',
+                'name' => 'anchor_everblock_meta_tools',
+                'html_content' => '<span id="everblock_meta_tools"></span>',
+            ],
+            [
+                'type' => 'text',
+                'label' => $this->l('Instagram access token'),
+                'desc' => $this->l('Add here your Instagram access token'),
+                'hint' => $this->l('Without access token, you wont be able to show Instagram slider'),
+                'name' => 'EVERINSTA_ACCESS_TOKEN',
+            ],
+        ];
+
+        foreach ($metaToolsInputs as $input) {
+            $input['tab'] = 'meta_tools';
+            $form['form']['input'][] = $input;
+        }
+
         $wordpressInputs = [
             [
                 'type' => 'html',
@@ -1121,7 +1134,7 @@ class Everblock extends Module
         ];
 
         foreach ($wordpressInputs as $input) {
-            $input['tab'] = 'wordpress';
+            $input['tab'] = 'meta_tools';
             $form['form']['input'][] = $input;
         }
 
@@ -1368,7 +1381,7 @@ class Everblock extends Module
             ];
 
             foreach ($instagramInputs as $input) {
-                $input['tab'] = 'settings';
+                $input['tab'] = 'meta_tools';
                 $form['form']['input'][] = $input;
             }
         }

--- a/views/templates/admin/config/docs/meta_tools.tpl
+++ b/views/templates/admin/config/docs/meta_tools.tpl
@@ -17,15 +17,25 @@
 <div class="card everblock-doc mt-3">
     <div class="card-body">
         <h3 class="card-title">
-            <i class="icon-wordpress"></i>
-            {l s='WordPress integration' mod='everblock'}
+            <i class="icon-cogs"></i>
+            {l s='Meta Tools integrations' mod='everblock'}
         </h3>
-        <p>{l s='Provide the credentials of your WordPress REST API to display the latest posts inside Ever Block widgets.' mod='everblock'}</p>
+        <p>{l s='This tab centralises the external services connected to Ever Block. Use it to authenticate WordPress and Instagram so their content can be embedded inside your store.' mod='everblock'}</p>
+
+        <h4><i class="icon-wordpress"></i> {l s='WordPress integration' mod='everblock'}</h4>
         <ul>
             <li>{l s='API URL must target the posts endpoint, for example: https://example.com/wp-json/wp/v2/posts' mod='everblock'}</li>
             <li>{l s='User and password are used for Basic Auth when the WordPress site requires authentication.' mod='everblock'}</li>
             <li>{l s='Use the “Number of blog posts to display” field to limit the feed when rendering the shortcode.' mod='everblock'}</li>
         </ul>
         <p>{l s='Once saved, the module can fetch and cache the remote posts that you will embed through the [everwp] shortcode.' mod='everblock'}</p>
+
+        <h4><i class="icon-instagram"></i> {l s='Instagram integration' mod='everblock'}</h4>
+        <ul>
+            <li>{l s='Generate a long-lived access token from Meta Business tools and paste it in the dedicated field.' mod='everblock'}</li>
+            <li>{l s='Provide your public profile link to redirect visitors to Instagram when they interact with the widget.' mod='everblock'}</li>
+            <li>{l s='Toggle the caption display if you want to show the text associated with each media.' mod='everblock'}</li>
+        </ul>
+        <p>{l s='Save the configuration and use the module tools to refresh tokens or fetch the latest media whenever needed.' mod='everblock'}</p>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- create a dedicated "Meta Tools" configuration tab for WordPress and Instagram integrations
- move all related inputs and documentation into the new tab and add an anchor for it
- update allowed files to expose the new meta tools documentation template

## Testing
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68d2522112248322b25a178dad52c890