### PR TITLE
Ensure store list fills width when map hidden

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -781,6 +781,7 @@
 #everblock-storelocator-wrapper.map-hidden #pane-list {
     flex: 0 0 100%;
     max-width: 100%;
+    width: 100%;
 }
 
 #everblock-storelocator-wrapper.map-hidden #storeLocatorTabs {


### PR DESCRIPTION
## Summary
- expand the store list pane to full width when the map is hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7522789083228e1e22b78deeed35