### PR TITLE
Adjust lookbook helper button layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -97,7 +97,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.85rem 1.75rem;
+    padding: 1rem 2.25rem;
     border-radius: 999px;
     background-color: #fff;
     border: 1px solid rgba(242, 91, 118, 0.25);
@@ -105,14 +105,15 @@
     font-size: 0.95rem;
     color: #3a3a3a;
     z-index: 1;
+    white-space: nowrap;
 }
 
 .lookbook-helper-icon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 2.75rem;
+    height: 2.75rem;
     border-radius: 50%;
     border: 2px solid #f25b76;
     background-color: #fff;
@@ -125,6 +126,8 @@
 
 .lookbook-helper-text {
     font-weight: 600;
+    font-size: 0.85rem;
+    line-height: 1;
 }
 
 @media (max-width: 767.98px) {
@@ -136,7 +139,7 @@
     .lookbook-helper {
         width: calc(100% - 3rem);
         max-width: 320px;
-        padding: 0.75rem 1.25rem;
+        padding: 0.85rem 1.75rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the lookbook helper button while reducing the text size for better balance
- keep the helper content on a single line with whitespace control and updated spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da468edd6c8322a119a1a3bbe134ed