### PR TITLE
Adjust lookbook helper text emphasis

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -96,6 +96,7 @@
     transform: translate(-50%, 50%);
     display: inline-flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.75rem;
     padding: 1rem 2.25rem;
     border-radius: 999px;
@@ -105,7 +106,8 @@
     font-size: 0.95rem;
     color: #3a3a3a;
     z-index: 1;
-    white-space: nowrap;
+    white-space: normal;
+    text-align: left;
 }
 
 .lookbook-helper-icon {
@@ -128,6 +130,7 @@
     font-weight: 600;
     font-size: 0.85rem;
     line-height: 1;
+    min-width: 0;
 }
 
 @media (max-width: 767.98px) {
@@ -140,6 +143,12 @@
         width: calc(100% - 3rem);
         max-width: 320px;
         padding: 0.85rem 1.75rem;
+        justify-content: center;
+        text-align: center;
+    }
+
+    .lookbook-helper-text {
+        flex-basis: 100%;
     }
 }
 

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -64,7 +64,7 @@
                 <path fill="currentColor" d="M454.423,278.957,328,243.839v-8.185a116,116,0,1,0-104,0V312H199.582l-18.494-22.6a90.414,90.414,0,0,0-126.43-13.367,20.862,20.862,0,0,0-8.026,33.47L215.084,496H472V302.08A24.067,24.067,0,0,0,454.423,278.957ZM192,132a84,84,0,1,1,136,65.9V132a52,52,0,0,0-104,0v65.9A83.866,83.866,0,0,1,192,132ZM440,464H229.3L79.141,297.75a58.438,58.438,0,0,1,77.181,11.91l28.1,34.34H256V132a20,20,0,0,1,40,0V268.161l144,40Z"/>
               </svg>
             </span>
-            <span class="lookbook-helper-text">{l s='Cliquez sur un point pour voir le produit' mod='everblock'}</span>
+            <span class="lookbook-helper-text"><strong>{l s='Cliquez sur un point' mod='everblock'}</strong> {l s='pour voir le produit' mod='everblock'}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- split the lookbook helper text into two translated segments
- emphasize the "Cliquez sur un point" portion with bold styling
- allow the lookbook helper bubble to wrap and center its text on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4e4c98c88322b747874d529df690