### PR TITLE
Hide empty helper anchors on module configuration page

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -385,6 +385,10 @@
     box-shadow: none;
 }
 
+#module_form .everblock-form-group--anchor {
+    display: none;
+}
+
 #module_form .form-group:last-of-type {
     margin-bottom: 0;
 }

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -56,6 +56,20 @@ $(document).ready(function() {
       .appendTo($wrapper);
   });
 
+  // Hide structural anchors injected as ``html`` helper inputs so that they do
+  // not render as empty form rows while keeping them in the DOM for potential
+  // scroll targeting.
+  $('.everblock-config__card--form span[id^="everblock_"]').each(function() {
+    const $anchor = $(this);
+    const $group = $anchor.closest('.form-group');
+
+    $anchor.attr('aria-hidden', 'true');
+
+    if ($group.length && $.trim($group.text()) === '') {
+      $group.addClass('everblock-form-group--anchor');
+    }
+  });
+
   // Transform legacy documentation cards into accessible accordions that match
   // the refreshed admin layout.
   $('.everblock-config__card--form .everblock-doc').each(function() {


### PR DESCRIPTION
## Summary
- hide the helper-generated anchor rows that rendered as empty form groups
- keep the anchors in the DOM for potential scroll targeting while marking them aria-hidden

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f22f5d4ba48322bdac561b17dd1f71