### PR TITLE
Limit reassurance hook to product page and render modal file

### DIFF
--- a/controllers/front/modal.php
+++ b/controllers/front/modal.php
@@ -75,8 +75,20 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
                 ? $modal->content[$this->context->language->id]
                 : '';
             $fileUrl = '';
+            $fileRenderType = '';
+            $fileExtension = '';
             if (!empty($modal->file)) {
                 $fileUrl = $this->context->link->getBaseLink() . 'img/cms/' . $modal->file;
+                $fileExtension = Tools::strtolower(pathinfo($modal->file, PATHINFO_EXTENSION));
+                $imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'svg'];
+                $videoExtensions = ['mp4', 'webm', 'ogg', 'ogv'];
+                if (in_array($fileExtension, $imageExtensions, true)) {
+                    $fileRenderType = 'image';
+                } elseif (in_array($fileExtension, $videoExtensions, true)) {
+                    $fileRenderType = 'video';
+                } else {
+                    $fileRenderType = 'iframe';
+                }
             }
             $this->context->smarty->assign([
                 'everblock_modal' => (object) [
@@ -86,6 +98,8 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
                         $this->module
                     ),
                     'file' => $fileUrl,
+                    'file_render_type' => $fileRenderType,
+                    'file_extension' => $fileExtension,
                 ],
             ]);
             $response = $this->context->smarty->fetch(_PS_MODULE_DIR_ . '/everblock/views/templates/front/modal.tpl');

--- a/everblock.php
+++ b/everblock.php
@@ -4504,12 +4504,28 @@ class Everblock extends Module
 
     public function hookDisplayReassurance($params)
     {
-        if (!Tools::getValue('id_product')) {
+        if (!isset($this->context->controller) || !is_object($this->context->controller)) {
+            return;
+        }
+
+        if (!class_exists('ProductController') || !($this->context->controller instanceof ProductController)) {
+            return;
+        }
+
+        $idProduct = (int) Tools::getValue('id_product');
+        if (!$idProduct
+            && property_exists($this->context->controller, 'product')
+            && isset($this->context->controller->product->id)
+        ) {
+            $idProduct = (int) $this->context->controller->product->id;
+        }
+
+        if ($idProduct <= 0) {
             return;
         }
 
         $modal = EverblockModal::getByProductId(
-            (int) Tools::getValue('id_product'),
+            $idProduct,
             (int) $this->context->shop->id
         );
 

--- a/views/templates/front/modal.tpl
+++ b/views/templates/front/modal.tpl
@@ -35,7 +35,18 @@
                 </button>
                 {$everblock_modal->content nofilter}
                 {if isset($everblock_modal->file) && $everblock_modal->file}
-                    <p><a href="{$everblock_modal->file|escape:'htmlall':'UTF-8'}" target="_blank">{l s='Download file' mod='everblock'}</a></p>
+                    <div class="everblock-modal-media mt-3">
+                        {if isset($everblock_modal->file_render_type) && $everblock_modal->file_render_type == 'image'}
+                            <img src="{$everblock_modal->file|escape:'htmlall':'UTF-8'}" alt="" class="img-fluid" loading="lazy" />
+                        {elseif isset($everblock_modal->file_render_type) && $everblock_modal->file_render_type == 'video'}
+                            <video controls preload="metadata" class="w-100">
+                                <source src="{$everblock_modal->file|escape:'htmlall':'UTF-8'}" type="video/{$everblock_modal->file_extension|escape:'htmlall':'UTF-8'}" />
+                                {l s='Your browser does not support the video tag.' mod='everblock'}
+                            </video>
+                        {else}
+                            <iframe src="{$everblock_modal->file|escape:'htmlall':'UTF-8'}" class="w-100 everblock-modal-iframe" frameborder="0" allowfullscreen></iframe>
+                        {/if}
+                    </div>
                 {/if}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- guard the `hookDisplayReassurance` output so it only runs on product pages with a valid product id
- determine modal file rendering details when loading a product modal through the front controller
- render modal files inline (image, video, or iframe fallback) instead of linking a download

## Testing
- php -l everblock.php
- php -l controllers/front/modal.php

------
https://chatgpt.com/codex/tasks/task_e_68d413c8db7483228ce0c4ab254d6cd7