### PR TITLE
Fix syntax error in advent calendar instructions string

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3485,7 +3485,7 @@ class EverblockPrettyBlocks
                         'instructions' => [
                             'type' => 'editor',
                             'label' => $module->l('Instructions text'),
-                            'default' => $module->l('Scratch or click on today's window to reveal your festive surprise!'),
+                            'default' => $module->l('Scratch or click on today\'s window to reveal your festive surprise!'),
                         ],
                         'start_date' => [
                             'type' => 'text',


### PR DESCRIPTION
## Summary
- escape the apostrophe in the advent calendar instructions default text to restore valid PHP syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ceabe4fc832293017bfc9c6dc2aa