### PR TITLE
Refine Prettyblock TOC layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -946,103 +946,182 @@
 }
 
 /* Table of Contents styles */
+.pb-toc-summary {
+    background-color: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    box-shadow: 0 4px 24px rgba(33, 37, 41, 0.04);
+    margin-bottom: 2rem;
+}
+
+@media (min-width: 992px) {
+    .pb-toc-summary {
+        position: sticky;
+        top: 1.5rem;
+        margin-bottom: 0;
+    }
+}
+
+.pb-toc-title {
+    font-weight: 600;
+    color: #1f2933;
+}
+
 .pb-toc-menu {
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 1rem;
 }
+
+.pb-toc-category + .pb-toc-category {
+    padding-top: 1rem;
+    border-top: 1px solid #edf2f7;
+}
+
 .pb-toc-toggle {
     cursor: pointer;
-    text-align: left;
     width: 100%;
-    background: none;
     border: none;
+    background: transparent;
+    padding: 0;
+    text-align: left;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.6rem;
-    color: #212529;
+    color: #1f2933;
     font-weight: 600;
-    transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
 }
+
+.pb-toc-toggle.pb-toc-toggle-category {
+    font-size: 1rem;
+    letter-spacing: 0.01em;
+}
+
+.pb-toc-toggle:hover,
+.pb-toc-toggle:focus {
+    color: #0d6efd;
+    text-decoration: none;
+}
+
+.pb-toc-toggle.is-open {
+    color: #0d6efd;
+}
+
 .pb-toc-toggle:focus-visible {
     outline: 2px solid rgba(13, 110, 253, 0.35);
     outline-offset: 2px;
 }
-.pb-toc-toggle:hover,
-.pb-toc-toggle[aria-expanded="true"],
-.pb-toc-toggle.is-open {
-    background-color: rgba(13, 110, 253, 0.08);
-    color: #0d6efd;
-    box-shadow: 0 8px 20px rgba(13, 110, 253, 0.08);
+
+.pb-toc-toggle.pb-toc-toggle-sub {
+    font-weight: 500;
+    color: #495057;
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
 }
+
+.pb-toc-toggle.pb-toc-toggle-sub:hover,
+.pb-toc-toggle.pb-toc-toggle-sub:focus {
+    color: #0d6efd;
+}
+
 .pb-toc-toggle-label {
     flex: 1;
-    padding-right: 0.5rem;
 }
+
 .pb-toc-toggle-icon {
-    flex-shrink: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border-radius: 50%;
-    background-color: rgba(13, 110, 253, 0.12);
-    color: #0d6efd;
-    transition: transform 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: currentColor;
+    transition: transform 0.2s ease;
 }
-.pb-toc-toggle:hover .pb-toc-toggle-icon,
-.pb-toc-toggle[aria-expanded="true"] .pb-toc-toggle-icon,
-.pb-toc-toggle.is-open .pb-toc-toggle-icon {
-    background-color: #0d6efd;
-    color: #fff;
-}
+
 .pb-toc-toggle-icon::before {
     content: "";
     display: block;
     width: 0.45rem;
     height: 0.45rem;
-    border-style: solid;
-    border-width: 0 2px 2px 0;
-    border-color: currentColor;
+    border: solid currentColor;
+    border-width: 0 1.5px 1.5px 0;
     transform: rotate(-45deg);
-    transition: transform 0.3s ease;
+    transition: transform 0.2s ease;
 }
-.pb-toc-toggle[aria-expanded="true"] .pb-toc-toggle-icon::before,
-.pb-toc-toggle.is-open .pb-toc-toggle-icon::before {
+
+.pb-toc-toggle.is-open .pb-toc-toggle-icon::before,
+.pb-toc-toggle[aria-expanded="true"] .pb-toc-toggle-icon::before {
     transform: rotate(45deg);
 }
+
+.pb-toc-subcategory {
+    padding-left: 1rem;
+}
+
+.pb-toc-subcategory .pb-toc-link {
+    padding-left: 0.25rem;
+}
+
 .pb-toc-link {
     display: block;
-    padding: 0.4rem 0.75rem;
-    border-radius: 0.6rem;
+    padding: 0.35rem 0;
     color: #495057;
     text-decoration: none;
-    transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+    border-radius: 0.25rem;
+    transition: color 0.2s ease, background-color 0.2s ease;
 }
+
 .pb-toc-link:hover,
 .pb-toc-link:focus {
     color: #0d6efd;
     background-color: rgba(13, 110, 253, 0.08);
     text-decoration: none;
 }
+
 .pb-toc-link:focus-visible {
     outline: 2px solid rgba(13, 110, 253, 0.35);
     outline-offset: 2px;
 }
+
 .pb-toc-link.is-active {
-    background-color: #0d6efd;
-    color: #fff;
-    box-shadow: 0 8px 24px rgba(13, 110, 253, 0.18);
+    color: #0d6efd;
+    font-weight: 600;
 }
+
+.pb-toc-section {
+    padding: 2rem 0;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.pb-toc-section:first-of-type {
+    padding-top: 0;
+}
+
+.pb-toc-section:last-of-type {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
 .pb-toc-section.is-hidden {
     display: none;
 }
+
 .pb-toc-section.is-active {
     display: block;
+}
+
+.pb-toc-content {
+    margin-top: 2rem;
+}
+
+@media (min-width: 992px) {
+    .pb-toc-content {
+        margin-top: 0;
+        padding-left: 3rem;
+    }
 }
 
 /* Pricing table styles */

--- a/views/templates/hook/prettyblocks/prettyblock_toc.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_toc.tpl
@@ -32,39 +32,42 @@
     <div class="row">
   {/if}
   {if isset($block.states) && $block.states}
-    <div class="col-12 col-lg-4 pb-toc-summary">
-      {if isset($block.settings.title) && $block.settings.title}
-        <span class="h2 pb-toc-title">{$block.settings.title|escape:'htmlall'}</span>
-      {/if}
-      <ul class="list-unstyled pb-toc-menu">
-        {assign var='currentCategory' value=''}
-        {assign var='currentSub' value=''}
-        {assign var='catIndex' value=0}
-        {assign var='subIndex' value=0}
-        {foreach from=$block.states item=state}
-          {if $state.category != $currentCategory}
-            {if $currentSub != ''}</ul></li>{/if}
-            {if $currentCategory != ''}</ul></li>{/if}
-            {assign var='catIndex' value=$catIndex+1}
-            <li class="pb-toc-category">
-              <button class="pb-toc-toggle btn btn-link p-0" type="button" data-toggle="collapse" data-target="#pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" data-bs-toggle="collapse" data-bs-target="#pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" aria-expanded="false" aria-controls="pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}">
-                <span class="pb-toc-toggle-label">{$state.category|escape:'htmlall'}</span>
-                <span class="pb-toc-toggle-icon" aria-hidden="true"></span>
-              </button>
-              <ul id="pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" class="list-unstyled collapse">
-            {assign var='currentCategory' value=$state.category}
-            {assign var='currentSub' value=''}
-          {/if}
-          {if $state.subcategory != $currentSub}
-            {if $currentSub != ''}</ul></li>{/if}
-            {if $state.subcategory != ''}
-              {assign var='subIndex' value=$subIndex+1}
-              <li class="pb-toc-subcategory">
-                <button class="pb-toc-toggle btn btn-link p-0" type="button" data-toggle="collapse" data-target="#pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" data-bs-toggle="collapse" data-bs-target="#pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" aria-expanded="false" aria-controls="pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}">
-                  <span class="pb-toc-toggle-label">{$state.subcategory|escape:'htmlall'}</span>
+    <div class="col-12 col-lg-4">
+      <aside class="pb-toc-summary">
+        {if isset($block.settings.title) && $block.settings.title}
+          <h2 class="pb-toc-title h4 mb-4">{$block.settings.title|escape:'htmlall'}</h2>
+        {/if}
+        <ul class="list-unstyled pb-toc-menu">
+          {assign var='currentCategory' value=''}
+          {assign var='currentSub' value=''}
+          {assign var='catIndex' value=0}
+          {assign var='subIndex' value=0}
+          {foreach from=$block.states item=state}
+            {if $state.category != $currentCategory}
+              {if $currentSub != ''}</ul></li>{/if}
+              {if $currentCategory != ''}</ul></li>{/if}
+              {assign var='catIndex' value=$catIndex+1}
+              <li class="pb-toc-category">
+                {assign var='categoryDefaultOpen' value=($catIndex eq 1)}
+                <button class="pb-toc-toggle pb-toc-toggle-category{if $categoryDefaultOpen} is-open{/if}" type="button" data-toggle="collapse" data-target="#pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" data-bs-toggle="collapse" data-bs-target="#pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" aria-expanded="{if $categoryDefaultOpen}true{else}false{/if}" aria-controls="pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}">
+                  <span class="pb-toc-toggle-label">{$state.category|escape:'htmlall'}</span>
                   <span class="pb-toc-toggle-icon" aria-hidden="true"></span>
                 </button>
-                <ul id="pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" class="list-unstyled collapse">
+                <ul id="pb-toc-cat-{$block.id_prettyblocks}-{$catIndex}" class="list-unstyled collapse{if $categoryDefaultOpen} show{/if}">
+              {assign var='currentCategory' value=$state.category}
+              {assign var='currentSub' value=''}
+            {/if}
+            {if $state.subcategory != $currentSub}
+              {if $currentSub != ''}</ul></li>{/if}
+              {if $state.subcategory != ''}
+                {assign var='subIndex' value=$subIndex+1}
+                <li class="pb-toc-subcategory">
+                  {assign var='subDefaultOpen' value=($categoryDefaultOpen && $subIndex eq 1)}
+                  <button class="pb-toc-toggle pb-toc-toggle-sub{if $subDefaultOpen} is-open{/if}" type="button" data-toggle="collapse" data-target="#pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" data-bs-toggle="collapse" data-bs-target="#pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" aria-expanded="{if $subDefaultOpen}true{else}false{/if}" aria-controls="pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}">
+                    <span class="pb-toc-toggle-label">{$state.subcategory|escape:'htmlall'}</span>
+                    <span class="pb-toc-toggle-icon" aria-hidden="true"></span>
+                  </button>
+                  <ul id="pb-toc-sub-{$block.id_prettyblocks}-{$catIndex}-{$subIndex}" class="list-unstyled collapse{if $subDefaultOpen} show{/if}">
               {assign var='currentSub' value=$state.subcategory}
             {else}
               {assign var='currentSub' value=''}
@@ -74,7 +77,8 @@
         {/foreach}
         {if $currentSub != ''}</ul></li>{/if}
         {if $currentCategory != ''}</ul></li>{/if}
-      </ul>
+        </ul>
+      </aside>
     </div>
     <div class="col-12 col-lg-8 pb-toc-content">
       {foreach from=$block.states item=state}


### PR DESCRIPTION
## Summary
- restyle the Prettyblock table of contents summary to match the provided UX with a sticky card layout
- simplify the navigation toggles and default-open behavior for the first category and subsection
- refresh section spacing and active states for clearer reading in the content column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2109f6b2c8322ab375c81a6b3e23e