### PR TITLE
Add admin configuration tab redirect

### DIFF
--- a/controllers/admin/AdminEverBlockConfigurationController.php
+++ b/controllers/admin/AdminEverBlockConfigurationController.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class AdminEverBlockConfigurationController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+
+        parent::__construct();
+    }
+
+    public function initContent()
+    {
+        $this->redirectToConfiguration();
+    }
+
+    protected function redirectToConfiguration()
+    {
+        $moduleName = $this->module instanceof Module ? $this->module->name : 'everblock';
+        $url = $this->context->link->getAdminLink(
+            'AdminModules',
+            true,
+            [],
+            [
+                'configure' => $moduleName,
+            ]
+        );
+
+        Tools::redirectAdmin($url);
+    }
+}

--- a/everblock.php
+++ b/everblock.php
@@ -194,6 +194,7 @@ class Everblock extends Module
             && $this->registerHook('actionRegisterBlock')
             && $this->registerHook('beforeRenderingEverblockSpecialEvent')
             && $this->installModuleTab('AdminEverBlockParent', 'IMPROVE', $this->l('Ever Block'))
+            && $this->installModuleTab('AdminEverBlockConfiguration', 'AdminEverBlockParent', $this->l('Configuration'))
             && $this->installModuleTab('AdminEverBlock', 'AdminEverBlockParent', $this->l('HTML Blocks'))
             && $this->installModuleTab('AdminEverBlockHook', 'AdminEverBlockParent', $this->l('Hooks'))
             && $this->installModuleTab('AdminEverBlockShortcode', 'AdminEverBlockParent', $this->l('Shortcodes')))
@@ -226,6 +227,7 @@ class Everblock extends Module
         Configuration::deleteByName('EVERBLOCK_STORELOCATOR_TOGGLE');
         return (parent::uninstall()
             && $this->uninstallModuleTab('AdminEverBlockParent')
+            && $this->uninstallModuleTab('AdminEverBlockConfiguration')
             && $this->uninstallModuleTab('AdminEverBlock')
             && $this->uninstallModuleTab('AdminEverBlockHook')
             && $this->uninstallModuleTab('AdminEverBlockShortcode')

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -194,6 +194,7 @@ $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_4d3d769b812b6faa6b
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_f05697e8558532fc1a7c1ca0556ea2eb'] = 'Ajouter un élément';
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_79c0d6cba080dc90b01c887064c9fc2f'] = 'Vider le cache';
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_254f642527b45bc260048e30704edb39'] = 'Configuration';
+$_MODULE['<{everblock}prestashop>admineverblockconfigurationcontroller_254f642527b45bc260048e30704edb39'] = 'Configuration';
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_6f8d052cd848658c2ab9ec9ae4c0783d'] = 'Télécharger le fichier Excel exemple pour les onglets';
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_761602a271b3e0dd17b0c135f448b786'] = 'Gestion des hooks';
 $_MODULE['<{everblock}prestashop>admineverblockhookcontroller_f152dcef37ff8deb5127c5228b0c36b3'] = 'Le cache a été vidé';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -17,6 +17,7 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 */
+$_MODULE['<{everblock}prestashop>admineverblockconfigurationcontroller_254f642527b45bc260048e30704edb39'] = 'Configuration';
 $_MODULE['<{everblock}prestashop>everblock_da3b1fba450fdb0bc71ccb8231f075d6'] = 'Number of brands per slide';
 $_MODULE['<{everblock}prestashop>everblock_5a007b1257a85c32e4c435c60cbad339'] = 'Plan title';
 $_MODULE['<{everblock}prestashop>everblock_1d89b70bf1410131de72cef713ef3d20'] = 'Plan price';


### PR DESCRIPTION
## Summary
- add a new AdminEverBlockConfiguration tab for the module menu
- create the controller that redirects to the module configuration page
- add French and English translations for the new tab label

## Testing
- php -l controllers/admin/AdminEverBlockConfigurationController.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ec5962a48322a5790d68c5e3b773