### PR TITLE
Adjust lookbook helper layout on desktop

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -152,6 +152,24 @@
     }
 }
 
+@media (min-width: 768px) {
+    .lookbook-helper {
+        flex-wrap: nowrap;
+        padding: 1.25rem 3rem;
+        white-space: nowrap;
+    }
+
+    .lookbook-helper-icon {
+        width: 3.25rem;
+        height: 3.25rem;
+    }
+
+    .lookbook-helper-text {
+        font-size: 0.95rem;
+        white-space: nowrap;
+    }
+}
+
 @media (min-width: 992px) {
     .prettyblock-lookbook {
         gap: 0;


### PR DESCRIPTION
## Summary
- prevent the lookbook helper bubble from wrapping on desktop by forcing nowrap layout
- enlarge the helper icon and padding on larger screens while preserving the mobile layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da50ac44f083229b0e02212d8b0960