### PR TITLE
Allow ShortcodeDocumentationProvider in allowed files list

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -76,6 +76,7 @@ return [
     'models/EverblockFlagsClass.php',
     'models/EverblockModal.php',
     'src/Service/EverblockPrettyBlocks.php',
+    'src/Service/ShortcodeDocumentationProvider.php',
     'models/EverblockShortcode.php',
     'models/EverblockTabsClass.php',
     'models/EverblockTools.php',


### PR DESCRIPTION
## Summary
- add `src/Service/ShortcodeDocumentationProvider.php` to the module's allowed files list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f21533d8b083228dfdc9db48a74291