### PR TITLE
Harden advent calendar window data handling

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -18,7 +18,6 @@
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
 
-{assign var=calendarWindows value=$block.states|default:[]}
 {assign var=isEmployee value=false}
 {if isset($everblock_is_employee) && $everblock_is_employee}
     {assign var=isEmployee value=true}
@@ -41,10 +40,10 @@
     'snowEnabled' => (bool) $snowEnabled,
     'isEmployee' => (bool) $isEmployee,
     'langId' => $currentLangId,
-    'windows' => $calendarWindows,
     'emptyMessage' => {l s='This window is not configured yet.' mod='everblock'},
     'fallbackLockedMessage' => {l s='Come back on %s to open this window.' mod='everblock'},
-    'errorMessage' => {l s='An error occurred. Please try again later.' mod='everblock'}
+    'errorMessage' => {l s='An error occurred. Please try again later.' mod='everblock'},
+    'missingContentMessage' => {l s='The surprise for this window is not available right now.' mod='everblock'}
 ]}
 {assign var=encodedConfig value=$adventConfig|json_encode|base64_encode|escape:'htmlall':'UTF-8'}
 {assign var=containerClass value=''}


### PR DESCRIPTION
## Summary
- sanitize advent calendar window payloads on the server and return them for both unlocked and already-opened responses
- stop embedding full window content in the front-end config and rely on API payloads to populate the calendar UI
- update the calendar JavaScript to consume sanitized window data, handle missing content errors, and remove the preloaded window map

## Testing
- php -l controllers/front/advent.php

------
https://chatgpt.com/codex/tasks/task_e_68e4ab6ee714832293bd9a6d5ff1c9d4