### PR TITLE
Add configurable background color for advent calendar

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3522,6 +3522,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Enable snowfall decoration'),
                             'default' => true,
                         ],
+                        'calendar_background_color' => [
+                            'type' => 'color',
+                            'label' => $module->l('Calendar background color'),
+                            'default' => '',
+                        ],
                     ], $module),
                 ],
                 'repeater' => [

--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -52,6 +52,7 @@
 {elseif $block.settings.default.container}
     {assign var=containerClass value='container'}
 {/if}
+{assign var=calendarBackgroundColor value=$block.settings.calendar_background_color|default:''}
 <div id="block-{$block.id_prettyblocks}" class="{$containerClass}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
@@ -63,7 +64,7 @@
     {if $block.settings.default.container}
         <div class="row">
     {/if}
-        <div class="ever-advent-calendar" data-block-id="{$block.id_prettyblocks}" data-config="{$encodedConfig}">
+        <div class="ever-advent-calendar" data-block-id="{$block.id_prettyblocks}" data-config="{$encodedConfig}"{if $calendarBackgroundColor} style="background-color:{$calendarBackgroundColor|escape:'htmlall':'UTF-8'};"{/if}>
             {if $block.settings.title}<h3 class="ever-advent-calendar__title">{$block.settings.title|escape:'htmlall':'UTF-8'}</h3>{/if}
             {if $instructionsHtml}
                 <div class="ever-advent-calendar__instructions">{$instructionsHtml}</div>


### PR DESCRIPTION
## Summary
- add a background color field to the Advent Calendar prettyblock configuration
- render the configured color as the background of the `.ever-advent-calendar` container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4de2df0b0832282e0c40086638ee3