### PR TITLE
Add infinite slider option to Prettyblock Simple Image block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1211,6 +1211,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Enable auto scroll'),
                             'default' => 0,
                         ],
+                        'slider_infinite' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable infinite loop'),
+                            'default' => 0,
+                        ],
                         'slider_autoplay_delay' => [
                             'type' => 'text',
                             'label' => $module->l('Auto scroll delay (ms)'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -160,6 +160,7 @@ $(document).ready(function(){
             var slides = parseInt($carousel.data('items')) || 3;
             var autoplay = parseInt($carousel.data('autoplay')) === 1;
             var autoplayDelay = parseInt($carousel.data('autoplayDelay')) || 5000;
+            var infinite = parseInt($carousel.data('infinite')) === 1;
             $carousel.on('init', function(event, slick){
                 var $center = $(slick.$slides[slick.currentSlide]);
                 $(slick.$prevArrow).appendTo($center);
@@ -175,6 +176,7 @@ $(document).ready(function(){
                 centerMode: true,
                 arrows: true,
                 dots: false,
+                infinite: infinite,
                 autoplay: autoplay,
                 autoplaySpeed: autoplayDelay,
                 responsive: [{

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -29,6 +29,7 @@
     <div class="mt-4 ever-cover-carousel"
          data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
+         data-infinite="{if isset($block.settings.slider_infinite) && $block.settings.slider_infinite}1{else}0{/if}"
          data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}">
       {foreach from=$block.states item=state key=key}
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}


### PR DESCRIPTION
## Summary
- add an infinite loop checkbox to the Prettyblock Simple Image configuration
- wire the setting to the template data attributes and slick initialization so sliders can loop endlessly

## Testing
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_68f2128ff5e88322b2d26d1d7ee5b3c0