### PR TITLE
Add autoplay controls to prettyblock simple image slider

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1206,6 +1206,16 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Enable slider'),
                             'default' => 0,
                         ],
+                        'slider_autoplay' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable auto scroll'),
+                            'default' => 0,
+                        ],
+                        'slider_autoplay_delay' => [
+                            'type' => 'text',
+                            'label' => $module->l('Auto scroll delay (ms)'),
+                            'default' => 5000,
+                        ],
                         'slider_items' => [
                             'type' => 'text',
                             'label' => $module->l('Number of images in slider'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -158,6 +158,8 @@ $(document).ready(function(){
         $('.ever-cover-carousel:not(.slick-initialised)').each(function(){
             var $carousel = $(this);
             var slides = parseInt($carousel.data('items')) || 3;
+            var autoplay = parseInt($carousel.data('autoplay')) === 1;
+            var autoplayDelay = parseInt($carousel.data('autoplayDelay')) || 5000;
             $carousel.on('init', function(event, slick){
                 var $center = $(slick.$slides[slick.currentSlide]);
                 $(slick.$prevArrow).appendTo($center);
@@ -173,7 +175,8 @@ $(document).ready(function(){
                 centerMode: true,
                 arrows: true,
                 dots: false,
-                autoplay: false,
+                autoplay: autoplay,
+                autoplaySpeed: autoplayDelay,
                 responsive: [{
                     breakpoint: 768,
                     settings: {

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -26,7 +26,10 @@
 {if isset($block.states) && $block.states}
   {assign var='use_slider' value=(isset($block.settings.slider) && $block.settings.slider && $block.states|@count > 1)}
   {if $use_slider}
-    <div class="mt-4 ever-cover-carousel" data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}">
+    <div class="mt-4 ever-cover-carousel"
+         data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}"
+         data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
+         data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}">
       {foreach from=$block.states item=state key=key}
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
         <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="


### PR DESCRIPTION
## Summary
- add configuration options to enable autoplay and configure delay for the simple image slider
- pass autoplay settings to the template and slick initialization
- update JavaScript to honor autoplay configuration when initializing the slider

## Testing
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68e3e7574654832280807d5cb698ab68