### PR TITLE
Move Prettyblock carousel navigation outside slider

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -199,6 +199,27 @@
     text-align: right;
     font-weight: bold;
 }
+
+/* Position carousel navigation outside of slider */
+.ever-featured-products .carousel {
+    overflow: visible;
+}
+
+.ever-featured-products .carousel-control-prev,
+.ever-featured-products .carousel-control-next {
+    width: 3rem;
+    height: 3rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.ever-featured-products .carousel-control-prev {
+    left: -1.5rem;
+}
+
+.ever-featured-products .carousel-control-next {
+    right: -1.5rem;
+}
 /* Style pour les boutons de partage */
 
 .everblock-sharer {


### PR DESCRIPTION
## Summary
- allow the Prettyblock featured category carousel to display navigation controls outside the product slider
- keep the controls vertically centered by overriding the default dimensions of the Bootstrap buttons

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4e50686cc8322a30ab8681faa5e95