### PR TITLE
Ensure bootstrap class persists as string

### DIFF
--- a/src/Form/DataProvider/EverblockFormDataProvider.php
+++ b/src/Form/DataProvider/EverblockFormDataProvider.php
@@ -88,7 +88,7 @@ class EverblockFormDataProvider
             'background' => '',
             'css_class' => '',
             'data_attribute' => '',
-            'bootstrap_class' => 0,
+            'bootstrap_class' => '',
             'position' => '',
             'modal' => false,
             'delay' => '',
@@ -134,7 +134,7 @@ class EverblockFormDataProvider
         $default['background'] = (string) $block->background;
         $default['css_class'] = (string) $block->css_class;
         $default['data_attribute'] = (string) $block->data_attribute;
-        $default['bootstrap_class'] = (int) $block->bootstrap_class;
+        $default['bootstrap_class'] = (string) $block->bootstrap_class;
         $default['position'] = (string) $block->position;
         $default['modal'] = (bool) $block->modal;
         $default['delay'] = (string) $block->delay;

--- a/src/Form/Handler/EverblockFormHandler.php
+++ b/src/Form/Handler/EverblockFormHandler.php
@@ -104,7 +104,7 @@ class EverblockFormHandler
         $everBlock->background = (string) $data['background'];
         $everBlock->css_class = (string) $data['css_class'];
         $everBlock->data_attribute = (string) $data['data_attribute'];
-        $everBlock->bootstrap_class = (int) $data['bootstrap_class'];
+        $everBlock->bootstrap_class = (string) $data['bootstrap_class'];
         $everBlock->device = (int) $data['device'];
         $everBlock->delay = $data['delay'] === '' ? 0 : (int) $data['delay'];
         $everBlock->timeout = $data['timeout'] === '' ? 0 : (int) $data['timeout'];


### PR DESCRIPTION
## Summary
- initialize the bootstrap class form data as an empty string and return it as a string when loading existing blocks
- persist the submitted bootstrap class value without casting to an integer so CSS classes are retained

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f34d463f488322ac62b8444a7e5891