### PR TITLE
Add isset guards for mobile margin settings in prettyblock templates

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -71,14 +71,17 @@
         {/if}
       </div>
     </div>
-    {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+    {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
+        (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
+        (isset($state.margin_top_mobile) && $state.margin_top_mobile) ||
+        (isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile)}
       <style>
         @media (max-width: 767px) {
           #block-{$block.id_prettyblocks}-{$key} .position-relative {
-            {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
-            {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
-            {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
-            {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+            {if isset($state.margin_left_mobile) && $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+            {if isset($state.margin_right_mobile) && $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+            {if isset($state.margin_top_mobile) && $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+            {if isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
           }
         }
       </style>

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -62,14 +62,17 @@
             {/if}
           </div>
         </div>
-        {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+        {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
+            (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
+            (isset($state.margin_top_mobile) && $state.margin_top_mobile) ||
+            (isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile)}
           <style>
             @media (max-width: 767px) {
               #block-{$block.id_prettyblocks}-{$key} {
-                {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
-                {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
-                {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
-                {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+                {if isset($state.margin_left_mobile) && $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+                {if isset($state.margin_right_mobile) && $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+                {if isset($state.margin_top_mobile) && $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+                {if isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
               }
             }
           </style>
@@ -113,14 +116,17 @@
           {/if}
         </div>
       </div>
-      {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+      {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
+          (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
+          (isset($state.margin_top_mobile) && $state.margin_top_mobile) ||
+          (isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile)}
         <style>
           @media (max-width: 767px) {
             #block-{$block.id_prettyblocks}-{$key} {
-              {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
-              {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
-              {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
-              {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
+              {if isset($state.margin_left_mobile) && $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall'};{/if}
+              {if isset($state.margin_right_mobile) && $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall'};{/if}
+              {if isset($state.margin_top_mobile) && $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall'};{/if}
+              {if isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall'};{/if}
             }
           }
         </style>

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -65,14 +65,17 @@
             </a>
           {/if}
         </div>
-        {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+        {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
+            (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
+            (isset($state.margin_top_mobile) && $state.margin_top_mobile) ||
+            (isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile)}
           <style>
             @media (max-width: 767px) {
               #block-{$block.id_prettyblocks}-{$key} {
-                {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_left_mobile) && $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_right_mobile) && $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_top_mobile) && $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall':'UTF-8'};{/if}
               }
             }
           </style>
@@ -121,14 +124,17 @@
             </a>
           {/if}
         </div>
-        {if $state.margin_left_mobile || $state.margin_right_mobile || $state.margin_top_mobile || $state.margin_bottom_mobile}
+        {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
+            (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
+            (isset($state.margin_top_mobile) && $state.margin_top_mobile) ||
+            (isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile)}
           <style>
             @media (max-width: 767px) {
               #block-{$block.id_prettyblocks}-{$key} {
-                {if $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall':'UTF-8'};{/if}
-                {if $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_left_mobile) && $state.margin_left_mobile}margin-left:{$state.margin_left_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_right_mobile) && $state.margin_right_mobile}margin-right:{$state.margin_right_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_top_mobile) && $state.margin_top_mobile}margin-top:{$state.margin_top_mobile|escape:'htmlall':'UTF-8'};{/if}
+                {if isset($state.margin_bottom_mobile) && $state.margin_bottom_mobile}margin-bottom:{$state.margin_bottom_mobile|escape:'htmlall':'UTF-8'};{/if}
               }
             }
           </style>


### PR DESCRIPTION
## Summary
- wrap mobile margin conditions in prettyblock templates with `isset` to avoid undefined index notices
- ensure margin styles are only applied when corresponding state values exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d252c5d5608322ad20d15c1354f55b