### PR TITLE
Secure admin block actions with CSRF tokens

### DIFF
--- a/config/routes/everblock_admin.yml
+++ b/config/routes/everblock_admin.yml
@@ -34,21 +34,23 @@ everblock_admin_blocks_edit:
 
 everblock_admin_blocks_duplicate:
     path: /everblock/blocks/{everblockId}/duplicate
-    methods: [GET]
+    methods: [POST]
     defaults:
         _controller: 'Everblock\\Tools\\Controller\\Admin\\EverblockBlockController::duplicate'
         _legacy_controller: 'AdminEverBlock'
         _legacy_link: 'AdminEverBlock:duplicate'
+        _token: true
     requirements:
         everblockId: "\\d+"
 
 everblock_admin_blocks_toggle:
     path: /everblock/blocks/{everblockId}/toggle
-    methods: [GET]
+    methods: [POST]
     defaults:
         _controller: 'Everblock\\Tools\\Controller\\Admin\\EverblockBlockController::toggle'
         _legacy_controller: 'AdminEverBlock'
         _legacy_link: 'AdminEverBlock:status'
+        _token: true
     requirements:
         everblockId: "\\d+"
 
@@ -80,11 +82,12 @@ everblock_admin_blocks_export:
 
 everblock_admin_blocks_clear_cache:
     path: /everblock/blocks/cache/clear
-    methods: [GET]
+    methods: [POST]
     defaults:
         _controller: 'Everblock\\Tools\\Controller\\Admin\\EverblockBlockController::clearCache'
         _legacy_controller: 'AdminEverBlock'
         _legacy_link: 'AdminEverBlock:clearcache'
+        _token: true
 
 everblock_admin_hooks:
     path: /everblock/hooks

--- a/src/Controller/Admin/EverblockBlockController.php
+++ b/src/Controller/Admin/EverblockBlockController.php
@@ -225,9 +225,13 @@ class EverblockBlockController extends BaseEverblockController
         );
     }
 
-    public function duplicate(int $everblockId): RedirectResponse
+    public function duplicate(int $everblockId, Request $request): RedirectResponse
     {
         $this->denyAccessUnlessGranted('create', 'AdminEverBlock');
+
+        if (!$this->isTokenValid($request, sprintf('everblock_block_duplicate_%d', $everblockId))) {
+            return $this->redirectToRoute('everblock_admin_blocks');
+        }
 
         $source = new EverBlockClass($everblockId);
         if (!Validate::isLoadedObject($source)) {
@@ -278,9 +282,13 @@ class EverblockBlockController extends BaseEverblockController
         return $this->redirectToRoute('everblock_admin_blocks');
     }
 
-    public function toggle(int $everblockId): RedirectResponse
+    public function toggle(int $everblockId, Request $request): RedirectResponse
     {
         $this->denyAccessUnlessGranted('update', 'AdminEverBlock');
+
+        if (!$this->isTokenValid($request, sprintf('everblock_block_toggle_%d', $everblockId))) {
+            return $this->redirectToRoute('everblock_admin_blocks');
+        }
 
         $block = new EverBlockClass($everblockId);
         if (!Validate::isLoadedObject($block)) {
@@ -302,6 +310,10 @@ class EverblockBlockController extends BaseEverblockController
     public function bulkDelete(Request $request): RedirectResponse
     {
         $this->denyAccessUnlessGranted('delete', 'AdminEverBlock');
+
+        if (!$this->isTokenValid($request, 'everblock_blocks_bulk_delete')) {
+            return $this->redirectToRoute('everblock_admin_blocks');
+        }
 
         $ids = $request->request->all('ids');
         if (!is_array($ids)) {
@@ -328,6 +340,10 @@ class EverblockBlockController extends BaseEverblockController
     public function bulkDuplicate(Request $request): RedirectResponse
     {
         $this->denyAccessUnlessGranted('create', 'AdminEverBlock');
+
+        if (!$this->isTokenValid($request, 'everblock_blocks_bulk_duplicate')) {
+            return $this->redirectToRoute('everblock_admin_blocks');
+        }
 
         $ids = $request->request->all('ids');
         if (!is_array($ids)) {
@@ -381,9 +397,13 @@ class EverblockBlockController extends BaseEverblockController
         return $response;
     }
 
-    public function clearCache(): RedirectResponse
+    public function clearCache(Request $request): RedirectResponse
     {
         $this->denyAccessUnlessGranted('update', 'AdminEverBlock');
+
+        if (!$this->isTokenValid($request, 'everblock_blocks_clear_cache')) {
+            return $this->redirectToRoute('everblock_admin_blocks');
+        }
 
         Tools::clearAllCache();
 
@@ -398,5 +418,18 @@ class EverblockBlockController extends BaseEverblockController
         $this->addFlash('success', $this->translate('Cache has been cleared.'));
 
         return $this->redirectToRoute('everblock_admin_blocks');
+    }
+
+    private function isTokenValid(Request $request, string $tokenId): bool
+    {
+        $token = (string) $request->request->get('_token');
+
+        if (empty($token) || !$this->isCsrfTokenValid($tokenId, $token)) {
+            $this->addFlash('error', $this->translate('The form token is invalid. Please try again.'));
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/templates/admin/everblock/block/index.html.twig
+++ b/templates/admin/everblock/block/index.html.twig
@@ -2,61 +2,71 @@
   <div class="card-header d-flex justify-content-between align-items-center">
     <h3 class="card-title mb-0">{{ 'Blocks list'|trans({}, 'Modules.Everblock.Admin') }}</h3>
     <div class="d-flex gap-2">
-      <a class="btn btn-outline-secondary" href="{{ clear_cache_url }}">{{ 'Clear cache'|trans({}, 'Modules.Everblock.Admin') }}</a>
+      <form method="post" action="{{ clear_cache_url }}" class="m-0">
+        <input type="hidden" name="_token" value="{{ csrf_token('everblock_blocks_clear_cache') }}">
+        <button type="submit" class="btn btn-outline-secondary">{{ 'Clear cache'|trans({}, 'Modules.Everblock.Admin') }}</button>
+      </form>
       <a class="btn btn-primary" href="{{ create_url }}">{{ 'Add new block'|trans({}, 'Modules.Everblock.Admin') }}</a>
     </div>
   </div>
   <div class="card-body">
-    <form method="post" action="{{ path('everblock_admin_blocks_bulk_delete') }}">
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th><input type="checkbox" class="js-everblock-select-all"></th>
-              {% for column in grid_definition.columns %}
-                <th>{{ column.label }}</th>
-              {% endfor %}
-              <th class="text-end">{{ 'Actions'|trans({}, 'Modules.Everblock.Admin') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for record in grid_data.records %}
-              <tr>
-                <td><input type="checkbox" name="ids[]" value="{{ record.id_everblock }}"></td>
-                {% for column in grid_definition.columns %}
-                  <td>
-                    {% set value = attribute(record, column.name) %}
-                    {% if column.type is defined and column.type == 'bool' %}
-                      {% if value %}
-                        <span class="badge bg-success">{{ 'Yes'|trans({}, 'Modules.Everblock.Admin') }}</span>
-                      {% else %}
-                        <span class="badge bg-secondary">{{ 'No'|trans({}, 'Modules.Everblock.Admin') }}</span>
-                      {% endif %}
-                    {% else %}
-                      {{ value }}
-                    {% endif %}
-                  </td>
-                {% endfor %}
-                <td class="text-end">
-                  <div class="btn-group" role="group">
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_edit', {everblockId: record.id_everblock}) }}">{{ 'Edit'|trans({}, 'Modules.Everblock.Admin') }}</a>
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_duplicate', {everblockId: record.id_everblock}) }}">{{ 'Duplicate'|trans({}, 'Modules.Everblock.Admin') }}</a>
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_toggle', {everblockId: record.id_everblock}) }}">{{ 'Toggle'|trans({}, 'Modules.Everblock.Admin') }}</a>
-                    <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_export', {everblockId: record.id_everblock}) }}">{{ 'Export'|trans({}, 'Modules.Everblock.Admin') }}</a>
-                  </div>
-                </td>
-              </tr>
-            {% else %}
-              <tr>
-                <td colspan="{{ grid_definition.columns|length + 2 }}" class="text-center text-muted">{{ 'No blocks found.'|trans({}, 'Modules.Everblock.Admin') }}</td>
-              </tr>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th><input type="checkbox" class="js-everblock-select-all"></th>
+            {% for column in grid_definition.columns %}
+              <th>{{ column.label }}</th>
             {% endfor %}
-          </tbody>
-        </table>
-      </div>
+            <th class="text-end">{{ 'Actions'|trans({}, 'Modules.Everblock.Admin') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for record in grid_data.records %}
+            <tr>
+              <td><input type="checkbox" name="ids[]" value="{{ record.id_everblock }}" form="everblock-bulk-form"></td>
+              {% for column in grid_definition.columns %}
+                <td>
+                  {% set value = attribute(record, column.name) %}
+                  {% if column.type is defined and column.type == 'bool' %}
+                    {% if value %}
+                      <span class="badge bg-success">{{ 'Yes'|trans({}, 'Modules.Everblock.Admin') }}</span>
+                    {% else %}
+                      <span class="badge bg-secondary">{{ 'No'|trans({}, 'Modules.Everblock.Admin') }}</span>
+                    {% endif %}
+                  {% else %}
+                    {{ value }}
+                  {% endif %}
+                </td>
+              {% endfor %}
+              <td class="text-end">
+                <div class="btn-group" role="group">
+                  <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_edit', {everblockId: record.id_everblock}) }}">{{ 'Edit'|trans({}, 'Modules.Everblock.Admin') }}</a>
+                  <form method="post" action="{{ path('everblock_admin_blocks_duplicate', {everblockId: record.id_everblock}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('everblock_block_duplicate_' ~ record.id_everblock) }}">
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">{{ 'Duplicate'|trans({}, 'Modules.Everblock.Admin') }}</button>
+                  </form>
+                  <form method="post" action="{{ path('everblock_admin_blocks_toggle', {everblockId: record.id_everblock}) }}" class="d-inline">
+                    <input type="hidden" name="_token" value="{{ csrf_token('everblock_block_toggle_' ~ record.id_everblock) }}">
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">{{ 'Toggle'|trans({}, 'Modules.Everblock.Admin') }}</button>
+                  </form>
+                  <a class="btn btn-outline-secondary btn-sm" href="{{ path('everblock_admin_blocks_export', {everblockId: record.id_everblock}) }}">{{ 'Export'|trans({}, 'Modules.Everblock.Admin') }}</a>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="{{ grid_definition.columns|length + 2 }}" class="text-center text-muted">{{ 'No blocks found.'|trans({}, 'Modules.Everblock.Admin') }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <form id="everblock-bulk-form" method="post" action="{{ path('everblock_admin_blocks_bulk_delete') }}">
+      <input type="hidden" name="_token" value="{{ csrf_token('everblock_blocks_bulk_delete') }}">
       <div class="d-flex gap-2 mt-3">
-        <button type="submit" class="btn btn-danger">{{ grid_definition.bulk_actions.delete.label }}</button>
-        <button type="submit" class="btn btn-outline-secondary" formaction="{{ path('everblock_admin_blocks_bulk_duplicate') }}">{{ grid_definition.bulk_actions.duplicate.label }}</button>
+        <button type="submit" class="btn btn-danger" data-token="{{ csrf_token('everblock_blocks_bulk_delete') }}">{{ grid_definition.bulk_actions.delete.label }}</button>
+        <button type="submit" class="btn btn-outline-secondary" formaction="{{ path('everblock_admin_blocks_bulk_duplicate') }}" data-token="{{ csrf_token('everblock_blocks_bulk_duplicate') }}">{{ grid_definition.bulk_actions.duplicate.label }}</button>
       </div>
     </form>
   </div>
@@ -71,6 +81,24 @@
     toggle.addEventListener('change', function (event) {
       document.querySelectorAll('input[name="ids[]"]').forEach(function (checkbox) {
         checkbox.checked = event.target.checked;
+      });
+    });
+  });
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var bulkForm = document.getElementById('everblock-bulk-form');
+    if (!bulkForm) {
+      return;
+    }
+
+    var tokenInput = bulkForm.querySelector('input[name="_token"]');
+    if (!tokenInput) {
+      return;
+    }
+
+    bulkForm.querySelectorAll('button[data-token]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        tokenInput.value = button.getAttribute('data-token');
       });
     });
   });


### PR DESCRIPTION
## Summary
- require POST requests and token validation for block duplication, toggle, and cache clearing routes
- add CSRF-protected forms to the blocks grid for row actions, bulk actions, and cache clearing
- validate submitted tokens server-side before executing sensitive operations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38d421dc88322a5327684fae6c5db