### PR TITLE
Allow CLI autoloading of shortcode documentation provider

### DIFF
--- a/src/Service/ShortcodeDocumentationProvider.php
+++ b/src/Service/ShortcodeDocumentationProvider.php
@@ -23,7 +23,7 @@ namespace Everblock\Tools\Service;
 use Context;
 use Module;
 
-if (!defined('_PS_VERSION_')) {
+if (!defined('_PS_VERSION_') && php_sapi_name() !== 'cli') {
     exit;
 }
 


### PR DESCRIPTION
## Summary
- relax the PrestaShop guard in `ShortcodeDocumentationProvider` so the class can be autoloaded when running in CLI contexts

## Testing
- php -l src/Service/ShortcodeDocumentationProvider.php

------
https://chatgpt.com/codex/tasks/task_e_68f2114d6370832294adc97a7c591d0e