### PR TITLE
Fix snowfall decoration toggle in Prettyblock Advent calendar

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -28,7 +28,11 @@
 {assign var=startDate value=$block.settings.start_date|default:''}
 {assign var=restrictToCurrent value=$block.settings.restrict_to_current_day|default:true}
 {assign var=openedLabel value=$block.settings.opened_label|default:{l s='Opened' mod='everblock'}}
-{assign var=snowEnabled value=$block.settings.snow_enabled|default:true}
+{if isset($block.settings.snow_enabled)}
+    {assign var=snowEnabled value=$block.settings.snow_enabled|@boolval}
+{else}
+    {assign var=snowEnabled value=true}
+{/if}
 {assign var=adventConfig value=[
     'idBlock' => $block.id_prettyblocks,
     'playUrl' => $link->getModuleLink('everblock','advent'),
@@ -53,6 +57,10 @@
     {assign var=containerClass value='container'}
 {/if}
 {assign var=calendarBackgroundColor value=$block.settings.calendar_background_color|default:''}
+{assign var=calendarClasses value='ever-advent-calendar'}
+{if $snowEnabled}
+    {assign var=calendarClasses value="{$calendarClasses} ever-advent-calendar--snow"}
+{/if}
 <div id="block-{$block.id_prettyblocks}" class="{$containerClass}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
@@ -64,7 +72,7 @@
     {if $block.settings.default.container}
         <div class="row">
     {/if}
-        <div class="ever-advent-calendar" data-block-id="{$block.id_prettyblocks}" data-config="{$encodedConfig}"{if $calendarBackgroundColor} style="background-color:{$calendarBackgroundColor|escape:'htmlall':'UTF-8'};"{/if}>
+        <div class="{$calendarClasses}" data-block-id="{$block.id_prettyblocks}" data-config="{$encodedConfig}"{if $calendarBackgroundColor} style="background-color:{$calendarBackgroundColor|escape:'htmlall':'UTF-8'};"{/if}>
             {if $block.settings.title}<h3 class="ever-advent-calendar__title">{$block.settings.title|escape:'htmlall':'UTF-8'}</h3>{/if}
             {if $instructionsHtml}
                 <div class="ever-advent-calendar__instructions">{$instructionsHtml nofilter}</div>


### PR DESCRIPTION
## Summary
- ensure the snowfall checkbox value is converted to a real boolean before building the Advent calendar config
- add the snow CSS class on the server side when the decoration is enabled so the effect is visible immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4decfa934832291af19d6179403f4