### PR TITLE
feat: add optional animation for lookbook markers

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3041,6 +3041,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Left position (e.g., 50%)'),
                             'default' => '0%',
                         ],
+                        'animation_enabled' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable zoom animation'),
+                            'default' => 0,
+                        ],
                     ], $module),
                 ],
             ];

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -38,6 +38,8 @@
     box-shadow: 0 12px 24px rgba(242, 91, 118, 0.25);
     transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
     color: #f25b76;
+    overflow: visible;
+    z-index: 1;
 }
 
 .lookbook-marker:focus,
@@ -53,6 +55,45 @@
 .lookbook-marker:focus-visible {
     outline: 3px solid rgba(242, 91, 118, 0.35);
     outline-offset: 2px;
+}
+
+.lookbook-marker--animated::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    border: 3px solid rgba(242, 91, 118, 0.4);
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.6;
+    animation: lookbook-marker-zoom 1.8s ease-in-out infinite;
+    pointer-events: none;
+    z-index: -1;
+}
+
+.lookbook-marker--animated:focus::after,
+.lookbook-marker--animated:hover::after,
+.lookbook-marker--animated:active::after {
+    animation-play-state: paused;
+}
+
+@keyframes lookbook-marker-zoom {
+    0% {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 0.6;
+    }
+
+    60% {
+        transform: translate(-50%, -50%) scale(1.35);
+        opacity: 0;
+    }
+
+    100% {
+        transform: translate(-50%, -50%) scale(1.35);
+        opacity: 0;
+    }
 }
 
 .prettyblock-lookbook {
@@ -89,84 +130,10 @@
     margin-bottom: 3.5rem;
 }
 
-.lookbook-helper {
-    position: absolute;
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, 50%);
-    display: inline-flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    padding: 1rem 2.25rem;
-    border-radius: 999px;
-    background-color: #fff;
-    border: 1px solid rgba(242, 91, 118, 0.25);
-    box-shadow: 0 18px 36px rgba(242, 91, 118, 0.18);
-    font-size: 0.95rem;
-    color: #3a3a3a;
-    z-index: 1;
-    white-space: normal;
-    text-align: left;
-}
-
-.lookbook-helper-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.75rem;
-    height: 2.75rem;
-    border-radius: 50%;
-    border: 2px solid #f25b76;
-    background-color: #fff;
-    color: #f25b76;
-}
-
-.lookbook-helper-svg {
-    display: block;
-}
-
-.lookbook-helper-text {
-    font-weight: 600;
-    font-size: 0.85rem;
-    line-height: 1;
-    min-width: 0;
-}
-
 @media (max-width: 767.98px) {
     .prettyblock-lookbook.columns-2,
     .prettyblock-lookbook.columns-3 {
         grid-template-columns: 1fr;
-    }
-
-    .lookbook-helper {
-        width: calc(100% - 3rem);
-        max-width: 320px;
-        padding: 0.85rem 1.75rem;
-        justify-content: center;
-        text-align: center;
-    }
-
-    .lookbook-helper-text {
-        flex-basis: 100%;
-    }
-}
-
-@media (min-width: 768px) {
-    .lookbook-helper {
-        flex-wrap: nowrap;
-        padding: 1.25rem 3rem;
-        white-space: nowrap;
-    }
-
-    .lookbook-helper-icon {
-        width: 3.25rem;
-        height: 3.25rem;
-    }
-
-    .lookbook-helper-text {
-        font-size: 0.95rem;
-        white-space: nowrap;
     }
 }
 
@@ -177,6 +144,12 @@
 
     .prettyblock-lookbook .lookbook-item--main {
         padding: 0 3rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lookbook-marker--animated::after {
+        animation: none;
     }
 }
 /* Style pour le panier déroulant */

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -52,20 +52,12 @@
           {if isset($block.states) && $block.states}
             {foreach from=$block.states item=state}
               {if isset($state.product.id) && $state.product.id}
-                <button type="button" class="lookbook-marker position-absolute" style="top:{$state.top|default:'0%'|escape:'htmlall'};left:{$state.left|default:'0%'|escape:'htmlall'};transform:translate(-50%,-50%);" data-product-id="{$state.product.id}">
+                <button type="button" class="lookbook-marker position-absolute{if $state.animation_enabled|default:false} lookbook-marker--animated{/if}" style="top:{$state.top|default:'0%'|escape:'htmlall'};left:{$state.left|default:'0%'|escape:'htmlall'};transform:translate(-50%,-50%);" data-product-id="{$state.product.id}">
                   <span class="visually-hidden">{l s='View product' mod='everblock'}</span>
                 </button>
               {/if}
             {/foreach}
           {/if}
-          <div class="lookbook-helper" role="note">
-            <span class="lookbook-helper-icon" aria-hidden="true">
-              <svg class="lookbook-helper-svg" width="24" height="24" viewBox="0 0 512 512" focusable="false" aria-hidden="true">
-                <path fill="currentColor" d="M454.423,278.957,328,243.839v-8.185a116,116,0,1,0-104,0V312H199.582l-18.494-22.6a90.414,90.414,0,0,0-126.43-13.367,20.862,20.862,0,0,0-8.026,33.47L215.084,496H472V302.08A24.067,24.067,0,0,0,454.423,278.957ZM192,132a84,84,0,1,1,136,65.9V132a52,52,0,0,0-104,0v65.9A83.866,83.866,0,0,1,192,132ZM440,464H229.3L79.141,297.75a58.438,58.438,0,0,1,77.181,11.91l28.1,34.34H256V132a20,20,0,0,1,40,0V268.161l144,40Z"/>
-              </svg>
-            </span>
-            <span class="lookbook-helper-text"><strong>{l s='Cliquez sur un point' mod='everblock'}</strong> {l s='pour voir le produit' mod='everblock'}</span>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove the helper overlay from the Prettyblock lookbook template
- add a per-product setting to toggle a zoom animation on lookbook markers
- style the optional marker animation and respect reduced motion preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ba0b41e08322a05ad4f769a16ae6