### PR TITLE
Hide prettyblock countdown after completion

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -714,15 +714,15 @@ $(document).ready(function(){
                 return;
             }
             completionShown = true;
+            $block.hide();
             if ($message.length) {
-                $block.hide();
                 $message.removeClass('d-none').show();
             }
         }
 
         function hideCompletion() {
+            $block.show();
             if ($message.length) {
-                $block.show();
                 $message.addClass('d-none').hide();
             }
             completionShown = false;


### PR DESCRIPTION
## Summary
- ensure the prettyblock countdown is hidden as soon as it finishes
- keep showing any configured completion message while the timer stays hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d535b27a088322aac7ac64854c592c