### PR TITLE
feat: migrate product flags and tabs to Doctrine services

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -45,6 +45,12 @@ services:
         tags:
             - { name: 'console.command' }
 
+    everblock.tools.cleanup_legacy_models:
+        class: Everblock\Tools\Command\CleanupLegacyModelsCommand
+        public: true
+        tags:
+            - { name: 'console.command' }
+
     Everblock\Tools\Service\Admin\NavigationBuilder:
         arguments:
             $context: '@prestashop.adapter.legacy.context'
@@ -125,8 +131,20 @@ services:
             $connection: '@doctrine.dbal.default_connection'
             $cache: '@cache.app'
 
+    Everblock\Tools\Repository\EverBlockFlagRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $cache: '@cache.app'
+
+    Everblock\Tools\Repository\EverBlockTabRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $cache: '@cache.app'
+
     Everblock\Tools\Service\EverBlockProvider: ~
     Everblock\Tools\Service\EverBlockFaqProvider: ~
+    Everblock\Tools\Service\EverBlockFlagProvider: ~
+    Everblock\Tools\Service\EverBlockTabProvider: ~
 
     Everblock\Tools\Controller\Admin\:
         resource: '../src/Controller/Admin'

--- a/models/EverblockFlagsClass.php
+++ b/models/EverblockFlagsClass.php
@@ -17,13 +17,18 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverBlockFlagProvider;
 use Everblock\Tools\Service\EverblockCache;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 class EverblockFlagsClass extends ObjectModel
 {
+    /** @var EverBlockFlagProvider|null */
+    protected static $provider;
+
     public $id_everblock_flags;
     public $id_product;
     public $id_shop;
@@ -66,6 +71,32 @@ class EverblockFlagsClass extends ObjectModel
             ],
         ],
     ];
+
+    public static function setProvider(EverBlockFlagProvider $provider): void
+    {
+        static::$provider = $provider;
+    }
+
+    protected static function getProvider(): ?EverBlockFlagProvider
+    {
+        if (static::$provider instanceof EverBlockFlagProvider) {
+            return static::$provider;
+        }
+
+        if (class_exists(SymfonyContainer::class)) {
+            $container = SymfonyContainer::getInstance();
+            if (null !== $container && $container->has(EverBlockFlagProvider::class)) {
+                $provider = $container->get(EverBlockFlagProvider::class);
+                if ($provider instanceof EverBlockFlagProvider) {
+                    static::$provider = $provider;
+
+                    return $provider;
+                }
+            }
+        }
+
+        return null;
+    }
 
     /**
      * get tab object per product & shop, admin only (no cache)

--- a/models/EverblockTabsClass.php
+++ b/models/EverblockTabsClass.php
@@ -17,11 +17,17 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+use Everblock\Tools\Service\EverBlockTabProvider;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 class EverblockTabsClass extends ObjectModel
 {
+    /** @var EverBlockTabProvider|null */
+    protected static $provider;
+
     public $id_everblock_tabs;
     public $id_product;
     public $id_shop;
@@ -64,6 +70,32 @@ class EverblockTabsClass extends ObjectModel
             ],
         ],
     ];
+
+    public static function setProvider(EverBlockTabProvider $provider): void
+    {
+        static::$provider = $provider;
+    }
+
+    protected static function getProvider(): ?EverBlockTabProvider
+    {
+        if (static::$provider instanceof EverBlockTabProvider) {
+            return static::$provider;
+        }
+
+        if (class_exists(SymfonyContainer::class)) {
+            $container = SymfonyContainer::getInstance();
+            if (null !== $container && $container->has(EverBlockTabProvider::class)) {
+                $provider = $container->get(EverBlockTabProvider::class);
+                if ($provider instanceof EverBlockTabProvider) {
+                    static::$provider = $provider;
+
+                    return $provider;
+                }
+            }
+        }
+
+        return null;
+    }
 
     /**
      * get tab object per product & shop, admin only (no cache)

--- a/src/Command/CleanupLegacyModelsCommand.php
+++ b/src/Command/CleanupLegacyModelsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanupLegacyModelsCommand extends Command
+{
+    protected static $defaultName = 'everblock:tools:cleanup-legacy-models';
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Remove the legacy Everblock ObjectModel classes once the migration is complete.')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Delete the legacy classes instead of running in dry-run mode.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $force = (bool) $input->getOption('force');
+        $moduleRoot = dirname(__DIR__, 2);
+        $targets = [
+            $moduleRoot . '/models/EverblockFlagsClass.php',
+            $moduleRoot . '/models/EverblockTabsClass.php',
+        ];
+
+        $hasFailure = false;
+        foreach ($targets as $file) {
+            if (!file_exists($file)) {
+                $output->writeln(sprintf('<info>Already removed:</info> %s', $file));
+                continue;
+            }
+
+            if ($force) {
+                if (@unlink($file)) {
+                    $output->writeln(sprintf('<comment>Deleted:</comment> %s', $file));
+                } else {
+                    $output->writeln(sprintf('<error>Unable to delete:</error> %s', $file));
+                    $hasFailure = true;
+                }
+            } else {
+                $output->writeln(sprintf('<info>Pending removal:</info> %s', $file));
+            }
+        }
+
+        if (!$force) {
+            $output->writeln('<comment>Run the command with --force to delete the legacy ObjectModel classes.</comment>');
+        }
+
+        return $hasFailure ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/src/Entity/EverBlockFlag.php
+++ b/src/Entity/EverBlockFlag.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_flags')]
+class EverBlockFlag
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_everblock_flags', type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'id_product', type: 'integer')]
+    private int $productId = 0;
+
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId = 0;
+
+    #[ORM\Column(name: 'id_flag', type: 'integer')]
+    private int $flagId = 0;
+
+    /**
+     * @var Collection<int, EverBlockFlagTranslation>
+     */
+    #[ORM\OneToMany(mappedBy: 'flag', targetEntity: EverBlockFlagTranslation::class, cascade: ['persist', 'remove'])]
+    private Collection $translations;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    public function setProductId(int $productId): void
+    {
+        $this->productId = $productId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function setShopId(int $shopId): void
+    {
+        $this->shopId = $shopId;
+    }
+
+    public function getFlagId(): int
+    {
+        return $this->flagId;
+    }
+
+    public function setFlagId(int $flagId): void
+    {
+        $this->flagId = $flagId;
+    }
+
+    /**
+     * @return Collection<int, EverBlockFlagTranslation>
+     */
+    public function getTranslations(): Collection
+    {
+        return $this->translations;
+    }
+}

--- a/src/Entity/EverBlockFlagTranslation.php
+++ b/src/Entity/EverBlockFlagTranslation.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_flags_lang')]
+class EverBlockFlagTranslation
+{
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: EverBlockFlag::class, inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'id_everblock_flags', referencedColumnName: 'id_everblock_flags', nullable: false, onDelete: 'CASCADE')]
+    private EverBlockFlag $flag;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_lang', type: 'integer')]
+    private int $languageId;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    public function __construct(EverBlockFlag $flag, int $languageId, int $shopId)
+    {
+        $this->flag = $flag;
+        $this->languageId = $languageId;
+        $this->shopId = $shopId;
+    }
+
+    public function getFlag(): EverBlockFlag
+    {
+        return $this->flag;
+    }
+
+    public function getLanguageId(): int
+    {
+        return $this->languageId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+}

--- a/src/Entity/EverBlockTab.php
+++ b/src/Entity/EverBlockTab.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_tabs')]
+class EverBlockTab
+{
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_everblock_tabs', type: 'integer')]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'id_product', type: 'integer')]
+    private int $productId = 0;
+
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId = 0;
+
+    #[ORM\Column(name: 'id_tab', type: 'integer')]
+    private int $tabId = 0;
+
+    /**
+     * @var Collection<int, EverBlockTabTranslation>
+     */
+    #[ORM\OneToMany(mappedBy: 'tab', targetEntity: EverBlockTabTranslation::class, cascade: ['persist', 'remove'])]
+    private Collection $translations;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    public function setProductId(int $productId): void
+    {
+        $this->productId = $productId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function setShopId(int $shopId): void
+    {
+        $this->shopId = $shopId;
+    }
+
+    public function getTabId(): int
+    {
+        return $this->tabId;
+    }
+
+    public function setTabId(int $tabId): void
+    {
+        $this->tabId = $tabId;
+    }
+
+    /**
+     * @return Collection<int, EverBlockTabTranslation>
+     */
+    public function getTranslations(): Collection
+    {
+        return $this->translations;
+    }
+}

--- a/src/Entity/EverBlockTabTranslation.php
+++ b/src/Entity/EverBlockTabTranslation.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'everblock_tabs_lang')]
+class EverBlockTabTranslation
+{
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: EverBlockTab::class, inversedBy: 'translations')]
+    #[ORM\JoinColumn(name: 'id_everblock_tabs', referencedColumnName: 'id_everblock_tabs', nullable: false, onDelete: 'CASCADE')]
+    private EverBlockTab $tab;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_lang', type: 'integer')]
+    private int $languageId;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id_shop', type: 'integer')]
+    private int $shopId;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $title = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    public function __construct(EverBlockTab $tab, int $languageId, int $shopId)
+    {
+        $this->tab = $tab;
+        $this->languageId = $languageId;
+        $this->shopId = $shopId;
+    }
+
+    public function getTab(): EverBlockTab
+    {
+        return $this->tab;
+    }
+
+    public function getLanguageId(): int
+    {
+        return $this->languageId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+}

--- a/src/Repository/EverBlockFlagRepository.php
+++ b/src/Repository/EverBlockFlagRepository.php
@@ -1,0 +1,373 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class EverBlockFlagRepository
+{
+    private const CACHE_TAG = 'everblock_flag';
+    private const CACHE_TTL = 86400;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TagAwareCacheInterface $cache,
+        private readonly ?string $tablePrefix = null
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getFlagsForAdmin(int $productId, int $shopId): array
+    {
+        $queryBuilder = $this->createAdminQueryBuilder()
+            ->where('f.id_product = :productId')
+            ->andWhere('f.id_shop = :shopId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->orderBy('f.id_flag', 'ASC');
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        return $this->groupTranslations($rows, 'id_everblock_flags');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getFlags(int $productId, int $shopId, int $languageId): array
+    {
+        $cacheKey = sprintf('everblock.flags.%d.%d.%d', $productId, $shopId, $languageId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($productId, $shopId, $languageId) {
+            $item->expiresAfter(self::CACHE_TTL);
+            $item->tag($this->buildTags($productId, $shopId, $languageId));
+
+            $queryBuilder = $this->createFrontQueryBuilder()
+                ->where('f.id_product = :productId')
+                ->andWhere('f.id_shop = :shopId')
+                ->andWhere('fl.id_lang = :languageId')
+                ->setParameter('productId', $productId, ParameterType::INTEGER)
+                ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+                ->setParameter('languageId', $languageId, ParameterType::INTEGER)
+                ->orderBy('f.id_flag', 'ASC');
+
+            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+            $flags = [];
+            foreach ($rows as $row) {
+                $flags[] = [
+                    'id_everblock_flags' => isset($row['id_everblock_flags']) ? (int) $row['id_everblock_flags'] : 0,
+                    'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : $productId,
+                    'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : $shopId,
+                    'id_flag' => isset($row['id_flag']) ? (int) $row['id_flag'] : 0,
+                    'title' => isset($row['title']) ? (string) $row['title'] : '',
+                    'content' => $row['content'] ?? '',
+                ];
+            }
+
+            return $flags;
+        });
+    }
+
+    /**
+     * @param array<int, string|null> $titles
+     * @param array<int, string|null> $contents
+     */
+    public function saveFlag(int $productId, int $shopId, int $flagId, array $titles, array $contents): int
+    {
+        $flagPrimaryId = $this->getFlagPrimaryId($productId, $shopId, $flagId);
+
+        if (null === $flagPrimaryId) {
+            $this->connection->insert(
+                $this->getTableName('everblock_flags'),
+                [
+                    'id_product' => $productId,
+                    'id_shop' => $shopId,
+                    'id_flag' => $flagId,
+                ],
+                [
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                ]
+            );
+
+            $flagPrimaryId = (int) $this->connection->lastInsertId();
+        } else {
+            $this->connection->update(
+                $this->getTableName('everblock_flags'),
+                [
+                    'id_product' => $productId,
+                    'id_shop' => $shopId,
+                    'id_flag' => $flagId,
+                ],
+                ['id_everblock_flags' => $flagPrimaryId],
+                [
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                ]
+            );
+        }
+
+        $this->saveTranslations($flagPrimaryId, $shopId, $titles, $contents);
+        $this->clearCacheForProduct($productId, $shopId);
+
+        return $flagPrimaryId;
+    }
+
+    public function deleteFlagsByProduct(int $productId, int $shopId): void
+    {
+        $ids = $this->connection->createQueryBuilder()
+            ->select('id_everblock_flags')
+            ->from($this->getTableName('everblock_flags'))
+            ->where('id_product = :productId')
+            ->andWhere('id_shop = :shopId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        if (!empty($ids)) {
+            $this->connection->createQueryBuilder()
+                ->delete($this->getTableName('everblock_flags_lang'))
+                ->where('id_everblock_flags IN (:ids)')
+                ->setParameter('ids', array_map('intval', $ids), Connection::PARAM_INT_ARRAY)
+                ->executeStatement();
+
+            $this->connection->createQueryBuilder()
+                ->delete($this->getTableName('everblock_flags'))
+                ->where('id_everblock_flags IN (:ids)')
+                ->setParameter('ids', array_map('intval', $ids), Connection::PARAM_INT_ARRAY)
+                ->executeStatement();
+        }
+
+        $this->clearCacheForProduct($productId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->cache->invalidateTags([self::CACHE_TAG]);
+    }
+
+    public function clearCacheForProduct(int $productId, int $shopId): void
+    {
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_flag_product_%d', $productId),
+            sprintf('everblock_flag_shop_%d', $shopId),
+        ]);
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_flag_shop_%d', $shopId),
+        ]);
+    }
+
+    public function hasFlagsForShop(int $shopId): bool
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('1')
+            ->from($this->getTableName('everblock_flags'), 'f')
+            ->where('f.id_shop = :shopId')
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->setMaxResults(1);
+
+        return (bool) $queryBuilder->executeQuery()->fetchOne();
+    }
+
+    private function getFlagPrimaryId(int $productId, int $shopId, int $flagId): ?int
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('id_everblock_flags')
+            ->from($this->getTableName('everblock_flags'))
+            ->where('id_product = :productId')
+            ->andWhere('id_shop = :shopId')
+            ->andWhere('id_flag = :flagId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->setParameter('flagId', $flagId, ParameterType::INTEGER)
+            ->setMaxResults(1);
+
+        $result = $queryBuilder->executeQuery()->fetchOne();
+
+        return $result === false ? null : (int) $result;
+    }
+
+    /**
+     * @param array<int, string|null> $titles
+     * @param array<int, string|null> $contents
+     */
+    private function saveTranslations(int $flagPrimaryId, int $shopId, array $titles, array $contents): void
+    {
+        $this->connection->createQueryBuilder()
+            ->delete($this->getTableName('everblock_flags_lang'))
+            ->where('id_everblock_flags = :id')
+            ->setParameter('id', $flagPrimaryId, ParameterType::INTEGER)
+            ->executeStatement();
+
+        $languageIds = array_unique(array_merge(array_keys($titles), array_keys($contents)));
+
+        foreach ($languageIds as $languageId) {
+            $title = $titles[$languageId] ?? null;
+            $content = $contents[$languageId] ?? null;
+
+            $queryBuilder = $this->connection->createQueryBuilder();
+            $queryBuilder
+                ->insert($this->getTableName('everblock_flags_lang'))
+                ->values([
+                    'id_everblock_flags' => ':flagId',
+                    'id_lang' => ':langId',
+                    'id_shop' => ':shopId',
+                    'title' => ':title',
+                    'content' => ':content',
+                ])
+                ->setParameter('flagId', $flagPrimaryId, ParameterType::INTEGER)
+                ->setParameter('langId', (int) $languageId, ParameterType::INTEGER)
+                ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+                ->setParameter('title', $title, null === $title ? ParameterType::NULL : ParameterType::STRING)
+                ->setParameter('content', $content, null === $content ? ParameterType::NULL : ParameterType::STRING)
+                ->executeStatement();
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param string $identifierKey
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function groupTranslations(array $rows, string $identifierKey): array
+    {
+        $grouped = [];
+
+        foreach ($rows as $row) {
+            if (!isset($row[$identifierKey])) {
+                continue;
+            }
+
+            $id = (int) $row[$identifierKey];
+            if (!isset($grouped[$id])) {
+                $grouped[$id] = [
+                    $identifierKey => $id,
+                    'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                    'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                    'id_flag' => isset($row['id_flag']) ? (int) $row['id_flag'] : 0,
+                    'title' => [],
+                    'content' => [],
+                ];
+            }
+
+            if (isset($row['id_lang'])) {
+                $languageId = (int) $row['id_lang'];
+                $grouped[$id]['title'][$languageId] = isset($row['title']) ? (string) $row['title'] : '';
+                $grouped[$id]['content'][$languageId] = $row['content'] ?? '';
+            }
+        }
+
+        return array_values($grouped);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildTags(int $productId, int $shopId, int $languageId): array
+    {
+        return [
+            self::CACHE_TAG,
+            sprintf('everblock_flag_product_%d', $productId),
+            sprintf('everblock_flag_shop_%d', $shopId),
+            sprintf('everblock_flag_lang_%d', $languageId),
+        ];
+    }
+
+    private function createAdminQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select(
+                'f.id_everblock_flags',
+                'f.id_product',
+                'f.id_shop',
+                'f.id_flag',
+                'fl.id_lang',
+                'fl.title',
+                'fl.content'
+            )
+            ->from($this->getTableName('everblock_flags'), 'f')
+            ->leftJoin(
+                'f',
+                $this->getTableName('everblock_flags_lang'),
+                'fl',
+                'f.id_everblock_flags = fl.id_everblock_flags'
+            );
+
+        return $queryBuilder;
+    }
+
+    private function createFrontQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select(
+                'f.id_everblock_flags',
+                'f.id_product',
+                'f.id_shop',
+                'f.id_flag',
+                'fl.title',
+                'fl.content'
+            )
+            ->from($this->getTableName('everblock_flags'), 'f')
+            ->leftJoin(
+                'f',
+                $this->getTableName('everblock_flags_lang'),
+                'fl',
+                'f.id_everblock_flags = fl.id_everblock_flags'
+            );
+
+        return $queryBuilder;
+    }
+
+    private function getTableName(string $table): string
+    {
+        if (null !== $this->tablePrefix && $this->tablePrefix !== '') {
+            return $this->tablePrefix . $table;
+        }
+
+        if (defined('_DB_PREFIX_')) {
+            return _DB_PREFIX_ . $table;
+        }
+
+        return $table;
+    }
+}

--- a/src/Repository/EverBlockTabRepository.php
+++ b/src/Repository/EverBlockTabRepository.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class EverBlockTabRepository
+{
+    private const CACHE_TAG = 'everblock_tab';
+    private const CACHE_TTL = 86400;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly TagAwareCacheInterface $cache,
+        private readonly ?string $tablePrefix = null
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTabsForAdmin(int $productId, int $shopId): array
+    {
+        $queryBuilder = $this->createAdminQueryBuilder()
+            ->where('t.id_product = :productId')
+            ->andWhere('t.id_shop = :shopId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->orderBy('t.id_tab', 'ASC');
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+        return $this->groupTranslations($rows, 'id_everblock_tabs');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTabs(int $productId, int $shopId, int $languageId): array
+    {
+        $cacheKey = sprintf('everblock.tabs.%d.%d.%d', $productId, $shopId, $languageId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($productId, $shopId, $languageId) {
+            $item->expiresAfter(self::CACHE_TTL);
+            $item->tag($this->buildTags($productId, $shopId, $languageId));
+
+            $queryBuilder = $this->createFrontQueryBuilder()
+                ->where('t.id_product = :productId')
+                ->andWhere('t.id_shop = :shopId')
+                ->andWhere('tl.id_lang = :languageId')
+                ->setParameter('productId', $productId, ParameterType::INTEGER)
+                ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+                ->setParameter('languageId', $languageId, ParameterType::INTEGER)
+                ->orderBy('t.id_tab', 'ASC');
+
+            $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+
+            $tabs = [];
+            foreach ($rows as $row) {
+                $tabs[] = [
+                    'id_everblock_tabs' => isset($row['id_everblock_tabs']) ? (int) $row['id_everblock_tabs'] : 0,
+                    'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : $productId,
+                    'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : $shopId,
+                    'id_tab' => isset($row['id_tab']) ? (int) $row['id_tab'] : 0,
+                    'title' => isset($row['title']) ? (string) $row['title'] : '',
+                    'content' => $row['content'] ?? '',
+                ];
+            }
+
+            return $tabs;
+        });
+    }
+
+    /**
+     * @param array<int, string|null> $titles
+     * @param array<int, string|null> $contents
+     */
+    public function saveTab(int $productId, int $shopId, int $tabId, array $titles, array $contents): int
+    {
+        $tabPrimaryId = $this->getTabPrimaryId($productId, $shopId, $tabId);
+
+        if (null === $tabPrimaryId) {
+            $this->connection->insert(
+                $this->getTableName('everblock_tabs'),
+                [
+                    'id_product' => $productId,
+                    'id_shop' => $shopId,
+                    'id_tab' => $tabId,
+                ],
+                [
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                ]
+            );
+
+            $tabPrimaryId = (int) $this->connection->lastInsertId();
+        } else {
+            $this->connection->update(
+                $this->getTableName('everblock_tabs'),
+                [
+                    'id_product' => $productId,
+                    'id_shop' => $shopId,
+                    'id_tab' => $tabId,
+                ],
+                ['id_everblock_tabs' => $tabPrimaryId],
+                [
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                    ParameterType::INTEGER,
+                ]
+            );
+        }
+
+        $this->saveTranslations($tabPrimaryId, $shopId, $titles, $contents);
+        $this->clearCacheForProduct($productId, $shopId);
+
+        return $tabPrimaryId;
+    }
+
+    public function deleteTabsByProduct(int $productId, int $shopId): void
+    {
+        $ids = $this->connection->createQueryBuilder()
+            ->select('id_everblock_tabs')
+            ->from($this->getTableName('everblock_tabs'))
+            ->where('id_product = :productId')
+            ->andWhere('id_shop = :shopId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        if (!empty($ids)) {
+            $this->connection->createQueryBuilder()
+                ->delete($this->getTableName('everblock_tabs_lang'))
+                ->where('id_everblock_tabs IN (:ids)')
+                ->setParameter('ids', array_map('intval', $ids), Connection::PARAM_INT_ARRAY)
+                ->executeStatement();
+
+            $this->connection->createQueryBuilder()
+                ->delete($this->getTableName('everblock_tabs'))
+                ->where('id_everblock_tabs IN (:ids)')
+                ->setParameter('ids', array_map('intval', $ids), Connection::PARAM_INT_ARRAY)
+                ->executeStatement();
+        }
+
+        $this->clearCacheForProduct($productId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->cache->invalidateTags([self::CACHE_TAG]);
+    }
+
+    public function clearCacheForProduct(int $productId, int $shopId): void
+    {
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_tab_product_%d', $productId),
+            sprintf('everblock_tab_shop_%d', $shopId),
+        ]);
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->cache->invalidateTags([
+            self::CACHE_TAG,
+            sprintf('everblock_tab_shop_%d', $shopId),
+        ]);
+    }
+
+    private function getTabPrimaryId(int $productId, int $shopId, int $tabId): ?int
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('id_everblock_tabs')
+            ->from($this->getTableName('everblock_tabs'))
+            ->where('id_product = :productId')
+            ->andWhere('id_shop = :shopId')
+            ->andWhere('id_tab = :tabId')
+            ->setParameter('productId', $productId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->setParameter('tabId', $tabId, ParameterType::INTEGER)
+            ->setMaxResults(1);
+
+        $result = $queryBuilder->executeQuery()->fetchOne();
+
+        return $result === false ? null : (int) $result;
+    }
+
+    /**
+     * @param array<int, string|null> $titles
+     * @param array<int, string|null> $contents
+     */
+    private function saveTranslations(int $tabPrimaryId, int $shopId, array $titles, array $contents): void
+    {
+        $this->connection->createQueryBuilder()
+            ->delete($this->getTableName('everblock_tabs_lang'))
+            ->where('id_everblock_tabs = :id')
+            ->setParameter('id', $tabPrimaryId, ParameterType::INTEGER)
+            ->executeStatement();
+
+        $languageIds = array_unique(array_merge(array_keys($titles), array_keys($contents)));
+
+        foreach ($languageIds as $languageId) {
+            $title = $titles[$languageId] ?? null;
+            $content = $contents[$languageId] ?? null;
+
+            $queryBuilder = $this->connection->createQueryBuilder();
+            $queryBuilder
+                ->insert($this->getTableName('everblock_tabs_lang'))
+                ->values([
+                    'id_everblock_tabs' => ':tabId',
+                    'id_lang' => ':langId',
+                    'id_shop' => ':shopId',
+                    'title' => ':title',
+                    'content' => ':content',
+                ])
+                ->setParameter('tabId', $tabPrimaryId, ParameterType::INTEGER)
+                ->setParameter('langId', (int) $languageId, ParameterType::INTEGER)
+                ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+                ->setParameter('title', $title, null === $title ? ParameterType::NULL : ParameterType::STRING)
+                ->setParameter('content', $content, null === $content ? ParameterType::NULL : ParameterType::STRING)
+                ->executeStatement();
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param string $identifierKey
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function groupTranslations(array $rows, string $identifierKey): array
+    {
+        $grouped = [];
+
+        foreach ($rows as $row) {
+            if (!isset($row[$identifierKey])) {
+                continue;
+            }
+
+            $id = (int) $row[$identifierKey];
+            if (!isset($grouped[$id])) {
+                $grouped[$id] = [
+                    $identifierKey => $id,
+                    'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                    'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                    'id_tab' => isset($row['id_tab']) ? (int) $row['id_tab'] : 0,
+                    'title' => [],
+                    'content' => [],
+                ];
+            }
+
+            if (isset($row['id_lang'])) {
+                $languageId = (int) $row['id_lang'];
+                $grouped[$id]['title'][$languageId] = isset($row['title']) ? (string) $row['title'] : '';
+                $grouped[$id]['content'][$languageId] = $row['content'] ?? '';
+            }
+        }
+
+        return array_values($grouped);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildTags(int $productId, int $shopId, int $languageId): array
+    {
+        return [
+            self::CACHE_TAG,
+            sprintf('everblock_tab_product_%d', $productId),
+            sprintf('everblock_tab_shop_%d', $shopId),
+            sprintf('everblock_tab_lang_%d', $languageId),
+        ];
+    }
+
+    private function createAdminQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select(
+                't.id_everblock_tabs',
+                't.id_product',
+                't.id_shop',
+                't.id_tab',
+                'tl.id_lang',
+                'tl.title',
+                'tl.content'
+            )
+            ->from($this->getTableName('everblock_tabs'), 't')
+            ->leftJoin(
+                't',
+                $this->getTableName('everblock_tabs_lang'),
+                'tl',
+                't.id_everblock_tabs = tl.id_everblock_tabs'
+            );
+
+        return $queryBuilder;
+    }
+
+    private function createFrontQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select(
+                't.id_everblock_tabs',
+                't.id_product',
+                't.id_shop',
+                't.id_tab',
+                'tl.title',
+                'tl.content'
+            )
+            ->from($this->getTableName('everblock_tabs'), 't')
+            ->leftJoin(
+                't',
+                $this->getTableName('everblock_tabs_lang'),
+                'tl',
+                't.id_everblock_tabs = tl.id_everblock_tabs'
+            );
+
+        return $queryBuilder;
+    }
+
+    private function getTableName(string $table): string
+    {
+        if (null !== $this->tablePrefix && $this->tablePrefix !== '') {
+            return $this->tablePrefix . $table;
+        }
+
+        if (defined('_DB_PREFIX_')) {
+            return _DB_PREFIX_ . $table;
+        }
+
+        return $table;
+    }
+}

--- a/src/Service/EverBlockFlagProvider.php
+++ b/src/Service/EverBlockFlagProvider.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use ArrayObject;
+use Everblock\Tools\Repository\EverBlockFlagRepository;
+
+class EverBlockFlagProvider
+{
+    public function __construct(private readonly EverBlockFlagRepository $repository)
+    {
+        if (class_exists(\EverblockFlagsClass::class) && method_exists(\EverblockFlagsClass::class, 'setProvider')) {
+            \EverblockFlagsClass::setProvider($this);
+        }
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getFlagsForAdmin(int $productId, int $shopId): array
+    {
+        return $this->hydrateAdmin($this->repository->getFlagsForAdmin($productId, $shopId));
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getFlags(int $productId, int $shopId, int $languageId): array
+    {
+        return $this->hydrateFront($this->repository->getFlags($productId, $shopId, $languageId));
+    }
+
+    /**
+     * @param array<int, array<string, string|null>> $translations
+     */
+    public function saveFlag(int $productId, int $shopId, int $flagId, array $translations): int
+    {
+        $titles = [];
+        $contents = [];
+
+        foreach ($translations as $languageId => $data) {
+            $langId = (int) $languageId;
+            $title = $data['title'] ?? null;
+            $content = $data['content'] ?? null;
+
+            $titles[$langId] = null === $title ? null : (string) $title;
+            $contents[$langId] = null === $content ? null : (string) $content;
+        }
+
+        return $this->repository->saveFlag($productId, $shopId, $flagId, $titles, $contents);
+    }
+
+    public function deleteFlagsByProduct(int $productId, int $shopId): void
+    {
+        $this->repository->deleteFlagsByProduct($productId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    public function clearCacheForProduct(int $productId, int $shopId): void
+    {
+        $this->repository->clearCacheForProduct($productId, $shopId);
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->repository->clearCacheForShop($shopId);
+    }
+
+    public function hasFlagsForShop(int $shopId): bool
+    {
+        return $this->repository->hasFlagsForShop($shopId);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return ArrayObject<int, mixed>[]
+     */
+    private function hydrateAdmin(array $rows): array
+    {
+        $flags = [];
+        foreach ($rows as $row) {
+            $flags[] = new ArrayObject([
+                'id_everblock_flags' => isset($row['id_everblock_flags']) ? (int) $row['id_everblock_flags'] : 0,
+                'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                'id_flag' => isset($row['id_flag']) ? (int) $row['id_flag'] : 0,
+                'title' => $row['title'] ?? [],
+                'content' => $row['content'] ?? [],
+            ], ArrayObject::ARRAY_AS_PROPS);
+        }
+
+        return $flags;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return ArrayObject<int, mixed>[]
+     */
+    private function hydrateFront(array $rows): array
+    {
+        $flags = [];
+        foreach ($rows as $row) {
+            $flags[] = new ArrayObject([
+                'id_everblock_flags' => isset($row['id_everblock_flags']) ? (int) $row['id_everblock_flags'] : 0,
+                'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                'id_flag' => isset($row['id_flag']) ? (int) $row['id_flag'] : 0,
+                'title' => isset($row['title']) ? (string) $row['title'] : '',
+                'content' => $row['content'] ?? '',
+            ], ArrayObject::ARRAY_AS_PROPS);
+        }
+
+        return $flags;
+    }
+}

--- a/src/Service/EverBlockTabProvider.php
+++ b/src/Service/EverBlockTabProvider.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use ArrayObject;
+use Everblock\Tools\Repository\EverBlockTabRepository;
+
+class EverBlockTabProvider
+{
+    public function __construct(private readonly EverBlockTabRepository $repository)
+    {
+        if (class_exists(\EverblockTabsClass::class) && method_exists(\EverblockTabsClass::class, 'setProvider')) {
+            \EverblockTabsClass::setProvider($this);
+        }
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getTabsForAdmin(int $productId, int $shopId): array
+    {
+        return $this->hydrateAdmin($this->repository->getTabsForAdmin($productId, $shopId));
+    }
+
+    /**
+     * @return ArrayObject<int, mixed>[]
+     */
+    public function getTabs(int $productId, int $shopId, int $languageId): array
+    {
+        return $this->hydrateFront($this->repository->getTabs($productId, $shopId, $languageId));
+    }
+
+    /**
+     * @param array<int, array<string, string|null>> $translations
+     */
+    public function saveTab(int $productId, int $shopId, int $tabId, array $translations): int
+    {
+        $titles = [];
+        $contents = [];
+
+        foreach ($translations as $languageId => $data) {
+            $langId = (int) $languageId;
+            $title = $data['title'] ?? null;
+            $content = $data['content'] ?? null;
+
+            $titles[$langId] = null === $title ? null : (string) $title;
+            $contents[$langId] = null === $content ? null : (string) $content;
+        }
+
+        return $this->repository->saveTab($productId, $shopId, $tabId, $titles, $contents);
+    }
+
+    public function deleteTabsByProduct(int $productId, int $shopId): void
+    {
+        $this->repository->deleteTabsByProduct($productId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    public function clearCacheForProduct(int $productId, int $shopId): void
+    {
+        $this->repository->clearCacheForProduct($productId, $shopId);
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->repository->clearCacheForShop($shopId);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return ArrayObject<int, mixed>[]
+     */
+    private function hydrateAdmin(array $rows): array
+    {
+        $tabs = [];
+        foreach ($rows as $row) {
+            $tabs[] = new ArrayObject([
+                'id_everblock_tabs' => isset($row['id_everblock_tabs']) ? (int) $row['id_everblock_tabs'] : 0,
+                'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                'id_tab' => isset($row['id_tab']) ? (int) $row['id_tab'] : 0,
+                'title' => $row['title'] ?? [],
+                'content' => $row['content'] ?? [],
+            ], ArrayObject::ARRAY_AS_PROPS);
+        }
+
+        return $tabs;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return ArrayObject<int, mixed>[]
+     */
+    private function hydrateFront(array $rows): array
+    {
+        $tabs = [];
+        foreach ($rows as $row) {
+            $tabs[] = new ArrayObject([
+                'id_everblock_tabs' => isset($row['id_everblock_tabs']) ? (int) $row['id_everblock_tabs'] : 0,
+                'id_product' => isset($row['id_product']) ? (int) $row['id_product'] : 0,
+                'id_shop' => isset($row['id_shop']) ? (int) $row['id_shop'] : 0,
+                'id_tab' => isset($row['id_tab']) ? (int) $row['id_tab'] : 0,
+                'title' => isset($row['title']) ? (string) $row['title'] : '',
+                'content' => $row['content'] ?? '',
+            ], ArrayObject::ARRAY_AS_PROPS);
+        }
+
+        return $tabs;
+    }
+}


### PR DESCRIPTION
## Summary
- add Doctrine entities for product flags and tabs, including translation tables
- implement repositories and providers backed by Doctrine DBAL and Symfony cache to serve flags and tabs data
- refactor module hooks to consume the new providers and add a cleanup console command for legacy models

## Testing
- php -l everblock.php
- php -l src/Repository/EverBlockFlagRepository.php
- php -l src/Repository/EverBlockTabRepository.php
- php -l src/Service/EverBlockFlagProvider.php
- php -l src/Service/EverBlockTabProvider.php
- php -l src/Command/CleanupLegacyModelsCommand.php
- php -l src/Entity/EverBlockFlag.php
- php -l src/Entity/EverBlockFlagTranslation.php
- php -l src/Entity/EverBlockTab.php
- php -l src/Entity/EverBlockTabTranslation.php

------
https://chatgpt.com/codex/tasks/task_e_68f3811fb44483228cebbf3029d945f0