### PR TITLE
Add Symfony-backed legacy adapters and deprecations

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -159,6 +159,22 @@ services:
     Everblock\Tools\Service\EverBlockModalProvider: ~
     Everblock\Tools\Service\EverBlockShortcodeProvider: ~
 
+    Everblock\Tools\Bridge\Legacy\EverBlockLegacyAdapter:
+        arguments:
+            $provider: '@Everblock\\Tools\\Service\\EverBlockProvider'
+
+    Everblock\Tools\Bridge\Legacy\EverBlockFaqLegacyAdapter:
+        arguments:
+            $provider: '@Everblock\\Tools\\Service\\EverBlockFaqProvider'
+
+    Everblock\Tools\Bridge\Legacy\EverBlockModalLegacyAdapter:
+        arguments:
+            $provider: '@Everblock\\Tools\\Service\\EverBlockModalProvider'
+
+    Everblock\Tools\Bridge\Legacy\EverBlockShortcodeLegacyAdapter:
+        arguments:
+            $provider: '@Everblock\\Tools\\Service\\EverBlockShortcodeProvider'
+
     Everblock\Tools\Controller\Admin\:
         resource: '../src/Controller/Admin'
         arguments:

--- a/models/EverblockClass.php
+++ b/models/EverblockClass.php
@@ -31,6 +31,11 @@ class EverBlockClass extends ObjectModel
     /** @var EverBlockProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     public $id_everblock;
     public $name;
     public $content;
@@ -250,11 +255,13 @@ class EverBlockClass extends ObjectModel
 
     public static function setProvider(EverBlockProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): EverBlockProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockProvider) {
             return static::$provider;
         }
@@ -276,11 +283,13 @@ class EverBlockClass extends ObjectModel
 
     public static function getAllBlocks(int $idLang, int $idShop): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getAllBlocks($idLang, $idShop);
     }
 
     public static function cleanBlocksCacheOnDate(int $idLang, int $idShop)
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $provider = static::getProvider();
         $blocks = $provider->getAllBlocks($idLang, $idShop);
         foreach ($blocks as $block) {
@@ -307,11 +316,13 @@ class EverBlockClass extends ObjectModel
 
     public static function getBlocks(int $idHook, int $idLang, int $idShop): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getBlocks($idHook, $idLang, $idShop);
     }
 
     public static function getBootstrapColClass(int $colNumber)
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getBootstrapColClass($colNumber);
     }
 }

--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -29,6 +29,11 @@ class EverblockFaq extends ObjectModel
     /** @var EverBlockFaqProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     public $id_everblock_faq;
     public $id_shop;
     public $id_lang;
@@ -99,11 +104,13 @@ class EverblockFaq extends ObjectModel
 
     public static function setProvider(EverBlockFaqProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): EverBlockFaqProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockFaqProvider) {
             return static::$provider;
         }
@@ -125,11 +132,13 @@ class EverblockFaq extends ObjectModel
 
     public static function getAllFaq(int $shopId, int $langId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getAllFaq($shopId, $langId);
     }
 
     public static function getFaqByTagName(int $shopId, int $langId, string $tagName): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getFaqByTagName($shopId, $langId, $tagName);
     }
 }

--- a/models/EverblockFlagsClass.php
+++ b/models/EverblockFlagsClass.php
@@ -29,6 +29,11 @@ class EverblockFlagsClass extends ObjectModel
     /** @var EverBlockFlagProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     public $id_everblock_flags;
     public $id_product;
     public $id_shop;
@@ -74,11 +79,13 @@ class EverblockFlagsClass extends ObjectModel
 
     public static function setProvider(EverBlockFlagProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): ?EverBlockFlagProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockFlagProvider) {
             return static::$provider;
         }
@@ -106,6 +113,7 @@ class EverblockFlagsClass extends ObjectModel
     */
     public static function getByIdProductInAdmin(int $productId, int $shopId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $sql = new DbQuery();
         $sql->select(self::$definition['primary']);
         $sql->from(self::$definition['table']);
@@ -123,6 +131,7 @@ class EverblockFlagsClass extends ObjectModel
 
     public static function getByIdProductIdFlag(int $productId, int $shopId, int $flagId)
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $sql = new DbQuery();
         $sql->select(self::$definition['primary']);
         $sql->from(self::$definition['table']);
@@ -146,6 +155,7 @@ class EverblockFlagsClass extends ObjectModel
     */
     public static function getByIdProduct(int $productId, int $shopId, int $langId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $cache_id = 'EverblockFlagsClass_getByIdProduct_'
         . (int) $productId
         . '_'

--- a/models/EverblockModal.php
+++ b/models/EverblockModal.php
@@ -29,6 +29,11 @@ class EverblockModal extends ObjectModel
     /** @var EverBlockModalProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     /** @var int */
     public $id_everblock_modal;
 
@@ -74,11 +79,13 @@ class EverblockModal extends ObjectModel
 
     public static function setProvider(EverBlockModalProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): EverBlockModalProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockModalProvider) {
             return static::$provider;
         }
@@ -100,6 +107,7 @@ class EverblockModal extends ObjectModel
 
     public static function getByProductId(int $idProduct, int $idShop)
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $provider = static::getProvider();
         $modalId = $provider->findModalIdByProduct($idProduct, $idShop);
         if (null !== $modalId) {

--- a/models/EverblockShortcode.php
+++ b/models/EverblockShortcode.php
@@ -29,6 +29,11 @@ class EverblockShortcode extends ObjectModel
     /** @var EverBlockShortcodeProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     public $id_everblock_shortcode;
     public $shortcode;
     public $id_shop;
@@ -70,11 +75,13 @@ class EverblockShortcode extends ObjectModel
 
     public static function setProvider(EverBlockShortcodeProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): EverBlockShortcodeProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockShortcodeProvider) {
             return static::$provider;
         }
@@ -96,16 +103,19 @@ class EverblockShortcode extends ObjectModel
 
     public static function getAllShortcodes(int $idShop, int $langId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getAllShortcodes($idShop, $langId);
     }
 
     public static function getAllShortcodeIds(int $idShop): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getAllShortcodeIds($idShop);
     }
 
     public static function getEverShortcode(string $shortcode, int $shopId, int $langId): string
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         return static::getProvider()->getEverShortcode($shortcode, $shopId, $langId);
     }
 }

--- a/models/EverblockTabsClass.php
+++ b/models/EverblockTabsClass.php
@@ -28,6 +28,11 @@ class EverblockTabsClass extends ObjectModel
     /** @var EverBlockTabProvider|null */
     protected static $provider;
 
+    private static function triggerLegacyDeprecation(string $method): void
+    {
+        @trigger_error(sprintf('%s::%s() is deprecated and will be removed in a future major version.', __CLASS__, $method), E_USER_DEPRECATED);
+    }
+
     public $id_everblock_tabs;
     public $id_product;
     public $id_shop;
@@ -73,11 +78,13 @@ class EverblockTabsClass extends ObjectModel
 
     public static function setProvider(EverBlockTabProvider $provider): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         static::$provider = $provider;
     }
 
     protected static function getProvider(): ?EverBlockTabProvider
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockTabProvider) {
             return static::$provider;
         }
@@ -105,6 +112,7 @@ class EverblockTabsClass extends ObjectModel
     */
     public static function getByIdProductInAdmin(int $productId, int $shopId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $sql = new DbQuery();
         $sql->select(self::$definition['primary']);
         $sql->from(self::$definition['table']);
@@ -122,6 +130,7 @@ class EverblockTabsClass extends ObjectModel
 
     public static function getByIdProductIdTab(int $productId, int $shopId, int $tabId)
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $sql = new DbQuery();
         $sql->select(self::$definition['primary']);
         $sql->from(self::$definition['table']);
@@ -145,6 +154,7 @@ class EverblockTabsClass extends ObjectModel
     */
     public static function getByIdProduct(int $productId, int $shopId, int $langId): array
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         $sql = new DbQuery();
         $sql->select(self::$definition['primary']);
         $sql->from(self::$definition['table']);
@@ -165,6 +175,7 @@ class EverblockTabsClass extends ObjectModel
 
     public static function createTabForAllProducts(int $idShop, array $titles, array $contents, bool $drop = false): void
     {
+        static::triggerLegacyDeprecation(__METHOD__);
         if ($drop) {
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'everblock_tabs`');
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'everblock_tabs_lang`');

--- a/src/Bridge/Legacy/EverBlockFaqLegacyAdapter.php
+++ b/src/Bridge/Legacy/EverBlockFaqLegacyAdapter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Bridge\Legacy;
+
+use Everblock\Tools\Service\EverBlockFaqProvider;
+
+class EverBlockFaqLegacyAdapter
+{
+    public function __construct(private readonly EverBlockFaqProvider $provider)
+    {
+    }
+
+    public function getAllFaq(int $shopId, int $languageId): array
+    {
+        return $this->provider->getAllFaq($shopId, $languageId);
+    }
+
+    public function getFaqByTagName(int $shopId, int $languageId, string $tagName): array
+    {
+        return $this->provider->getFaqByTagName($shopId, $languageId, $tagName);
+    }
+}

--- a/src/Bridge/Legacy/EverBlockLegacyAdapter.php
+++ b/src/Bridge/Legacy/EverBlockLegacyAdapter.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Bridge\Legacy;
+
+use DateTimeImmutable;
+use Everblock\Tools\Service\EverBlockProvider;
+
+class EverBlockLegacyAdapter
+{
+    public function __construct(private readonly EverBlockProvider $provider)
+    {
+    }
+
+    public function getAllBlocks(int $languageId, int $shopId): array
+    {
+        return $this->provider->getAllBlocks($languageId, $shopId);
+    }
+
+    public function cleanBlocksCacheOnDate(int $languageId, int $shopId): void
+    {
+        $blocks = $this->provider->getAllBlocks($languageId, $shopId);
+        $now = new DateTimeImmutable();
+
+        foreach ($blocks as $block) {
+            $cacheShouldBeFlushed = false;
+            $dateStart = $block['date_start'] ?? null;
+            $dateEnd = $block['date_end'] ?? null;
+            $formattedNow = $now->format('Y-m-d H:i:s');
+
+            if (!empty($dateStart) && $dateStart !== '0000-00-00 00:00:00' && $dateStart > $formattedNow) {
+                $cacheShouldBeFlushed = true;
+            }
+
+            if (!empty($dateEnd) && $dateEnd !== '0000-00-00 00:00:00' && $dateEnd < $formattedNow) {
+                $cacheShouldBeFlushed = true;
+            }
+
+            if ($cacheShouldBeFlushed && isset($block['id_hook'])) {
+                $this->provider->clearCacheForHook((int) $block['id_hook']);
+            }
+        }
+    }
+
+    public function getBlocks(int $hookId, int $languageId, int $shopId): array
+    {
+        return $this->provider->getBlocks($hookId, $languageId, $shopId);
+    }
+
+    public function getBootstrapColClass(int $colNumber): string
+    {
+        return $this->provider->getBootstrapColClass($colNumber);
+    }
+
+    public function clearCache(): void
+    {
+        $this->provider->clearCache();
+    }
+
+    public function clearCacheForHook(int $hookId): void
+    {
+        $this->provider->clearCacheForHook($hookId);
+    }
+
+    public function clearCacheForLanguageAndShop(int $languageId, int $shopId): void
+    {
+        $this->provider->clearCacheForLanguageAndShop($languageId, $shopId);
+    }
+}

--- a/src/Bridge/Legacy/EverBlockModalLegacyAdapter.php
+++ b/src/Bridge/Legacy/EverBlockModalLegacyAdapter.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Bridge\Legacy;
+
+use ArrayObject;
+use Everblock\Tools\Service\EverBlockModalProvider;
+
+class EverBlockModalLegacyAdapter
+{
+    public function __construct(private readonly EverBlockModalProvider $provider)
+    {
+    }
+
+    public function findModalIdByProduct(int $productId, int $shopId): ?int
+    {
+        return $this->provider->findModalIdByProduct($productId, $shopId);
+    }
+
+    public function getModalForProduct(int $productId, int $shopId, int $languageId): ?ArrayObject
+    {
+        return $this->provider->getModalForProduct($productId, $shopId, $languageId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->provider->clearCache();
+    }
+
+    public function clearCacheForShop(int $shopId): void
+    {
+        $this->provider->clearCacheForShop($shopId);
+    }
+
+    public function clearCacheForModal(int $modalId, int $shopId): void
+    {
+        $this->provider->clearCacheForModal($modalId, $shopId);
+    }
+}

--- a/src/Bridge/Legacy/EverBlockShortcodeLegacyAdapter.php
+++ b/src/Bridge/Legacy/EverBlockShortcodeLegacyAdapter.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Bridge\Legacy;
+
+use Everblock\Tools\Service\EverBlockShortcodeProvider;
+
+class EverBlockShortcodeLegacyAdapter
+{
+    public function __construct(private readonly EverBlockShortcodeProvider $provider)
+    {
+    }
+
+    public function getAllShortcodes(int $shopId, int $languageId): array
+    {
+        return $this->provider->getAllShortcodes($shopId, $languageId);
+    }
+
+    public function getAllShortcodeIds(int $shopId): array
+    {
+        return $this->provider->getAllShortcodeIds($shopId);
+    }
+
+    public function getEverShortcode(string $shortcode, int $shopId, int $languageId): string
+    {
+        return $this->provider->getEverShortcode($shortcode, $shopId, $languageId);
+    }
+}

--- a/src/Command/ExecuteAction.php
+++ b/src/Command/ExecuteAction.php
@@ -28,6 +28,7 @@ use Configuration;
 use Currency;
 use Db;
 use DbQuery;
+use Everblock\Tools\Bridge\Legacy\EverBlockLegacyAdapter;
 use Everblock\Tools\Service\ImportFile;
 use Everblock\Tools\Service\EverblockCache;
 use EverblockTools;
@@ -140,9 +141,15 @@ class ExecuteAction extends Command
         ],
     ];
 
-    public function __construct(KernelInterface $kernel)
+    /**
+     * @var EverBlockLegacyAdapter
+     */
+    private $legacyAdapter;
+
+    public function __construct(KernelInterface $kernel, EverBlockLegacyAdapter $legacyAdapter)
     {
         parent::__construct();
+        $this->legacyAdapter = $legacyAdapter;
     }
 
     protected function configure()
@@ -428,6 +435,11 @@ class ExecuteAction extends Command
                     $output->writeln('<warning>' . $e->getMessage() . '</warning>');
                 }
             }
+            $this->legacyAdapter->clearCacheForLanguageAndShop((int) $idLangFrom, (int) $shop->id);
+            if ((int) $idLangTo !== (int) $idLangFrom) {
+                $this->legacyAdapter->clearCacheForLanguageAndShop((int) $idLangTo, (int) $shop->id);
+            }
+
             $output->writeln('<success>All blocks duplicated from lang ' . (int) $idLangFrom . ' to ' . (int) $idLangTo . '</success>');
             return self::SUCCESS;
         }

--- a/src/Controller/Admin/EverblockBlockController.php
+++ b/src/Controller/Admin/EverblockBlockController.php
@@ -23,6 +23,7 @@ namespace Everblock\Tools\Controller\Admin;
 use Context;
 use EverBlockClass;
 use EverblockTools;
+use Everblock\Tools\Bridge\Legacy\EverBlockLegacyAdapter;
 use Everblock\Tools\Form\DataProvider\EverblockFormDataProvider;
 use Everblock\Tools\Form\Handler\EverblockFormHandler;
 use Everblock\Tools\Form\Type\EverblockFormType;
@@ -73,6 +74,11 @@ class EverblockBlockController extends BaseEverblockController
      */
     private $router;
 
+    /**
+     * @var EverBlockLegacyAdapter
+     */
+    private $legacyAdapter;
+
     public function __construct(
         EverblockGridDefinitionFactory $gridDefinitionFactory,
         EverblockGridDataFactory $gridDataFactory,
@@ -80,6 +86,7 @@ class EverblockBlockController extends BaseEverblockController
         EverblockFormDataProvider $formDataProvider,
         EverblockFormHandler $formHandler,
         RouterInterface $router,
+        EverBlockLegacyAdapter $legacyAdapter,
         ?Context $context = null,
         ?\PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository $moduleRepository = null,
         ?\Symfony\Contracts\Translation\TranslatorInterface $translator = null,
@@ -93,6 +100,7 @@ class EverblockBlockController extends BaseEverblockController
         $this->formDataProvider = $formDataProvider;
         $this->formHandler = $formHandler;
         $this->router = $router;
+        $this->legacyAdapter = $legacyAdapter;
     }
 
     public function index(Request $request): Response
@@ -360,6 +368,15 @@ class EverblockBlockController extends BaseEverblockController
     public function clearCache(): RedirectResponse
     {
         Tools::clearAllCache();
+
+        if (isset($this->context->language, $this->context->shop)) {
+            $this->legacyAdapter->clearCacheForLanguageAndShop(
+                (int) $this->context->language->id,
+                (int) $this->context->shop->id
+            );
+        } else {
+            $this->legacyAdapter->clearCache();
+        }
         $this->addFlash('success', $this->translate('Cache has been cleared.'));
 
         return $this->redirectToRoute('everblock_admin_blocks');


### PR DESCRIPTION
## Summary
- add legacy bridge adapters that delegate to the Symfony services for blocks, FAQ, modals, and shortcodes
- wire the new adapters into the service container and start injecting them in the admin controller and console command
- instrument legacy ObjectModel classes with deprecation notices to guide the migration away from them

## Testing
- `for f in src/Bridge/Legacy/*.php; do php -l "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68f3878eee108322ba034604dd2d5344