### PR TITLE
Fix everPresentProducts call in header hook

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -4025,8 +4025,7 @@ class Everblock extends Module
             if (Validate::isLoadedObject($product)) {
                 $presentedProducts = EverblockTools::everPresentProducts(
                     [$product->id],
-                    $this->context,
-                    $this
+                    $this->context
                 );
                 $presentedProduct = reset($presentedProducts);
 


### PR DESCRIPTION
## Summary
- remove the redundant module instance argument when presenting Google Shopping products in hookDisplayHeader
- ensure the helper method is always invoked with only the expected arguments

## Testing
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68f34d3310bc832290a2998dda302fe0