### PR TITLE
Fix mobile position class hyphenation for Prettyblock overlays

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -53,7 +53,7 @@
           {/if}
 
         {if $state.name}
-          <div class="prettyblock-cover-overlay category_state_name position-desktop-{$state.title_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.title_position_mobile|default:'center'|lower|escape:'htmlall'}">
+          <div class="prettyblock-cover-overlay category_state_name position-desktop-{$state.title_position_desktop|default:'center'|lower|replace:' ':'-'|escape:'htmlall'} position-mobile-{$state.title_position_mobile|default:'center'|lower|replace:' ':'-'|escape:'htmlall'}">
             <h2 class="m-0 text-white">{$state.name nofilter}</h2>
           </div>
         {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -78,7 +78,7 @@
                 </picture>
               {/if}
             {/if}
-          <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
+          <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|replace:' ':'-'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|replace:' ':'-'|escape:'htmlall'}">
             {if $state.title}
               <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
             {/if}
@@ -159,7 +159,7 @@
             </picture>
           {/if}
         {/if}
-        <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|escape:'htmlall'}">
+        <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|replace:' ':'-'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|replace:' ':'-'|escape:'htmlall'}">
           {if $state.title}
             <{$state.title_tag|default:'h2'}{if isset($state.title_color) && $state.title_color} style="color: {$state.title_color|escape:'htmlall'}"{/if}>{$state.title|escape:'htmlall'}</{$state.title_tag|default:'h2'}>
           {/if}


### PR DESCRIPTION
## Summary
- normalize desktop and mobile position class names in Prettyblock cover templates
- ensure multi-word positions replace spaces with hyphens so CSS selectors apply

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e709d5dc832283fae7f6f38af997