### PR TITLE
Add server-side captcha to contact shortcodes

### DIFF
--- a/controllers/front/contact.php
+++ b/controllers/front/contact.php
@@ -41,6 +41,15 @@ class EverblockcontactModuleFrontController extends ModuleFrontController
             return $this->terminateWithResponse($this->module->l('Invalid security token.'));
         }
 
+        if (!\Everblock\Tools\Service\CaptchaService::validateResponse(
+            Tools::getValue('evercaptcha_token'),
+            Tools::getValue('evercaptcha_answer')
+        )) {
+            return $this->terminateWithResponse(
+                $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/front/error.tpl')
+            );
+        }
+
         // ➕ Récupération du formulaire
         $formData = Tools::getAllValues();
 
@@ -60,7 +69,7 @@ class EverblockcontactModuleFrontController extends ModuleFrontController
 
         // ➕ Contenu du message HTML
         $messageContent = '';
-        $excludedKeys = ['token', 'everHide', 'submit', 'action'];
+        $excludedKeys = ['token', 'everHide', 'submit', 'action', 'evercaptcha_token', 'evercaptcha_answer'];
 
         foreach ($formData as $key => $value) {
             if (in_array($key, $excludedKeys)) {

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -17,6 +17,7 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\CaptchaService;
 use Everblock\Tools\Service\EverblockCache;
 
 if (!defined('_PS_VERSION_')) {
@@ -1858,11 +1859,15 @@ class EverblockTools extends ObjectModel
             $txt
         );
 
-        // Remplace [evercontactform_close] par input token + fermeture du form
+        // Remplace [evercontactform_close] par captcha + input token + fermeture du form
         $token = Tools::getToken();
-        $txt = str_replace(
-            '[evercontactform_close]',
-            '<input type="hidden" name="token" value="' . $token . '"></form></div>',
+        $txt = preg_replace_callback(
+            '/\[evercontactform_close\]/',
+            function () use ($context, $module, $token) {
+                $captchaHtml = CaptchaService::renderCaptchaField($context, $module);
+
+                return $captchaHtml . '<input type="hidden" name="token" value="' . $token . '"></form></div>';
+            },
             $txt
         );
 

--- a/src/Service/CaptchaService.php
+++ b/src/Service/CaptchaService.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use Configuration;
+use Context;
+use Exception;
+use Tools;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class CaptchaService
+{
+    private const TOKEN_SEPARATOR = '.';
+    private const TOKEN_TTL = 900; // 15 minutes
+
+    /**
+     * Render the captcha block for a contact form.
+     */
+    public static function renderCaptchaField(Context $context, \Everblock $module): string
+    {
+        try {
+            $challenge = static::createChallengePayload();
+        } catch (Exception $e) {
+            return '';
+        }
+
+        $question = sprintf(
+            $module->l('What is %d + %d?', 'captchaservice'),
+            $challenge['a'],
+            $challenge['b']
+        );
+        $fieldId = 'evercaptcha_' . $challenge['nonce'];
+        $token = static::buildToken($challenge);
+
+        $context->smarty->assign([
+            'captcha' => [
+                'label' => $module->l('Security question', 'captchaservice'),
+                'helper' => $module->l('Please answer the security question to validate your request.', 'captchaservice'),
+                'question' => $question,
+                'field_id' => $fieldId,
+                'token' => $token,
+            ],
+        ]);
+
+        $templatePath = \EverblockTools::getTemplatePath('hook/contact_captcha.tpl', $module);
+
+        return $context->smarty->fetch($templatePath);
+    }
+
+    /**
+     * Validate the captcha answer received from the form submission.
+     */
+    public static function validateResponse(?string $token, ?string $answer): bool
+    {
+        if (!$token || !$answer) {
+            return false;
+        }
+
+        $payload = static::decodeToken($token);
+        if (empty($payload)) {
+            return false;
+        }
+
+        if (!isset($payload['a'], $payload['b'], $payload['ts']) || !is_numeric($payload['a']) || !is_numeric($payload['b'])) {
+            return false;
+        }
+
+        if (!is_int($payload['ts']) || (time() - $payload['ts']) > self::TOKEN_TTL) {
+            return false;
+        }
+
+        $expected = (int) ($payload['a'] + $payload['b']);
+        $cleanAnswer = trim((string) $answer);
+
+        if ($cleanAnswer === '' || !ctype_digit($cleanAnswer)) {
+            return false;
+        }
+
+        return (int) $cleanAnswer === $expected;
+    }
+
+    private static function createChallengePayload(): array
+    {
+        $a = random_int(1, 9);
+        $b = random_int(1, 9);
+        $nonce = bin2hex(random_bytes(6));
+
+        return [
+            'a' => $a,
+            'b' => $b,
+            'nonce' => $nonce,
+            'ts' => time(),
+        ];
+    }
+
+    private static function buildToken(array $payload): string
+    {
+        $json = json_encode($payload);
+        if ($json === false) {
+            throw new Exception('Unable to encode captcha payload.');
+        }
+
+        $signature = hash_hmac('sha256', $json, static::getSecret());
+
+        return base64_encode($json) . self::TOKEN_SEPARATOR . $signature;
+    }
+
+    private static function decodeToken(string $token): array
+    {
+        $parts = explode(self::TOKEN_SEPARATOR, $token, 2);
+        if (count($parts) !== 2) {
+            return [];
+        }
+
+        [$encoded, $signature] = $parts;
+        $json = base64_decode($encoded, true);
+        if ($json === false) {
+            return [];
+        }
+
+        $expectedSignature = hash_hmac('sha256', $json, static::getSecret());
+        if (!hash_equals($expectedSignature, $signature)) {
+            return [];
+        }
+
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return [];
+        }
+
+        $data['ts'] = isset($data['ts']) ? (int) $data['ts'] : 0;
+
+        return $data;
+    }
+
+    private static function getSecret(): string
+    {
+        if (defined('_COOKIE_KEY_')) {
+            return (string) _COOKIE_KEY_;
+        }
+
+        $fallback = Configuration::get('PS_SHOP_EMAIL');
+
+        return Tools::hash($fallback ?: 'everblock');
+    }
+}

--- a/views/templates/hook/contact_captcha.tpl
+++ b/views/templates/hook/contact_captcha.tpl
@@ -1,0 +1,28 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{if isset($captcha)}
+  <div class="form-group mb-4 evercontact-captcha">
+    <label for="{$captcha.field_id|escape:'htmlall':'UTF-8'}" class="form-label fw-bold d-block">{$captcha.label|escape:'htmlall':'UTF-8'}</label>
+    <p class="small text-muted">{$captcha.helper|escape:'htmlall':'UTF-8'}</p>
+    <div class="input-group">
+      <span class="input-group-text">{$captcha.question|escape:'htmlall':'UTF-8'}</span>
+      <input type="text" name="evercaptcha_answer" id="{$captcha.field_id|escape:'htmlall':'UTF-8'}" class="form-control" required>
+    </div>
+    <input type="hidden" name="evercaptcha_token" value="{$captcha.token|escape:'htmlall':'UTF-8'}">
+  </div>
+{/if}


### PR DESCRIPTION
## Summary
- add a dedicated server-side captcha service and template for contact forms
- inject the captcha challenge into `[evercontact]` shortcodes when rendering forms
- validate the captcha before processing submissions and filter captcha fields from the email content

## Testing
- php -l controllers/front/contact.php
- php -l models/EverblockTools.php
- php -l src/Service/CaptchaService.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ad5404d08322aea7b4793b93e9d8