### PR TITLE
Add responsive visibility option to Prettyblocks

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -197,6 +197,7 @@ return [
     'views/templates/hook/pdf.tpl',
     'views/templates/hook/prettyblocks.tpl',
     'views/templates/hook/prettyblocks/index.php',
+    'views/templates/hook/prettyblocks/_partials/visibility_class.tpl',
     'views/templates/hook/prettyblocks/prettyblock_accordeon.tpl',
     'views/templates/hook/prettyblocks/prettyblock_alert.tpl',
     'views/templates/hook/prettyblocks/prettyblock_button.tpl',

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -4372,11 +4372,47 @@ class EverblockPrettyBlocks
                     ],
                 ],
             ];
+            $blocks = self::addDisplaySettings($blocks, $module);
             $blocks = self::applyFileUploadPath($blocks);
             EverblockCache::cacheStore($cacheId, $blocks);
             return $blocks;
         }
         return EverblockCache::cacheRetrieve($cacheId);
+    }
+
+    private static function addDisplaySettings(array $blocks, Module $module): array
+    {
+        foreach ($blocks as &$block) {
+            if (!isset($block['config']) || !is_array($block['config'])) {
+                $block['config'] = [];
+            }
+
+            if (!isset($block['config']['fields']) || !is_array($block['config']['fields'])) {
+                $block['config']['fields'] = [];
+            }
+
+            if (isset($block['config']['fields']['display_on'])) {
+                continue;
+            }
+
+            $displayField = [
+                'display_on' => [
+                    'type' => 'select',
+                    'label' => $module->l('Display on'),
+                    'default' => 'all',
+                    'choices' => [
+                        'all' => $module->l('Mobile and desktop'),
+                        'mobile' => $module->l('Mobile only'),
+                        'desktop' => $module->l('Desktop only'),
+                        'none' => $module->l('Nowhere'),
+                    ],
+                ],
+            ];
+
+            $block['config']['fields'] = array_merge($displayField, $block['config']['fields']);
+        }
+
+        return $blocks;
     }
 
     private static function applyFileUploadPath(array $blocks): array

--- a/views/templates/hook/prettyblocks.tpl
+++ b/views/templates/hook/prettyblocks.tpl
@@ -15,4 +15,21 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+<style>
+.everblock-visibility-none {
+  display: none !important;
+}
+
+@media (min-width: 992px) {
+  .everblock-visibility-mobile {
+    display: none !important;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .everblock-visibility-desktop {
+    display: none !important;
+  }
+}
+</style>
 {widget name="prettyblocks" zone_name="{$zone}{$objectName}{$idObj}"}

--- a/views/templates/hook/prettyblocks/_partials/visibility_class.tpl
+++ b/views/templates/hook/prettyblocks/_partials/visibility_class.tpl
@@ -1,0 +1,9 @@
+{assign var='prettyblock_visibility' value=$block.settings.default.display_on|default:'all'}
+{assign var='prettyblock_visibility_class' value=''}
+{if $prettyblock_visibility === 'mobile'}
+  {assign var='prettyblock_visibility_class' value=' everblock-visibility-mobile'}
+{elseif $prettyblock_visibility === 'desktop'}
+  {assign var='prettyblock_visibility_class' value=' everblock-visibility-desktop'}
+{elseif $prettyblock_visibility === 'none'}
+  {assign var='prettyblock_visibility_class' value=' everblock-visibility-none'}
+{/if}

--- a/views/templates/hook/prettyblocks/prettyblock_accordeon.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_accordeon.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_alert.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_alert.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_brands.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_brands.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {assign var=brands value=[]}
   {if isset($block.states) && $block.states}
     {foreach from=$block.states item=state}

--- a/views/templates/hook/prettyblocks/prettyblock_button.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_button.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if isset($block.states) && $block.states}
     <div class="{if $block.settings.center_cards}px-2 px-md-0 pb-2{else}overflow-auto px-2 px-md-0 pb-2{/if}">
       <div class="d-flex gap-3 pe-1{if $block.settings.center_cards} flex-wrap justify-content-center{else} flex-nowrap{/if}">

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
     {if $block.settings.default.force_full_width}
       <div class="row row-cols-1 row-cols-md-{$block.settings.desktop_columns|default:2} gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_price.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if isset($block.states) && $block.states}
     <div class="d-none d-md-block">
       {if $block.settings.default.force_full_width}

--- a/views/templates/hook/prettyblocks/prettyblock_category_products.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_products.tpl
@@ -15,8 +15,10 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {if isset($block.states) && $block.states}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_contact.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_contact.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_countdown.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_counters.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_counters.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_cta.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cta.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_divider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_divider.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {foreach from=$block.states item=state key=key}
     <div class="modal fade ever-exit-intent-modal" id="everExitIntent-{$block.id_prettyblocks}-{$key}" tabindex="-1">
       <div class="modal-dialog">

--- a/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl
@@ -15,8 +15,10 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {if isset($block.extra.deals) && $block.extra.deals}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_gallery.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_gallery.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_gmap.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_gmap.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
@@ -14,7 +14,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_layout.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_layout.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
     
   {if $block.settings.default.container}
     <div class="row">

--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_login.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_login.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -15,8 +15,10 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {assign var=columns value=$block.settings.columns|default:'1'}
-<div class="prettyblock-lookbook columns-{$columns}">
+<div class="prettyblock-lookbook columns-{$columns}{$prettyblock_visibility_class}">
   <div class="lookbook-item">
     {prettyblocks_zone zone_name="block-lookbook-{$block.id_prettyblocks}-before"}
   </div>

--- a/views/templates/hook/prettyblocks/prettyblock_masonry_gallery.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_masonry_gallery.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_modal.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_modal.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl
@@ -15,6 +15,8 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {assign var=mysteryBoxes value=$block.states|default:[]}
 {assign var=isEmployee value=false}
 {if isset($everblock_is_employee) && $everblock_is_employee}
@@ -50,7 +52,7 @@
 {elseif $block.settings.default.container}
     {assign var=containerClass value='container'}
 {/if}
-<div id="block-{$block.id_prettyblocks}" class="{$containerClass}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{$containerClass}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_podcasts.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_podcasts.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
@@ -15,8 +15,10 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {if isset($block.states) && $block.states}
-<div id="block-{$block.id_prettyblocks}" class="everblock-pricing-table{if $block.settings.default.force_full_width} container-fluid px-0 mx-0{elseif $block.settings.default.container} container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="everblock-pricing-table{if $block.settings.default.force_full_width} container-fluid px-0 mx-0{elseif $block.settings.default.container} container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   <div class="{if $block.settings.slider}ever-slick-carousel row g-4{else}row g-4{/if}"
        {if $block.settings.slider}data-items="{$block.settings.plans_per_slide|escape:'htmlall'}"{/if}
        style="

--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -15,7 +15,9 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0 mt-20px{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0 mt-20px{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row g-10px">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_scratch_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_scratch_card.tpl
@@ -15,6 +15,8 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {assign var=scratchSegments value=$block.states|default:[]}
 {assign var=isEmployee value=false}
 {if isset($everblock_is_employee) && $everblock_is_employee}
@@ -26,7 +28,7 @@
 {assign var=endDate value=$block.settings.end_date|default:''}
 {capture assign=defaultPreStartMessage}{l s='The game has not started yet.' mod='everblock'}{/capture}
 {capture assign=defaultPostEndMessage}{l s='The game is over.' mod='everblock'}{/capture}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_shortcode.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_shortcode.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_slot_machine.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_slot_machine.tpl
@@ -15,6 +15,8 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {assign var=symbols value=$block.states|default:[]}
 {assign var=isEmployee value=false}
 {if isset($everblock_is_employee) && $everblock_is_employee}
@@ -63,7 +65,7 @@
 {elseif $block.settings.default.container}
     {assign var=containerClass value='container'}
 {/if}
-<div id="block-{$block.id_prettyblocks}" class="{$containerClass}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{$containerClass}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -15,8 +15,10 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 <!-- Module Ever Block -->
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_tab.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_tab.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -2,7 +2,9 @@
  * 2019-2025 Team Ever
  * LICENSE INFO
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_toc.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_toc.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
 *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_video_gallery.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_video_gallery.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_video_products.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_video_products.tpl
@@ -15,7 +15,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}">
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
@@ -15,6 +15,8 @@
  * @copyright 2019-2025 Team Ever
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+
 {assign var=wheelSegments value=$block.states|default:[]}
 {assign var=isEmployee value=false}
 {if isset($everblock_is_employee) && $everblock_is_employee}
@@ -27,7 +29,7 @@
 {capture assign=defaultPreStartMessage}{l s='The game has not started yet.' mod='everblock'}{/capture}
 {capture assign=defaultPostEndMessage}{l s='The game is over.' mod='everblock'}{/capture}
 {capture assign=countdownLabel}{l s='Game starts in:' mod='everblock'}{/capture}
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}


### PR DESCRIPTION
## Summary
- add a visibility selector to Prettyblock configurations so each block can target desktop, mobile, both, or be hidden
- introduce a shared Smarty partial and CSS helpers so every Prettyblock template honours the selected visibility

## Testing
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68d2741dd8ac8322a9a3f2a7d11f9323