### PR TITLE
Fix Smarty array syntax for spacing style partial

### DIFF
--- a/views/templates/hook/prettyblocks/_partials/spacing_style.tpl
+++ b/views/templates/hook/prettyblocks/_partials/spacing_style.tpl
@@ -1,7 +1,7 @@
 {* Generates inline spacing styles for blocks and repeater states *}
 {capture name='spacing_styles'}
 {if isset($spacing) && $spacing}
-  {assign var='spacingMap' value=[
+  {assign var='spacingMap' value=array(
     'padding_left' => 'padding-left',
     'padding_right' => 'padding-right',
     'padding_top' => 'padding-top',
@@ -9,19 +9,19 @@
     'margin_left' => 'margin-left',
     'margin_right' => 'margin-right',
     'margin_top' => 'margin-top',
-    'margin_bottom' => 'margin-bottom',
-  ]}
+    'margin_bottom' => 'margin-bottom'
+  )}
   {foreach from=$spacingMap key=spacingKey item=cssProperty}
     {if isset($spacing[$spacingKey]) && $spacing[$spacingKey]}
       {$cssProperty}:{$spacing[$spacingKey]|escape:'htmlall':'UTF-8'};
     {/if}
   {/foreach}
-  {assign var='mobileSpacingMap' value=[
+  {assign var='mobileSpacingMap' value=array(
     'margin_left_mobile' => '--margin-left-mobile',
     'margin_right_mobile' => '--margin-right-mobile',
     'margin_top_mobile' => '--margin-top-mobile',
-    'margin_bottom_mobile' => '--margin-bottom-mobile',
-  ]}
+    'margin_bottom_mobile' => '--margin-bottom-mobile'
+  )}
   {foreach from=$mobileSpacingMap key=spacingKey item=cssProperty}
     {if isset($spacing[$spacingKey]) && $spacing[$spacingKey]}
       {$cssProperty}:{$spacing[$spacingKey]|escape:'htmlall':'UTF-8'};


### PR DESCRIPTION
## Summary
- replace shorthand array notation in the spacing style partial with array() for Smarty compatibility
- ensure both desktop and mobile spacing maps compile correctly without syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b03f3f9c8322b7806ccb83fe699d