### PR TITLE
feat: migrate FAQ fetching to Doctrine repository

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -120,7 +120,13 @@ services:
             $connection: '@doctrine.dbal.default_connection'
             $cache: '@cache.app'
 
+    Everblock\Tools\Repository\EverBlockFaqRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $cache: '@cache.app'
+
     Everblock\Tools\Service\EverBlockProvider: ~
+    Everblock\Tools\Service\EverBlockFaqProvider: ~
 
     Everblock\Tools\Controller\Admin\:
         resource: '../src/Controller/Admin'

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -17,7 +17,9 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverBlockFaqProvider;
 use Everblock\Tools\Service\EverblockCache;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -956,7 +958,16 @@ class EverblockTools extends ObjectModel
         $txt = preg_replace_callback($pattern, function ($matches) use ($context, $templatePath) {
             $tagName = $matches[1];
 
-            $faqs = EverblockFaq::getFaqByTagName($context->shop->id, $context->language->id, $tagName);
+            $faqs = [];
+            if (class_exists(SymfonyContainer::class)) {
+                $container = SymfonyContainer::getInstance();
+                if (null !== $container && $container->has(EverBlockFaqProvider::class)) {
+                    $provider = $container->get(EverBlockFaqProvider::class);
+                    if ($provider instanceof EverBlockFaqProvider) {
+                        $faqs = $provider->getFaqByTagName($context->shop->id, $context->language->id, $tagName);
+                    }
+                }
+            }
 
             $context->smarty->assign('everFaqs', $faqs);
 

--- a/src/Entity/EverBlockFaq.php
+++ b/src/Entity/EverBlockFaq.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_faq')]
+class EverBlockFaq
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_everblock_faq', type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'tag_name', type: 'text', nullable: true)]
+    private ?string $tagName = null;
+
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId = 0;
+
+    #[ORM\Column(name: 'position', type: 'integer', options: ['default' => 0])]
+    private int $position = 0;
+
+    #[ORM\Column(name: 'active', type: 'boolean', options: ['default' => true])]
+    private bool $active = true;
+
+    #[ORM\Column(name: 'date_add', type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $dateAdd = null;
+
+    #[ORM\Column(name: 'date_upd', type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $dateUpdated = null;
+
+    /**
+     * @var Collection<int, EverBlockFaqTranslation>
+     */
+    #[ORM\OneToMany(mappedBy: 'faq', targetEntity: EverBlockFaqTranslation::class, cascade: ['persist', 'remove'])]
+    private Collection $translations;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTagName(): ?string
+    {
+        return $this->tagName;
+    }
+
+    public function setTagName(?string $tagName): void
+    {
+        $this->tagName = $tagName;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function setShopId(int $shopId): void
+    {
+        $this->shopId = $shopId;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): void
+    {
+        $this->active = $active;
+    }
+
+    public function getDateAdd(): ?\DateTimeInterface
+    {
+        return $this->dateAdd;
+    }
+
+    public function setDateAdd(?\DateTimeInterface $dateAdd): void
+    {
+        $this->dateAdd = $dateAdd;
+    }
+
+    public function getDateUpdated(): ?\DateTimeInterface
+    {
+        return $this->dateUpdated;
+    }
+
+    public function setDateUpdated(?\DateTimeInterface $dateUpdated): void
+    {
+        $this->dateUpdated = $dateUpdated;
+    }
+
+    /**
+     * @return Collection<int, EverBlockFaqTranslation>
+     */
+    public function getTranslations(): Collection
+    {
+        return $this->translations;
+    }
+}

--- a/src/Entity/EverBlockFaqTranslation.php
+++ b/src/Entity/EverBlockFaqTranslation.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_faq_lang')]
+class EverBlockFaqTranslation
+{
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: EverBlockFaq::class, inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'id_everblock_faq', referencedColumnName: 'id_everblock_faq', nullable: false, onDelete: 'CASCADE')]
+    private EverBlockFaq $faq;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_lang', type: 'integer')]
+    private int $languageId;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    public function __construct(EverBlockFaq $faq, int $languageId, int $shopId)
+    {
+        $this->faq = $faq;
+        $this->languageId = $languageId;
+        $this->shopId = $shopId;
+    }
+
+    public function getFaq(): EverBlockFaq
+    {
+        return $this->faq;
+    }
+
+    public function getLanguageId(): int
+    {
+        return $this->languageId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+}

--- a/src/Repository/EverBlockFaqRepository.php
+++ b/src/Repository/EverBlockFaqRepository.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class EverBlockFaqRepository
+{
+    private const CACHE_TAG = 'everblock_faq';
+    private const CACHE_TTL = 86400;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TagAwareCacheInterface $cache,
+        private readonly ?string $tablePrefix = null
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAllFaq(int $shopId, int $languageId): array
+    {
+        $cacheKey = sprintf('everblock.faq.all.%d.%d', $shopId, $languageId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($shopId, $languageId) {
+            $item->expiresAfter(self::CACHE_TTL);
+            $item->tag($this->buildTags($shopId, $languageId));
+
+            $queryBuilder = $this->createBaseQueryBuilder($shopId, $languageId)
+                ->andWhere('faq.active = 1')
+                ->orderBy('faq.position', 'ASC');
+
+            return $queryBuilder->executeQuery()->fetchAllAssociative();
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getFaqByTagName(int $shopId, int $languageId, string $tagName): array
+    {
+        $normalizedTag = $this->normalizeTagName($tagName);
+        $cacheKey = sprintf('everblock.faq.tag.%d.%d.%s', $shopId, $languageId, $normalizedTag);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($shopId, $languageId, $tagName, $normalizedTag) {
+            $item->expiresAfter(self::CACHE_TTL);
+            $item->tag(array_merge(
+                $this->buildTags($shopId, $languageId),
+                [sprintf('everblock_faq_tag_%s', $normalizedTag)]
+            ));
+
+            $queryBuilder = $this->createBaseQueryBuilder($shopId, $languageId)
+                ->andWhere('faq.active = 1')
+                ->andWhere('faq.tag_name = :tagName')
+                ->setParameter('tagName', trim($tagName), ParameterType::STRING)
+                ->orderBy('faq.position', 'ASC');
+
+            return $queryBuilder->executeQuery()->fetchAllAssociative();
+        });
+    }
+
+    public function clearCache(): void
+    {
+        $this->cache->invalidateTags([self::CACHE_TAG]);
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_faq_shop_%d', $shopId),
+        ]);
+    }
+
+    public function clearCacheForTag(int $shopId, string $tagName): void
+    {
+        $normalizedTag = $this->normalizeTagName($tagName);
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_faq_shop_%d', $shopId),
+            sprintf('everblock_faq_tag_%s', $normalizedTag),
+        ]);
+    }
+
+    private function createBaseQueryBuilder(int $shopId, int $languageId): QueryBuilder
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select(
+                'faq.id_everblock_faq',
+                'faq.id_shop',
+                'faq.tag_name',
+                'faq.position',
+                'faq.active',
+                'faq.date_add',
+                'faq.date_upd',
+                'faql.title',
+                'faql.content'
+            )
+            ->from($this->getTableName('everblock_faq'), 'faq')
+            ->leftJoin(
+                'faq',
+                $this->getTableName('everblock_faq_lang'),
+                'faql',
+                'faq.id_everblock_faq = faql.id_everblock_faq AND faql.id_lang = :languageId AND faql.id_shop = :shopId'
+            )
+            ->where('faq.id_shop = :shopId')
+            ->setParameter('languageId', $languageId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildTags(int $shopId, int $languageId): array
+    {
+        return [
+            self::CACHE_TAG,
+            sprintf('everblock_faq_shop_%d', $shopId),
+            sprintf('everblock_faq_lang_%d', $languageId),
+        ];
+    }
+
+    private function normalizeTagName(string $tagName): string
+    {
+        return preg_replace('/[^a-z0-9_]/', '_', strtolower(trim($tagName))) ?: 'default';
+    }
+
+    private function getTableName(string $table): string
+    {
+        if (null !== $this->tablePrefix && $this->tablePrefix !== '') {
+            return $this->tablePrefix . $table;
+        }
+
+        if (defined('_DB_PREFIX_')) {
+            return _DB_PREFIX_ . $table;
+        }
+
+        return $table;
+    }
+}

--- a/src/Service/EverBlockFaqProvider.php
+++ b/src/Service/EverBlockFaqProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use ArrayObject;
+use Everblock\Tools\Repository\EverBlockFaqRepository;
+
+class EverBlockFaqProvider
+{
+    public function __construct(private readonly EverBlockFaqRepository $repository)
+    {
+        if (class_exists(\EverblockFaq::class) && method_exists(\EverblockFaq::class, 'setProvider')) {
+            \EverblockFaq::setProvider($this);
+        }
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getAllFaq(int $shopId, int $languageId): array
+    {
+        return $this->hydrateFaqs($this->repository->getAllFaq($shopId, $languageId));
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getFaqByTagName(int $shopId, int $languageId, string $tagName): array
+    {
+        return $this->hydrateFaqs($this->repository->getFaqByTagName($shopId, $languageId, $tagName));
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->repository->clearCacheForShop($shopId);
+    }
+
+    public function clearCacheForTag(int $shopId, string $tagName): void
+    {
+        $this->repository->clearCacheForTag($shopId, $tagName);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return ArrayObject<int, mixed>[]
+     */
+    private function hydrateFaqs(array $rows): array
+    {
+        $faqs = [];
+        foreach ($rows as $row) {
+            $row['id_everblock_faq'] = isset($row['id_everblock_faq']) ? (int) $row['id_everblock_faq'] : 0;
+            $row['position'] = isset($row['position']) ? (int) $row['position'] : 0;
+            $row['id_shop'] = isset($row['id_shop']) ? (int) $row['id_shop'] : 0;
+            $row['active'] = isset($row['active']) ? (bool) $row['active'] : false;
+            $row['tag_name'] = isset($row['tag_name']) ? (string) $row['tag_name'] : '';
+            $row['title'] = isset($row['title']) ? (string) $row['title'] : '';
+            $row['content'] = $row['content'] ?? '';
+            $faqs[] = new ArrayObject($row, ArrayObject::ARRAY_AS_PROPS);
+        }
+
+        return $faqs;
+    }
+}


### PR DESCRIPTION
## Summary
- add Doctrine entities and repository for FAQs backed by Symfony cache
- introduce an EverBlockFaqProvider service and inject it into the module and admin controller
- update FAQ shortcode rendering and admin actions to use the provider and invalidate cache

## Testing
- php -l src/Repository/EverBlockFaqRepository.php
- php -l src/Service/EverBlockFaqProvider.php
- php -l src/Entity/EverBlockFaq.php
- php -l src/Entity/EverBlockFaqTranslation.php
- php -l models/EverblockFaq.php
- php -l models/EverblockTools.php
- php -l everblock.php
- php -l src/Controller/Admin/EverblockFaqController.php

------
https://chatgpt.com/codex/tasks/task_e_68f37d90467083228aa231eb84788d2a