### PR TITLE
Fix advent calendar instructions HTML rendering

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -66,7 +66,7 @@
         <div class="ever-advent-calendar" data-block-id="{$block.id_prettyblocks}" data-config="{$encodedConfig}">
             {if $block.settings.title}<h3 class="ever-advent-calendar__title">{$block.settings.title|escape:'htmlall':'UTF-8'}</h3>{/if}
             {if $instructionsHtml}
-                <div class="ever-advent-calendar__instructions">{$instructionsHtml}</div>
+                <div class="ever-advent-calendar__instructions">{$instructionsHtml nofilter}</div>
             {/if}
             <div class="ever-advent-calendar__status" role="status" aria-live="polite" style="display:none;"></div>
             <div class="ever-advent-calendar__content">


### PR DESCRIPTION
## Summary
- ensure the advent calendar instructions block renders raw HTML content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4dd829ca883229d54521a71c1328e