### PR TITLE
Fix duplicated admin footer rendering

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -262,20 +262,37 @@ class AdminEverBlockController extends ModuleAdminController
         $lists = parent::renderList();
 
         $moduleInstance = Module::getInstanceByName($this->table);
-        if ($moduleInstance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_ . '/' . $this->table . '/views/templates/admin/upgrade.tpl');
-        }
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
 
-        return $this->html;
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $lists,
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
+
+        return $content;
     }
 
     private function moveDocumentationToTabEnd(array $inputs)
@@ -982,22 +999,37 @@ class AdminEverBlockController extends ModuleAdminController
         ];
         $helper->currentIndex = AdminController::$currentIndex;
         $moduleInstance = Module::getInstanceByName($this->table);
-        $render = '';
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/' . $this->table . '/views/templates/admin/header.tpl');
-        if ($moduleInstance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_ . '/' . $this->table . '/views/templates/admin/upgrade.tpl');
-        }
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $render .= $helper->generateForm($fields_form);
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
 
-        return $render;
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $helper->generateForm($fields_form),
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
+
+        return $content;
     }
 
     protected function getConfigFormValues($obj)

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -149,8 +149,6 @@ class AdminEverBlockFaqController extends ModuleAdminController
 
     public function renderList()
     {
-        $this->html = '';
-
         $this->addRowAction('edit');
         $this->addRowAction('delete');
         $this->addRowAction('duplicate');
@@ -163,16 +161,39 @@ class AdminEverBlockFaqController extends ModuleAdminController
             $this->confirmations[] = $this->l('Cache has been cleared');
         }
         $lists = parent::renderList();
+
+        $moduleInstance = Module::getInstanceByName('everblock');
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
 
-        return $this->html;
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $lists,
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
+
+        return $content;
     }
 
     public function renderForm()

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -175,20 +175,37 @@ class AdminEverBlockHookController extends ModuleAdminController
         $lists = parent::renderList();
 
         $moduleInstance = Module::getInstanceByName('everblock');
-        if ($moduleInstance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_ . '/everblock/views/templates/admin/upgrade.tpl');
-        }
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
 
-        return $this->html;
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $lists,
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
+
+        return $content;
     }
 
     public function renderForm()
@@ -308,23 +325,38 @@ class AdminEverBlockHookController extends ModuleAdminController
 
 
         $moduleInstance = Module::getInstanceByName('everblock');
-        $render = '';
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl');
-        if ($moduleInstance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_ . '/everblock/views/templates/admin/upgrade.tpl');
-        }
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $render .= $helper->generateForm($fields_form);
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $render .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
+
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $helper->generateForm($fields_form),
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
 
 
-        return $render;
+        return $content;
     }
 
     protected function getConfigFormValues($obj)

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -127,8 +127,6 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
 
     public function renderList()
     {
-        $this->html = '';
-
         $this->addRowAction('edit');
         $this->addRowAction('delete');
         $this->toolbar_title = $this->l('Registered shortcodes');
@@ -141,16 +139,38 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
         }
         $lists = parent::renderList();
 
+        $moduleInstance = Module::getInstanceByName('everblock');
+        $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
+
+        $notifications = '';
         if (count($this->errors)) {
             foreach ($this->errors as $error) {
-                $this->html .= Tools::displayError($error);
+                $notifications .= Tools::displayError($error);
             }
         }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl');
-        $this->html .= $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl');
+        if (is_array($this->confirmations) && count($this->confirmations)) {
+            foreach ($this->confirmations as $confirmation) {
+                $notifications .= $this->displayConfirmation($confirmation);
+            }
+        }
 
-        return $this->html;
+        $this->context->smarty->assign([
+            'everblock_notifications' => $notifications,
+            'everblock_form' => $lists,
+            'display_upgrade' => $displayUpgrade,
+        ]);
+
+        $content = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/header.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/configure.tpl'
+        );
+        $content .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/everblock/views/templates/admin/footer.tpl'
+        );
+
+        return $content;
     }
 
     public function renderForm()

--- a/everblock.php
+++ b/everblock.php
@@ -755,9 +755,17 @@ class Everblock extends Module
             'everblock_form' => $this->renderForm(),
             'display_upgrade' => $displayUpgrade,
         ]);
-        return $this->context->smarty->fetch(
+        $output = $this->context->smarty->fetch(
+            $this->local_path . 'views/templates/admin/header.tpl'
+        );
+        $output .= $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/configure.tpl'
         );
+        $output .= $this->context->smarty->fetch(
+            $this->local_path . 'views/templates/admin/footer.tpl'
+        );
+
+        return $output;
     }
 
     protected function renderForm()

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -16,8 +16,6 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 
-{include file='module:everblock/views/templates/admin/header.tpl'}
-
 {if isset($everblock_notifications) && $everblock_notifications}
     {$everblock_notifications nofilter}
 {/if}
@@ -29,5 +27,3 @@
 {if isset($everblock_form)}
     {$everblock_form nofilter}
 {/if}
-
-{include file='module:everblock/views/templates/admin/footer.tpl'}


### PR DESCRIPTION
## Summary
- render admin pages by composing the module header, body and footer explicitly to avoid duplicated footers
- expose lists and forms through the shared configure template so notifications and upgrade prompts stay consistent across controllers
- trim the configure.tpl template to only output notifications, upgrades and provided content

## Testing
- php -l everblock.php
- php -l controllers/admin/AdminEverBlockController.php
- php -l controllers/admin/AdminEverBlockHookController.php
- php -l controllers/admin/AdminEverBlockShortcodeController.php
- php -l controllers/admin/AdminEverBlockFaqController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2937af9cc8322bae9a0062d8b60e7