### PR TITLE
Add parallax support to Prettyblock cover block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2376,6 +2376,11 @@ class EverblockPrettyBlocks
                                 'url' => '',
                             ],
                         ],
+                        'parallax' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable parallax effect'),
+                            'default' => false,
+                        ],
                         'btn1_text' => [
                             'type' => 'text',
                             'label' => $module->l('Button 1 text'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -583,6 +583,14 @@
     overflow: hidden;
 }
 
+.prettyblock-cover-item--parallax {
+    background-attachment: fixed;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    min-height: 300px;
+}
+
 .prettyblock-cover-item img.prettyblock-cover-image {
     width: 100%;
     height: auto;
@@ -633,6 +641,10 @@
 }
 
 @media (max-width: 767px) {
+    .prettyblock-cover-item--parallax {
+        background-attachment: scroll;
+    }
+
     .prettyblock-cover-overlay.position-mobile-top {
         justify-content: flex-start;
         align-items: center;

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -39,21 +39,44 @@
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
         {capture name='prettyblock_cover_state_style'}
           {$prettyblock_cover_state_spacing_style}
+          {if $state.parallax && isset($state.background_image.url) && $state.background_image.url}
+            background-image:url('{$state.background_image.url|escape:'htmlall'}');
+            background-size:cover;
+            background-position:center;
+            background-repeat:no-repeat;
+            background-attachment:fixed;
+            {if isset($state.background_image.height) && $state.background_image.height}
+              min-height:{$state.background_image.height|intval}px;
+            {/if}
+          {/if}
         {/capture}
         {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
         <div id="block-{$block.id_prettyblocks}-{$key}"
-             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
+             class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
             {if isset($state.background_image.url) && $state.background_image.url}
-              <picture>
+              {if $state.parallax}
                 {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-                  <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
+                  <style>
+                    @media (max-width: 767px) {
+                      #block-{$block.id_prettyblocks}-{$key} {
+                        background-image:url('{$state.background_image_mobile.url|escape:'htmlall'}');
+                        {if isset($state.background_image_mobile.height) && $state.background_image_mobile.height}min-height:{$state.background_image_mobile.height|intval}px;{/if}
+                      }
+                    }
+                  </style>
                 {/if}
-                <img src="{$state.background_image.url|escape:'htmlall'}"
-                     alt="{$state.title|escape:'htmlall'}"
-                     {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
-                     {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
-                     class="prettyblock-cover-image">
-              </picture>
+              {else}
+                <picture>
+                  {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
+                    <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
+                  {/if}
+                  <img src="{$state.background_image.url|escape:'htmlall'}"
+                       alt="{$state.title|escape:'htmlall'}"
+                       {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
+                       {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
+                       class="prettyblock-cover-image">
+                </picture>
+              {/if}
             {/if}
           <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
             {if $state.title}
@@ -97,21 +120,44 @@
       {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
       {capture name='prettyblock_cover_state_style'}
         {$prettyblock_cover_state_spacing_style}
+        {if $state.parallax && isset($state.background_image.url) && $state.background_image.url}
+          background-image:url('{$state.background_image.url|escape:'htmlall'}');
+          background-size:cover;
+          background-position:center;
+          background-repeat:no-repeat;
+          background-attachment:fixed;
+          {if isset($state.background_image.height) && $state.background_image.height}
+            min-height:{$state.background_image.height|intval}px;
+          {/if}
+        {/if}
       {/capture}
       {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
       <div id="block-{$block.id_prettyblocks}-{$key}"
-           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
+           class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
         {if isset($state.background_image.url) && $state.background_image.url}
-          <picture>
+          {if $state.parallax}
             {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-              <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
+              <style>
+                @media (max-width: 767px) {
+                  #block-{$block.id_prettyblocks}-{$key} {
+                    background-image:url('{$state.background_image_mobile.url|escape:'htmlall'}');
+                    {if isset($state.background_image_mobile.height) && $state.background_image_mobile.height}min-height:{$state.background_image_mobile.height|intval}px;{/if}
+                  }
+                }
+              </style>
             {/if}
-            <img src="{$state.background_image.url|escape:'htmlall'}"
-                 alt="{$state.title|escape:'htmlall'}"
-                 {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
-                 {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
-                 class="prettyblock-cover-image">
-          </picture>
+          {else}
+            <picture>
+              {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
+                <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
+              {/if}
+              <img src="{$state.background_image.url|escape:'htmlall'}"
+                   alt="{$state.title|escape:'htmlall'}"
+                   {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
+                   {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
+                   class="prettyblock-cover-image">
+            </picture>
+          {/if}
         {/if}
         <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
           {if $state.title}


### PR DESCRIPTION
## Summary
- add a parallax toggle to Prettyblock cover block state configuration
- update the cover template to render background-based parallax images with mobile overrides
- style parallax-enabled cover items for both desktop and mobile behaviour

## Testing
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68d6596049e48322b49452b58c11aefe