### PR TITLE
Ensure prettyblock spacing settings propagate

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -294,7 +294,7 @@ class EverblockPrettyBlocks
                     'default' => $spacerTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'space_top' => [
                             'type' => 'text',
                             'label' => $module->l('Space top (rem)'),
@@ -310,7 +310,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -895,7 +895,7 @@ class EverblockPrettyBlocks
                     'default' => $featuredCategoryTemplate
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'desktop_columns' => [
                             'type' => 'select',
                             'label' => $module->l('Desktop columns'),
@@ -909,7 +909,7 @@ class EverblockPrettyBlocks
                                 '6' => '6',
                             ],
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Menu',
@@ -1130,7 +1130,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => $module->l('Offer'),
                     'nameFrom' => 'title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Title'),
@@ -1158,7 +1158,7 @@ class EverblockPrettyBlocks
                                 'url' => '',
                             ],
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -1199,7 +1199,7 @@ class EverblockPrettyBlocks
                     'default' => $imgTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'slider' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Enable slider'),
@@ -1210,7 +1210,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Number of images in slider'),
                             'default' => 3,
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => $module->l('Image title'),
@@ -1848,13 +1848,13 @@ class EverblockPrettyBlocks
                     'default' => $linkListTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Block title'),
                             'default' => $module->l('Links'),
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Link',
@@ -1895,18 +1895,18 @@ class EverblockPrettyBlocks
                     'default' => $downloadsTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Block title'),
                             'default' => $module->l('Downloads'),
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Download',
                     'nameFrom' => 'title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Title'),
@@ -1930,7 +1930,7 @@ class EverblockPrettyBlocks
                             'choices' => EverblockTools::getAvailableSvgIcons(),
                             'default' => 'file.svg',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
 
@@ -1945,18 +1945,18 @@ class EverblockPrettyBlocks
                     'default' => $podcastsTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Block title'),
                             'default' => $module->l('Podcasts'),
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Podcast',
                     'nameFrom' => 'episode_title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'cover_image' => [
                             'type' => 'fileupload',
                             'label' => $module->l('Cover image'),
@@ -1984,7 +1984,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Description'),
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
 
@@ -2019,18 +2019,18 @@ class EverblockPrettyBlocks
                     'default' => $socialLinksTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'icon_color' => [
                             'type' => 'color',
                             'label' => $module->l('Icon color'),
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Social link',
                     'nameFrom' => 'url',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'url' => [
                             'type' => 'text',
                             'label' => $module->l('Link URL'),
@@ -2042,7 +2042,7 @@ class EverblockPrettyBlocks
                             'choices' => EverblockTools::getAvailableSvgIcons(),
                             'default' => 'facebook.svg',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2079,7 +2079,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Brand',
                     'nameFrom' => 'brand',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'brand' => [
                             'type' => 'selector',
                             'label' => $module->l('Choose a brand'),
@@ -2087,7 +2087,7 @@ class EverblockPrettyBlocks
                             'selector' => '{id} - {name}',
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2181,7 +2181,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Counter',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'icon' => [
                             'type' => 'select',
                             'label' => $module->l('Select an icon'),
@@ -2203,7 +2203,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Animation speed (ms)'),
                             'default' => '2000',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2247,13 +2247,13 @@ class EverblockPrettyBlocks
                     'default' => $cardTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'center_cards' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Center cards in container'),
                             'default' => 0,
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Card',
@@ -2321,18 +2321,18 @@ class EverblockPrettyBlocks
                     'default' => $coverTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'slider' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Enable slider'),
                             'default' => 0,
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Cover',
                     'nameFrom' => 'title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Title'),
@@ -2471,47 +2471,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
-                        'margin_left' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin left (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_right' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin right (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_top' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin top (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_bottom' => [
-                            'type' => 'text',
-                            'label' => $module->l('Margin bottom (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_left_mobile' => [
-                            'type' => 'text',
-                            'label' => $module->l('Mobile margin left (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_right_mobile' => [
-                            'type' => 'text',
-                            'label' => $module->l('Mobile margin right (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_top_mobile' => [
-                            'type' => 'text',
-                            'label' => $module->l('Mobile margin top (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                        'margin_bottom_mobile' => [
-                            'type' => 'text',
-                            'label' => $module->l('Mobile margin bottom (Please specify the unit of measurement)'),
-                            'default' => '',
-                        ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2525,18 +2485,18 @@ class EverblockPrettyBlocks
                     'default' => $tocTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Summary title'),
                             'default' => $module->l('Summary'),
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Section',
                     'nameFrom' => 'title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'anchor' => [
                             'type' => 'text',
                             'label' => $module->l('Anchor ID'),
@@ -2562,7 +2522,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Content'),
                             'default' => '[llorem]',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2609,7 +2569,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Marker',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'label' => [
                             'type' => 'text',
                             'label' => $module->l('Marker label'),
@@ -2625,7 +2585,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Left position (e.g., 50%)'),
                             'default' => '0%',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2650,7 +2610,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Product',
                     'nameFrom' => 'product',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'product' => [
                             'type' => 'selector',
                             'label' => $module->l('Choose a product'),
@@ -2658,7 +2618,7 @@ class EverblockPrettyBlocks
                             'selector' => '{id} - {name}',
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2672,18 +2632,18 @@ class EverblockPrettyBlocks
                     'default' => $guidedSelectorTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'fallback_shortcode' => [
                             'type' => 'editor',
                             'label' => $module->l('Fallback content (shortcodes allowed)'),
                             'default' => '[evercontactform_open][evercontact type="text" label="' . $module->l('Your name') . '"][evercontact type="email" label="' . $module->l('Your email') . '"][evercontact type="textarea" label="' . $module->l('Message') . '"][evercontact type="submit" label="' . $module->l('Send') . '"][evercontactform_close]',
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Question',
                     'nameFrom' => 'question',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'question' => [
                             'type' => 'text',
                             'label' => $module->l('Question'),
@@ -2694,7 +2654,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Answers (one per line: "Answer label|Answer link")'),
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2785,7 +2745,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Deal',
                     'nameFrom' => 'product',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'product' => [
                             'type' => 'selector',
                             'label' => $module->l('Choose a product'),
@@ -2793,7 +2753,7 @@ class EverblockPrettyBlocks
                             'selector' => '{id} - {name}',
                             'default' => '',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2892,7 +2852,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Plan',
                     'nameFrom' => 'title',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Plan title'),
@@ -2923,7 +2883,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Highlight'),
                             'default' => 0,
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -2937,7 +2897,7 @@ class EverblockPrettyBlocks
                     'default' => $lookbookTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => static::appendSpacingFields([
                         'title' => [
                             'type' => 'text',
                             'label' => $module->l('Look title'),
@@ -2960,12 +2920,12 @@ class EverblockPrettyBlocks
                                 '3' => '3',
                             ],
                         ],
-                    ],
+                    ], $module),
                 ],
                 'repeater' => [
                     'name' => 'Product',
                     'nameFrom' => 'product',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'product' => [
                             'type' => 'selector',
                             'label' => $module->l('Choose a product'),
@@ -2983,7 +2943,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Left position (e.g., 50%)'),
                             'default' => '0%',
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -3048,7 +3008,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Segment',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'label' => [
                             'type' => 'text',
                             'label' => $module->l('Label'),
@@ -3121,7 +3081,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Winning segment'),
                             'default' => false,
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -3176,7 +3136,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Mystery box',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'label' => [
                             'type' => 'text',
                             'label' => $module->l('Label'),
@@ -3261,7 +3221,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Winning box'),
                             'default' => false,
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks[] = [
@@ -3365,7 +3325,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Symbol',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'symbol_key' => [
                             'type' => 'text',
                             'label' => $module->l('Internal symbol key'),
@@ -3398,7 +3358,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Accessible description'),
                             'default' => $module->l('A juicy cherry symbol that hints at the jackpot.'),
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $scratchTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_scratch_card.tpl';
@@ -3449,7 +3409,7 @@ class EverblockPrettyBlocks
                 'repeater' => [
                     'name' => 'Scratch case',
                     'nameFrom' => 'label',
-                    'groups' => [
+                    'groups' => static::appendSpacingFields([
                         'label' => [
                             'type' => 'text',
                             'label' => $module->l('Label'),
@@ -3529,7 +3489,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Winning scratch'),
                             'default' => false,
                         ],
-                    ],
+                    ], $module),
                 ],
             ];
             $blocks = self::addDisplaySettings($blocks, $module);

--- a/views/templates/hook/prettyblocks/_partials/spacing_style.tpl
+++ b/views/templates/hook/prettyblocks/_partials/spacing_style.tpl
@@ -1,0 +1,32 @@
+{* Generates inline spacing styles for blocks and repeater states *}
+{capture name='spacing_styles'}
+{if isset($spacing) && $spacing}
+  {assign var='spacingMap' value=[
+    'padding_left' => 'padding-left',
+    'padding_right' => 'padding-right',
+    'padding_top' => 'padding-top',
+    'padding_bottom' => 'padding-bottom',
+    'margin_left' => 'margin-left',
+    'margin_right' => 'margin-right',
+    'margin_top' => 'margin-top',
+    'margin_bottom' => 'margin-bottom',
+  ]}
+  {foreach from=$spacingMap key=spacingKey item=cssProperty}
+    {if isset($spacing[$spacingKey]) && $spacing[$spacingKey]}
+      {$cssProperty}:{$spacing[$spacingKey]|escape:'htmlall':'UTF-8'};
+    {/if}
+  {/foreach}
+  {assign var='mobileSpacingMap' value=[
+    'margin_left_mobile' => '--margin-left-mobile',
+    'margin_right_mobile' => '--margin-right-mobile',
+    'margin_top_mobile' => '--margin-top-mobile',
+    'margin_bottom_mobile' => '--margin-bottom-mobile',
+  ]}
+  {foreach from=$mobileSpacingMap key=spacingKey item=cssProperty}
+    {if isset($spacing[$spacingKey]) && $spacing[$spacingKey]}
+      {$cssProperty}:{$spacing[$spacingKey]|escape:'htmlall':'UTF-8'};
+    {/if}
+  {/foreach}
+{/if}
+{/capture}
+{$smarty.capture.spacing_styles|trim}

--- a/views/templates/hook/prettyblocks/prettyblock_brands.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_brands.tpl
@@ -16,8 +16,16 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_brands_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_brands_wrapper_style' value=$smarty.capture.prettyblock_brands_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_brands_wrapper_style} style="{$prettyblock_brands_wrapper_style}"{/if}>
   {assign var=brands value=[]}
   {if isset($block.states) && $block.states}
     {foreach from=$block.states item=state}

--- a/views/templates/hook/prettyblocks/prettyblock_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_card.tpl
@@ -16,13 +16,27 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_card_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_card_wrapper_style' value=$smarty.capture.prettyblock_card_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_card_wrapper_style} style="{$prettyblock_card_wrapper_style}"{/if}>
   {if isset($block.states) && $block.states}
     <div class="{if $block.settings.center_cards}px-2 px-md-0 pb-2{else}overflow-auto px-2 px-md-0 pb-2{/if}">
       <div class="d-flex gap-3 pe-1{if $block.settings.center_cards} flex-wrap justify-content-center{else} flex-nowrap{/if}">
         {foreach from=$block.states item=state}
-          <div class="flex-shrink-0 prettyblocks-card-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="width:90%;max-width:90%;">
+          {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_card_state_spacing_style'}
+          {capture name='prettyblock_card_state_style'}
+            width:90%;max-width:90%;
+            {$prettyblock_card_state_spacing_style}
+          {/capture}
+          {assign var='prettyblock_card_state_style' value=$smarty.capture.prettyblock_card_state_style|trim}
+          <div class="flex-shrink-0 prettyblocks-card-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"{if $prettyblock_card_state_style} style="{$prettyblock_card_state_style}"{/if}>
             <div class="card h-100 mb-3 border border-light-subtle rounded-4 shadow-sm">
               <div class="card-body d-flex flex-column h-100 p-4">
                 {if isset($state.image.url) && $state.image.url}

--- a/views/templates/hook/prettyblocks/prettyblock_contact.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_contact.tpl
@@ -16,8 +16,16 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_contact_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_contact_wrapper_style' value=$smarty.capture.prettyblock_contact_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_contact_wrapper_style} style="{$prettyblock_contact_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -16,8 +16,16 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_cover_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_cover_wrapper_style' value=$smarty.capture.prettyblock_cover_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_cover_wrapper_style} style="{$prettyblock_cover_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -28,9 +36,13 @@
   {if $use_slider}
     <div class="ever-cover-carousel">
       {foreach from=$block.states item=state key=key}
+        {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
+        {capture name='prettyblock_cover_state_style'}
+          {$prettyblock_cover_state_spacing_style}
+        {/capture}
+        {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
         <div id="block-{$block.id_prettyblocks}-{$key}"
-             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"
-             {if $state.margin_left || $state.margin_right || $state.margin_top || $state.margin_bottom}style="{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall'};{/if}"{/if}>
+             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
             {if isset($state.background_image.url) && $state.background_image.url}
               <picture>
                 {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
@@ -82,9 +94,13 @@
       {/foreach}
   {else}
     {foreach from=$block.states item=state key=key}
+      {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
+      {capture name='prettyblock_cover_state_style'}
+        {$prettyblock_cover_state_spacing_style}
+      {/capture}
+      {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
       <div id="block-{$block.id_prettyblocks}-{$key}"
-           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"
-           {if $state.margin_left || $state.margin_right || $state.margin_top || $state.margin_bottom}style="{if $state.margin_left}margin-left:{$state.margin_left|escape:'htmlall'};{/if}{if $state.margin_right}margin-right:{$state.margin_right|escape:'htmlall'};{/if}{if $state.margin_top}margin-top:{$state.margin_top|escape:'htmlall'};{/if}{if $state.margin_bottom}margin-bottom:{$state.margin_bottom|escape:'htmlall'};{/if}"{/if}>
+           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
         {if isset($state.background_image.url) && $state.background_image.url}
           <picture>
             {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}

--- a/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
@@ -16,8 +16,16 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_exit_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_exit_wrapper_style' value=$smarty.capture.prettyblock_exit_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_exit_wrapper_style} style="{$prettyblock_exit_wrapper_style}"{/if}>
   {foreach from=$block.states item=state key=key}
     <div class="modal fade ever-exit-intent-modal" id="everExitIntent-{$block.id_prettyblocks}-{$key}" tabindex="-1">
       <div class="modal-dialog">

--- a/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl
@@ -16,8 +16,16 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_guided_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_guided_wrapper_style' value=$smarty.capture.prettyblock_guided_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_guided_wrapper_style} style="{$prettyblock_guided_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -16,14 +16,25 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_lookbook_wrapper_style'}
+  {$prettyblock_spacing_style}
+{/capture}
+{assign var='prettyblock_lookbook_wrapper_style' value=$smarty.capture.prettyblock_lookbook_wrapper_style|trim}
 
 {assign var=columns value=$block.settings.columns|default:'1'}
-<div class="prettyblock-lookbook columns-{$columns}{$prettyblock_visibility_class}">
+<div class="prettyblock-lookbook columns-{$columns}{$prettyblock_visibility_class}"{if $prettyblock_lookbook_wrapper_style} style="{$prettyblock_lookbook_wrapper_style}"{/if}>
   <div class="lookbook-item">
     {prettyblocks_zone zone_name="block-lookbook-{$block.id_prettyblocks}-before"}
   </div>
   <div class="lookbook-item">
-    <div id="block-{$block.id_prettyblocks}" data-lookbook-url="{$link->getModuleLink('everblock', 'lookbook', ['token' => $static_token])|escape:'html':'UTF-8'}" class="{if $block.settings.default.force_full_width|default:false}container-fluid px-0 mx-0{elseif $block.settings.default.container|default:false}container{/if}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+    {capture name='prettyblock_lookbook_inner_style'}
+      {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+        background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+      {/if}
+    {/capture}
+    {assign var='prettyblock_lookbook_inner_style' value=$smarty.capture.prettyblock_lookbook_inner_style|trim}
+    <div id="block-{$block.id_prettyblocks}" data-lookbook-url="{$link->getModuleLink('everblock', 'lookbook', ['token' => $static_token])|escape:'html':'UTF-8'}" class="{if $block.settings.default.force_full_width|default:false}container-fluid px-0 mx-0{elseif $block.settings.default.container|default:false}container{/if}"{if $prettyblock_lookbook_inner_style} style="{$prettyblock_lookbook_inner_style}"{/if}>
       {if $block.settings.default.force_full_width|default:false}
         <div class="row gx-0 no-gutters">
       {elseif $block.settings.default.container|default:false}

--- a/views/templates/hook/prettyblocks/prettyblock_podcasts.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_podcasts.tpl
@@ -16,8 +16,16 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_podcasts_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_podcasts_wrapper_style' value=$smarty.capture.prettyblock_podcasts_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_podcasts_wrapper_style} style="{$prettyblock_podcasts_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -29,7 +37,12 @@
   {if isset($block.states) && $block.states}
     <div class="everblock-podcasts">
       {foreach from=$block.states item=state}
-        <div class="podcast-item">
+        {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_podcast_state_spacing_style'}
+        {capture name='prettyblock_podcast_state_style'}
+          {$prettyblock_podcast_state_spacing_style}
+        {/capture}
+        {assign var='prettyblock_podcast_state_style' value=$smarty.capture.prettyblock_podcast_state_style|trim}
+        <div class="podcast-item"{if $prettyblock_podcast_state_style} style="{$prettyblock_podcast_state_style}"{/if}>
           {if isset($state.cover_image.url) && $state.cover_image.url}
             <img src="{$state.cover_image.url|escape:'htmlall'}" alt="{$state.episode_title|escape:'htmlall'}" class="podcast-cover" loading="lazy" />
           {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -16,8 +16,16 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_product_highlight_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_product_highlight_wrapper_style' value=$smarty.capture.prettyblock_product_highlight_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_product_highlight_wrapper_style} style="{$prettyblock_product_highlight_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -16,9 +16,17 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_social_links_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_social_links_wrapper_style' value=$smarty.capture.prettyblock_social_links_wrapper_style|trim}
 
 <!-- Module Ever Block -->
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_social_links_wrapper_style} style="{$prettyblock_social_links_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -44,7 +52,12 @@
               {/if}
 
               {* ✅ Chaque icône dans un wrapper séparé *}
-              <span class="everblock-social-link">
+              {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_social_link_style'}
+              {capture name='prettyblock_social_link_style_attr'}
+                {$prettyblock_social_link_style}
+              {/capture}
+              {assign var='prettyblock_social_link_style_attr' value=$smarty.capture.prettyblock_social_link_style_attr|trim}
+              <span class="everblock-social-link"{if $prettyblock_social_link_style_attr} style="{$prettyblock_social_link_style_attr}"{/if}>
                 <a href="{$state.url|escape:'htmlall'}"
                    title="{$state.url|escape:'htmlall'}"
                    target="_blank"

--- a/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_spacer.tpl
@@ -16,15 +16,30 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_spacer_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_spacer_wrapper_style' value=$smarty.capture.prettyblock_spacer_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_spacer_wrapper_style} style="{$prettyblock_spacer_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
 
-<div id="block-{$block.id_prettyblocks}" class="everblock-spacer {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{if isset($block.settings.space_top) && $block.settings.space_top}margin-top:{$block.settings.space_top|escape:'htmlall':'UTF-8'}rem;{/if}{if isset($block.settings.space_bottom) && $block.settings.space_bottom}margin-bottom:{$block.settings.space_bottom|escape:'htmlall':'UTF-8'}rem;{/if}height:0;"></div>
+{capture name='prettyblock_spacer_inner_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.space_top) && $block.settings.space_top}margin-top:{$block.settings.space_top|escape:'htmlall':'UTF-8'}rem;{/if}
+  {if isset($block.settings.space_bottom) && $block.settings.space_bottom}margin-bottom:{$block.settings.space_bottom|escape:'htmlall':'UTF-8'}rem;{/if}
+  height:0;
+{/capture}
+{assign var='prettyblock_spacer_inner_style' value=$smarty.capture.prettyblock_spacer_inner_style|trim}
+<div id="block-{$block.id_prettyblocks}" class="everblock-spacer {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $prettyblock_spacer_inner_style} style="{$prettyblock_spacer_inner_style}"{/if}></div>
 
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>

--- a/views/templates/hook/prettyblocks/prettyblock_toc.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_toc.tpl
@@ -16,8 +16,16 @@
 *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_toc_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_toc_wrapper_style' value=$smarty.capture.prettyblock_toc_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_toc_wrapper_style} style="{$prettyblock_toc_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -68,7 +76,12 @@
     </div>
     <div class="col-12 col-lg-8 pb-toc-content">
       {foreach from=$block.states item=state}
-        <div id="{$state.anchor|escape:'htmlall'}" class="pb-toc-section">
+        {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_toc_state_style'}
+        {capture name='prettyblock_toc_state_style_attr'}
+          {$prettyblock_toc_state_style}
+        {/capture}
+        {assign var='prettyblock_toc_state_style_attr' value=$smarty.capture.prettyblock_toc_state_style_attr|trim}
+        <div id="{$state.anchor|escape:'htmlall'}" class="pb-toc-section"{if $prettyblock_toc_state_style_attr} style="{$prettyblock_toc_state_style_attr}"{/if}>
           {$state.content nofilter}
         </div>
       {/foreach}


### PR DESCRIPTION
## Summary
- merge spacing settings into all prettyblock configurations and repeaters so margin/padding controls are available everywhere
- add a reusable spacing_style partial and update the prettyblock templates to render padding and margin styles when values are provided

## Testing
- composer validate
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68d2823e16748322a1f5b56d96ed13c9