### PR TITLE
Relax FAQ language and position requirements

### DIFF
--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -57,7 +57,8 @@ class EverblockFaq extends ObjectModel
                 'type' => self::TYPE_INT,
                 'lang' => false,
                 'validate' => 'isUnsignedInt',
-                'required' => true,
+                'required' => false,
+                'default' => 0,
             ],
             'active' => [
                 'type' => self::TYPE_BOOL,
@@ -69,7 +70,7 @@ class EverblockFaq extends ObjectModel
                 'type' => self::TYPE_STRING,
                 'lang' => true,
                 'validate' => 'isString',
-                'required' => true,
+                'required' => false,
             ],
             'content' => [
                 'type' => self::TYPE_HTML,


### PR DESCRIPTION
## Summary
- allow the FAQ form to accept translations for only the default language while still saving provided locale values
- make the FAQ position optional and default to zero when omitted

## Testing
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l models/EverblockFaq.php

------
https://chatgpt.com/codex/tasks/task_e_68d26d16aae883229cbad44deb14ae53