### PR TITLE
Introduce domain services and Doctrine entities for legacy models

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -152,6 +152,13 @@ services:
             $connection: '@doctrine.dbal.default_connection'
             $cache: '@cache.app'
 
+    Everblock\Tools\Service\Domain\EverBlockDomainService: ~
+    Everblock\Tools\Service\Domain\EverBlockFaqDomainService: ~
+    Everblock\Tools\Service\Domain\LegacyModelMap: ~
+    Everblock\Tools\Service\Domain\EverBlockFlagDomainService: ~
+    Everblock\Tools\Service\Domain\EverBlockTabDomainService: ~
+    Everblock\Tools\Service\Domain\EverBlockModalDomainService: ~
+
     Everblock\Tools\Service\EverBlockProvider: ~
     Everblock\Tools\Service\EverBlockFaqProvider: ~
     Everblock\Tools\Service\EverBlockFlagProvider: ~

--- a/src/Entity/EverBlock.php
+++ b/src/Entity/EverBlock.php
@@ -33,7 +33,7 @@ class EverBlock
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
-    #[ORM\Column(type: 'text')]
+    #[ORM\Column(type: 'string', length: 255)]
     private string $name = '';
 
     #[ORM\Column(name: 'id_hook', type: 'integer')]
@@ -142,5 +142,323 @@ class EverBlock
     public function getTranslations(): Collection
     {
         return $this->translations;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getHookId(): int
+    {
+        return $this->hookId;
+    }
+
+    public function setHookId(int $hookId): void
+    {
+        $this->hookId = $hookId;
+    }
+
+    public function getOnlyHome(): bool
+    {
+        return $this->onlyHome;
+    }
+
+    public function setOnlyHome(bool $onlyHome): void
+    {
+        $this->onlyHome = $onlyHome;
+    }
+
+    public function getOnlyCategory(): bool
+    {
+        return $this->onlyCategory;
+    }
+
+    public function setOnlyCategory(bool $onlyCategory): void
+    {
+        $this->onlyCategory = $onlyCategory;
+    }
+
+    public function getOnlyCategoryProduct(): bool
+    {
+        return $this->onlyCategoryProduct;
+    }
+
+    public function setOnlyCategoryProduct(bool $onlyCategoryProduct): void
+    {
+        $this->onlyCategoryProduct = $onlyCategoryProduct;
+    }
+
+    public function getOnlyManufacturer(): bool
+    {
+        return $this->onlyManufacturer;
+    }
+
+    public function setOnlyManufacturer(bool $onlyManufacturer): void
+    {
+        $this->onlyManufacturer = $onlyManufacturer;
+    }
+
+    public function getOnlySupplier(): bool
+    {
+        return $this->onlySupplier;
+    }
+
+    public function setOnlySupplier(bool $onlySupplier): void
+    {
+        $this->onlySupplier = $onlySupplier;
+    }
+
+    public function getOnlyCmsCategory(): bool
+    {
+        return $this->onlyCmsCategory;
+    }
+
+    public function setOnlyCmsCategory(bool $onlyCmsCategory): void
+    {
+        $this->onlyCmsCategory = $onlyCmsCategory;
+    }
+
+    public function getObfuscateLink(): bool
+    {
+        return $this->obfuscateLink;
+    }
+
+    public function setObfuscateLink(bool $obfuscateLink): void
+    {
+        $this->obfuscateLink = $obfuscateLink;
+    }
+
+    public function getAddContainer(): bool
+    {
+        return $this->addContainer;
+    }
+
+    public function setAddContainer(bool $addContainer): void
+    {
+        $this->addContainer = $addContainer;
+    }
+
+    public function getLazyload(): bool
+    {
+        return $this->lazyload;
+    }
+
+    public function setLazyload(bool $lazyload): void
+    {
+        $this->lazyload = $lazyload;
+    }
+
+    public function getDevice(): int
+    {
+        return $this->device;
+    }
+
+    public function setDevice(int $device): void
+    {
+        $this->device = $device;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function setShopId(int $shopId): void
+    {
+        $this->shopId = $shopId;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function getCategories(): ?string
+    {
+        return $this->categories;
+    }
+
+    public function setCategories(?string $categories): void
+    {
+        $this->categories = $categories;
+    }
+
+    public function getManufacturers(): ?string
+    {
+        return $this->manufacturers;
+    }
+
+    public function setManufacturers(?string $manufacturers): void
+    {
+        $this->manufacturers = $manufacturers;
+    }
+
+    public function getSuppliers(): ?string
+    {
+        return $this->suppliers;
+    }
+
+    public function setSuppliers(?string $suppliers): void
+    {
+        $this->suppliers = $suppliers;
+    }
+
+    public function getCmsCategories(): ?string
+    {
+        return $this->cmsCategories;
+    }
+
+    public function setCmsCategories(?string $cmsCategories): void
+    {
+        $this->cmsCategories = $cmsCategories;
+    }
+
+    public function getGroups(): ?string
+    {
+        return $this->groups;
+    }
+
+    public function setGroups(?string $groups): void
+    {
+        $this->groups = $groups;
+    }
+
+    public function getBackground(): ?string
+    {
+        return $this->background;
+    }
+
+    public function setBackground(?string $background): void
+    {
+        $this->background = $background;
+    }
+
+    public function getCssClass(): ?string
+    {
+        return $this->cssClass;
+    }
+
+    public function setCssClass(?string $cssClass): void
+    {
+        $this->cssClass = $cssClass;
+    }
+
+    public function getDataAttribute(): ?string
+    {
+        return $this->dataAttribute;
+    }
+
+    public function setDataAttribute(?string $dataAttribute): void
+    {
+        $this->dataAttribute = $dataAttribute;
+    }
+
+    public function getBootstrapClass(): ?string
+    {
+        return $this->bootstrapClass;
+    }
+
+    public function setBootstrapClass(?string $bootstrapClass): void
+    {
+        $this->bootstrapClass = $bootstrapClass;
+    }
+
+    public function isModal(): bool
+    {
+        return $this->modal;
+    }
+
+    public function setModal(bool $modal): void
+    {
+        $this->modal = $modal;
+    }
+
+    public function getDelay(): int
+    {
+        return $this->delay;
+    }
+
+    public function setDelay(int $delay): void
+    {
+        $this->delay = $delay;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    public function setTimeout(int $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
+
+    public function getDateStart(): ?\DateTimeInterface
+    {
+        return $this->dateStart;
+    }
+
+    public function setDateStart(?\DateTimeInterface $dateStart): void
+    {
+        $this->dateStart = $dateStart;
+    }
+
+    public function getDateEnd(): ?\DateTimeInterface
+    {
+        return $this->dateEnd;
+    }
+
+    public function setDateEnd(?\DateTimeInterface $dateEnd): void
+    {
+        $this->dateEnd = $dateEnd;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): void
+    {
+        $this->active = $active;
+    }
+
+    public function addTranslation(EverBlockTranslation $translation): void
+    {
+        foreach ($this->translations as $existingTranslation) {
+            if ($existingTranslation->getLanguageId() === $translation->getLanguageId()) {
+                $this->translations->removeElement($existingTranslation);
+                break;
+            }
+        }
+
+        $this->translations->add($translation);
+    }
+
+    public function getTranslation(int $languageId): ?EverBlockTranslation
+    {
+        foreach ($this->translations as $translation) {
+            if ($translation->getLanguageId() === $languageId) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Entity/EverBlockFaq.php
+++ b/src/Entity/EverBlockFaq.php
@@ -67,6 +67,11 @@ class EverBlockFaq
         return $this->id;
     }
 
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
     public function getTagName(): ?string
     {
         return $this->tagName;
@@ -133,5 +138,31 @@ class EverBlockFaq
     public function getTranslations(): Collection
     {
         return $this->translations;
+    }
+
+    public function addTranslation(EverBlockFaqTranslation $translation): void
+    {
+        foreach ($this->translations as $existingTranslation) {
+            if ($existingTranslation->getLanguageId() === $translation->getLanguageId()
+                && $existingTranslation->getShopId() === $translation->getShopId()
+            ) {
+                $this->translations->removeElement($existingTranslation);
+
+                break;
+            }
+        }
+
+        $this->translations->add($translation);
+    }
+
+    public function getTranslation(int $languageId, int $shopId): ?EverBlockFaqTranslation
+    {
+        foreach ($this->translations as $translation) {
+            if ($translation->getLanguageId() === $languageId && $translation->getShopId() === $shopId) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Entity/EverBlockFlag.php
+++ b/src/Entity/EverBlockFlag.php
@@ -58,6 +58,11 @@ class EverBlockFlag
         return $this->id;
     }
 
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
     public function getProductId(): int
     {
         return $this->productId;
@@ -94,5 +99,29 @@ class EverBlockFlag
     public function getTranslations(): Collection
     {
         return $this->translations;
+    }
+
+    public function addTranslation(EverBlockFlagTranslation $translation): void
+    {
+        foreach ($this->translations as $existingTranslation) {
+            if ($existingTranslation->getLanguageId() === $translation->getLanguageId()) {
+                $this->translations->removeElement($existingTranslation);
+
+                break;
+            }
+        }
+
+        $this->translations->add($translation);
+    }
+
+    public function getTranslation(int $languageId): ?EverBlockFlagTranslation
+    {
+        foreach ($this->translations as $translation) {
+            if ($translation->getLanguageId() === $languageId) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Entity/EverBlockModal.php
+++ b/src/Entity/EverBlockModal.php
@@ -58,6 +58,11 @@ class EverBlockModal
         return $this->id;
     }
 
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
     public function getProductId(): int
     {
         return $this->productId;
@@ -94,5 +99,29 @@ class EverBlockModal
     public function getTranslations(): Collection
     {
         return $this->translations;
+    }
+
+    public function addTranslation(EverBlockModalTranslation $translation): void
+    {
+        foreach ($this->translations as $existingTranslation) {
+            if ($existingTranslation->getLanguageId() === $translation->getLanguageId()) {
+                $this->translations->removeElement($existingTranslation);
+
+                break;
+            }
+        }
+
+        $this->translations->add($translation);
+    }
+
+    public function getTranslation(int $languageId): ?EverBlockModalTranslation
+    {
+        foreach ($this->translations as $translation) {
+            if ($translation->getLanguageId() === $languageId) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Entity/EverBlockTab.php
+++ b/src/Entity/EverBlockTab.php
@@ -58,6 +58,11 @@ class EverBlockTab
         return $this->id;
     }
 
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
     public function getProductId(): int
     {
         return $this->productId;
@@ -94,5 +99,31 @@ class EverBlockTab
     public function getTranslations(): Collection
     {
         return $this->translations;
+    }
+
+    public function addTranslation(EverBlockTabTranslation $translation): void
+    {
+        foreach ($this->translations as $existingTranslation) {
+            if ($existingTranslation->getLanguageId() === $translation->getLanguageId()
+                && $existingTranslation->getShopId() === $translation->getShopId()
+            ) {
+                $this->translations->removeElement($existingTranslation);
+
+                break;
+            }
+        }
+
+        $this->translations->add($translation);
+    }
+
+    public function getTranslation(int $languageId, int $shopId): ?EverBlockTabTranslation
+    {
+        foreach ($this->translations as $translation) {
+            if ($translation->getLanguageId() === $languageId && $translation->getShopId() === $shopId) {
+                return $translation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Repository/EverBlockFaqRepository.php
+++ b/src/Repository/EverBlockFaqRepository.php
@@ -20,9 +20,12 @@
 
 namespace Everblock\Tools\Repository;
 
+use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Everblock\Tools\Entity\EverBlockFaq;
+use Everblock\Tools\Entity\EverBlockFaqTranslation;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
@@ -105,6 +108,70 @@ class EverBlockFaqRepository
         ]);
     }
 
+    public function findById(int $faqId, int $shopId): ?EverBlockFaq
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->select('*')
+            ->from($this->getTableName('everblock_faq'))
+            ->where('id_everblock_faq = :faqId')
+            ->andWhere('id_shop = :shopId')
+            ->setParameter('faqId', $faqId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->setMaxResults(1);
+
+        $row = $queryBuilder->executeQuery()->fetchAssociative();
+
+        if (false === $row) {
+            return null;
+        }
+
+        $faq = $this->hydrateFaq($row);
+        $translations = $this->fetchTranslations($faqId, $shopId, $faq);
+
+        foreach ($translations as $translation) {
+            $faq->addTranslation($translation);
+        }
+
+        return $faq;
+    }
+
+    /**
+     * @param array<int, array{title: string|null, content: string|null}> $translations
+     */
+    public function save(EverBlockFaq $faq, array $translations): EverBlockFaq
+    {
+        if (null === $faq->getId()) {
+            $faqId = $this->insertFaq($faq);
+            $faq->setId($faqId);
+        } else {
+            $this->updateFaq($faq);
+        }
+
+        $this->saveTranslations((int) $faq->getId(), $faq->getShopId(), $translations);
+        $this->clearCacheForShop($faq->getShopId());
+
+        if (null !== $faq->getTagName()) {
+            $this->clearCacheForTag($faq->getShopId(), $faq->getTagName());
+        }
+
+        return $faq;
+    }
+
+    public function delete(int $faqId, int $shopId): void
+    {
+        $this->connection->delete($this->getTableName('everblock_faq_lang'), [
+            'id_everblock_faq' => $faqId,
+            'id_shop' => $shopId,
+        ]);
+        $this->connection->delete($this->getTableName('everblock_faq'), [
+            'id_everblock_faq' => $faqId,
+            'id_shop' => $shopId,
+        ]);
+
+        $this->clearCacheForShop($shopId);
+    }
+
     private function createBaseQueryBuilder(int $shopId, int $languageId): QueryBuilder
     {
         $queryBuilder = $this->connection->createQueryBuilder();
@@ -132,6 +199,102 @@ class EverBlockFaqRepository
             ->setParameter('shopId', $shopId, ParameterType::INTEGER);
 
         return $queryBuilder;
+    }
+
+    private function hydrateFaq(array $row): EverBlockFaq
+    {
+        $faq = new EverBlockFaq();
+        $faq->setShopId((int) $row['id_shop']);
+        $faq->setTagName($row['tag_name']);
+        $faq->setPosition((int) $row['position']);
+        $faq->setActive((bool) $row['active']);
+
+        if (!empty($row['date_add']) && $row['date_add'] !== '0000-00-00 00:00:00') {
+            $faq->setDateAdd(new DateTimeImmutable((string) $row['date_add']));
+        }
+        if (!empty($row['date_upd']) && $row['date_upd'] !== '0000-00-00 00:00:00') {
+            $faq->setDateUpdated(new DateTimeImmutable((string) $row['date_upd']));
+        }
+
+        $faq->setId((int) $row['id_everblock_faq']);
+
+        return $faq;
+    }
+
+    private function fetchTranslations(int $faqId, int $shopId, EverBlockFaq $faq): array
+    {
+        $rows = $this->connection->createQueryBuilder()
+            ->select('id_lang', 'title', 'content')
+            ->from($this->getTableName('everblock_faq_lang'))
+            ->where('id_everblock_faq = :faqId')
+            ->andWhere('id_shop = :shopId')
+            ->setParameter('faqId', $faqId, ParameterType::INTEGER)
+            ->setParameter('shopId', $shopId, ParameterType::INTEGER)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $translations = [];
+        foreach ($rows as $row) {
+            $translation = new EverBlockFaqTranslation($faq, (int) $row['id_lang'], $shopId);
+            $translation->setTitle($row['title']);
+            $translation->setContent($row['content']);
+            $translations[] = $translation;
+        }
+
+        return $translations;
+    }
+
+    private function insertFaq(EverBlockFaq $faq): int
+    {
+        $this->connection->insert($this->getTableName('everblock_faq'), [
+            'tag_name' => $faq->getTagName(),
+            'id_shop' => $faq->getShopId(),
+            'position' => $faq->getPosition(),
+            'date_add' => $faq->getDateAdd()?->format('Y-m-d H:i:s'),
+            'date_upd' => $faq->getDateUpdated()?->format('Y-m-d H:i:s'),
+            'active' => $faq->isActive() ? 1 : 0,
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function updateFaq(EverBlockFaq $faq): void
+    {
+        $this->connection->update(
+            $this->getTableName('everblock_faq'),
+            [
+                'tag_name' => $faq->getTagName(),
+                'position' => $faq->getPosition(),
+                'date_add' => $faq->getDateAdd()?->format('Y-m-d H:i:s'),
+                'date_upd' => $faq->getDateUpdated()?->format('Y-m-d H:i:s'),
+                'active' => $faq->isActive() ? 1 : 0,
+            ],
+            [
+                'id_everblock_faq' => $faq->getId(),
+                'id_shop' => $faq->getShopId(),
+            ]
+        );
+    }
+
+    /**
+     * @param array<int, array{title: string|null, content: string|null}> $translations
+     */
+    private function saveTranslations(int $faqId, int $shopId, array $translations): void
+    {
+        $this->connection->delete($this->getTableName('everblock_faq_lang'), [
+            'id_everblock_faq' => $faqId,
+            'id_shop' => $shopId,
+        ]);
+
+        foreach ($translations as $languageId => $data) {
+            $this->connection->insert($this->getTableName('everblock_faq_lang'), [
+                'id_everblock_faq' => $faqId,
+                'id_lang' => $languageId,
+                'id_shop' => $shopId,
+                'title' => $data['title'] ?? null,
+                'content' => $data['content'] ?? null,
+            ]);
+        }
     }
 
     /**

--- a/src/Service/Domain/EverBlockDomainService.php
+++ b/src/Service/Domain/EverBlockDomainService.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use DateTimeImmutable;
+use Everblock\Tools\Entity\EverBlock;
+use Everblock\Tools\Repository\EverBlockRepository;
+
+class EverBlockDomainService
+{
+    public function __construct(private readonly EverBlockRepository $repository)
+    {
+    }
+
+    public function getAllBlocks(int $languageId, int $shopId): array
+    {
+        return $this->repository->getAllBlocks($languageId, $shopId);
+    }
+
+    public function getBlocks(int $hookId, int $languageId, int $shopId): array
+    {
+        return $this->repository->getBlocks($hookId, $languageId, $shopId);
+    }
+
+    public function getBootstrapColClass(int $colNumber): string
+    {
+        return $this->repository->getBootstrapColClass($colNumber);
+    }
+
+    public function cleanBlocksCacheOnDate(int $languageId, int $shopId): void
+    {
+        $blocks = $this->repository->getAllBlocks($languageId, $shopId);
+
+        $now = new DateTimeImmutable('now');
+        $formattedNow = $now->format('Y-m-d H:i:s');
+
+        foreach ($blocks as $block) {
+            $needsFlush = false;
+
+            if (!empty($block['date_start']) && $block['date_start'] !== '0000-00-00 00:00:00' && $block['date_start'] > $formattedNow) {
+                $needsFlush = true;
+            }
+
+            if (!empty($block['date_end']) && $block['date_end'] !== '0000-00-00 00:00:00' && $block['date_end'] < $formattedNow) {
+                $needsFlush = true;
+            }
+
+            if (true === $needsFlush) {
+                $this->repository->clearCacheForHook((int) $block['id_hook']);
+            }
+        }
+    }
+
+    public function find(int $blockId, int $shopId): ?EverBlock
+    {
+        return $this->repository->findById($blockId, $shopId);
+    }
+
+    /**
+     * @param array<int, array{content: string|null, custom_code: string|null}> $translations
+     */
+    public function save(EverBlock $block, array $translations): EverBlock
+    {
+        return $this->repository->save($block, $translations);
+    }
+
+    public function delete(int $blockId, int $shopId): void
+    {
+        $this->repository->delete($blockId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+}
+

--- a/src/Service/Domain/EverBlockFaqDomainService.php
+++ b/src/Service/Domain/EverBlockFaqDomainService.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Entity\EverBlockFaq;
+use Everblock\Tools\Repository\EverBlockFaqRepository;
+
+class EverBlockFaqDomainService
+{
+    public function __construct(private readonly EverBlockFaqRepository $repository)
+    {
+    }
+
+    public function getAll(int $shopId, int $languageId): array
+    {
+        return $this->repository->getAllFaq($shopId, $languageId);
+    }
+
+    public function findByTagName(int $shopId, int $languageId, string $tagName): array
+    {
+        return $this->repository->getFaqByTagName($shopId, $languageId, $tagName);
+    }
+
+    public function find(int $faqId, int $shopId): ?EverBlockFaq
+    {
+        return $this->repository->findById($faqId, $shopId);
+    }
+
+    /**
+     * @param array<int, array{title: string|null, content: string|null}> $translations
+     */
+    public function save(EverBlockFaq $faq, array $translations): EverBlockFaq
+    {
+        return $this->repository->save($faq, $translations);
+    }
+
+    public function delete(int $faqId, int $shopId): void
+    {
+        $this->repository->delete($faqId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+}
+

--- a/src/Service/Domain/EverBlockFlagDomainService.php
+++ b/src/Service/Domain/EverBlockFlagDomainService.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Entity\EverBlockFlag;
+use Everblock\Tools\Entity\EverBlockFlagTranslation;
+use Everblock\Tools\Repository\EverBlockFlagRepository;
+
+class EverBlockFlagDomainService
+{
+    public function __construct(private readonly EverBlockFlagRepository $repository)
+    {
+    }
+
+    /**
+     * @return EverBlockFlag[]
+     */
+    public function getFlagsForAdmin(int $productId, int $shopId): array
+    {
+        $rows = $this->repository->getFlagsForAdmin($productId, $shopId);
+
+        return array_map(function (array $row) use ($shopId) {
+            return $this->hydrateFlag($row, $shopId);
+        }, $rows);
+    }
+
+    public function getFlags(int $productId, int $shopId, int $languageId): array
+    {
+        return $this->repository->getFlags($productId, $shopId, $languageId);
+    }
+
+    /**
+     * @param array<int, array{title: string|null, content: string|null}> $translations
+     */
+    public function save(EverBlockFlag $flag, array $translations): EverBlockFlag
+    {
+        $titles = [];
+        $contents = [];
+        foreach ($translations as $languageId => $data) {
+            $titles[(int) $languageId] = $data['title'] ?? null;
+            $contents[(int) $languageId] = $data['content'] ?? null;
+        }
+
+        $flagId = $this->repository->saveFlag(
+            $flag->getProductId(),
+            $flag->getShopId(),
+            $flag->getFlagId(),
+            $titles,
+            $contents
+        );
+
+        $flag->setId($flagId);
+
+        return $flag;
+    }
+
+    public function deleteByProduct(int $productId, int $shopId): void
+    {
+        $this->repository->deleteFlagsByProduct($productId, $shopId);
+    }
+
+    public function hasFlagsForShop(int $shopId): bool
+    {
+        return $this->repository->hasFlagsForShop($shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    private function hydrateFlag(array $row, int $shopId): EverBlockFlag
+    {
+        $flag = new EverBlockFlag();
+        $flag->setId((int) ($row['id_everblock_flags'] ?? 0));
+        $flag->setProductId((int) ($row['id_product'] ?? 0));
+        $flag->setShopId((int) ($row['id_shop'] ?? $shopId));
+        $flag->setFlagId((int) ($row['id_flag'] ?? 0));
+
+        if (isset($row['title']) && is_array($row['title'])) {
+            foreach ($row['title'] as $languageId => $title) {
+                $translation = new EverBlockFlagTranslation($flag, (int) $languageId, $flag->getShopId());
+                $translation->setTitle($title);
+                $translation->setContent($row['content'][$languageId] ?? null);
+                $flag->addTranslation($translation);
+            }
+        }
+
+        return $flag;
+    }
+}
+

--- a/src/Service/Domain/EverBlockModalDomainService.php
+++ b/src/Service/Domain/EverBlockModalDomainService.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Entity\EverBlockModal;
+use Everblock\Tools\Entity\EverBlockModalTranslation;
+use Everblock\Tools\Repository\EverBlockModalRepository;
+
+class EverBlockModalDomainService
+{
+    public function __construct(private readonly EverBlockModalRepository $repository)
+    {
+    }
+
+    public function findByProduct(int $productId, int $shopId, int $languageId): ?array
+    {
+        return $this->repository->getModalForProduct($productId, $shopId, $languageId);
+    }
+
+    public function find(int $modalId, int $shopId): ?EverBlockModal
+    {
+        return $this->repository->findById($modalId, $shopId);
+    }
+
+    /**
+     * @param array<int, array{content: string|null}> $translations
+     */
+    public function save(EverBlockModal $modal, array $translations): EverBlockModal
+    {
+        return $this->repository->save($modal, $translations);
+    }
+
+    public function delete(int $modalId, int $shopId): void
+    {
+        $this->repository->delete($modalId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    /**
+     * @param array<int, string|null> $contents
+     */
+    public function buildTranslations(EverBlockModal $modal, array $contents): array
+    {
+        $translations = [];
+        foreach ($contents as $languageId => $content) {
+            $translation = new EverBlockModalTranslation($modal, (int) $languageId);
+            $translation->setContent($content);
+            $modal->addTranslation($translation);
+            $translations[(int) $languageId] = ['content' => $content];
+        }
+
+        return $translations;
+    }
+}
+

--- a/src/Service/Domain/EverBlockTabDomainService.php
+++ b/src/Service/Domain/EverBlockTabDomainService.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Entity\EverBlockTab;
+use Everblock\Tools\Entity\EverBlockTabTranslation;
+use Everblock\Tools\Repository\EverBlockTabRepository;
+
+class EverBlockTabDomainService
+{
+    public function __construct(private readonly EverBlockTabRepository $repository)
+    {
+    }
+
+    /**
+     * @return EverBlockTab[]
+     */
+    public function getTabsForAdmin(int $productId, int $shopId): array
+    {
+        $rows = $this->repository->getTabsForAdmin($productId, $shopId);
+
+        return array_map(function (array $row) use ($shopId) {
+            return $this->hydrateTab($row, $shopId);
+        }, $rows);
+    }
+
+    public function getTabs(int $productId, int $shopId, int $languageId): array
+    {
+        return $this->repository->getTabs($productId, $shopId, $languageId);
+    }
+
+    /**
+     * @param array<int, array{title: string|null, content: string|null}> $translations
+     */
+    public function save(EverBlockTab $tab, array $translations): EverBlockTab
+    {
+        $titles = [];
+        $contents = [];
+        foreach ($translations as $languageId => $data) {
+            $titles[(int) $languageId] = $data['title'] ?? null;
+            $contents[(int) $languageId] = $data['content'] ?? null;
+        }
+
+        $tabId = $this->repository->saveTab(
+            $tab->getProductId(),
+            $tab->getShopId(),
+            $tab->getTabId(),
+            $titles,
+            $contents
+        );
+
+        $tab->setId($tabId);
+
+        return $tab;
+    }
+
+    public function deleteByProduct(int $productId, int $shopId): void
+    {
+        $this->repository->deleteTabsByProduct($productId, $shopId);
+    }
+
+    public function clearCache(): void
+    {
+        $this->repository->clearCache();
+    }
+
+    private function hydrateTab(array $row, int $shopId): EverBlockTab
+    {
+        $tab = new EverBlockTab();
+        $tab->setId((int) ($row['id_everblock_tabs'] ?? 0));
+        $tab->setProductId((int) ($row['id_product'] ?? 0));
+        $tab->setShopId((int) ($row['id_shop'] ?? $shopId));
+        $tab->setTabId((int) ($row['id_tab'] ?? 0));
+
+        if (isset($row['title']) && is_array($row['title'])) {
+            foreach ($row['title'] as $languageId => $title) {
+                $translation = new EverBlockTabTranslation($tab, (int) $languageId, $tab->getShopId());
+                $translation->setTitle($title);
+                $translation->setContent($row['content'][$languageId] ?? null);
+                $tab->addTranslation($translation);
+            }
+        }
+
+        return $tab;
+    }
+}
+

--- a/src/Service/Domain/LegacyModelMap.php
+++ b/src/Service/Domain/LegacyModelMap.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Entity\EverBlock;
+use Everblock\Tools\Entity\EverBlockFaq;
+use Everblock\Tools\Entity\EverBlockFlag;
+use Everblock\Tools\Entity\EverBlockModal;
+use Everblock\Tools\Entity\EverBlockTab;
+use Everblock\Tools\Repository\EverBlockFaqRepository;
+use Everblock\Tools\Repository\EverBlockFlagRepository;
+use Everblock\Tools\Repository\EverBlockModalRepository;
+use Everblock\Tools\Repository\EverBlockRepository;
+use Everblock\Tools\Repository\EverBlockTabRepository;
+use Everblock\Tools\Service\EverBlockFlagProvider;
+use Everblock\Tools\Service\EverBlockModalProvider;
+use Everblock\Tools\Service\EverBlockTabProvider;
+
+class LegacyModelMap
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getMappings(): array
+    {
+        return [
+            'EverblockClass' => [
+                'entity' => EverBlock::class,
+                'repository' => EverBlockRepository::class,
+                'service' => EverBlockDomainService::class,
+                'usage' => [
+                    'everblock.php',
+                    'models/EverblockTools.php',
+                    'src/Form/Handler/EverblockFormHandler.php',
+                ],
+            ],
+            'EverblockFaq' => [
+                'entity' => EverBlockFaq::class,
+                'repository' => EverBlockFaqRepository::class,
+                'service' => EverBlockFaqDomainService::class,
+                'usage' => [
+                    'everblock.php',
+                    'models/EverblockTools.php',
+                    'controllers/front/contact.php',
+                ],
+            ],
+            'EverblockFlagsClass' => [
+                'entity' => EverBlockFlag::class,
+                'repository' => EverBlockFlagRepository::class,
+                'service' => EverBlockFlagProvider::class,
+                'usage' => [
+                    'everblock.php',
+                    'models/EverblockTools.php',
+                    'controllers/front/videoproducts.php',
+                ],
+            ],
+            'EverblockTabsClass' => [
+                'entity' => EverBlockTab::class,
+                'repository' => EverBlockTabRepository::class,
+                'service' => EverBlockTabProvider::class,
+                'usage' => [
+                    'everblock.php',
+                    'models/EverblockTools.php',
+                    'controllers/front/videoproducts.php',
+                ],
+            ],
+            'EverblockModal' => [
+                'entity' => EverBlockModal::class,
+                'repository' => EverBlockModalRepository::class,
+                'service' => EverBlockModalProvider::class,
+                'usage' => [
+                    'everblock.php',
+                    'models/EverblockTools.php',
+                    'controllers/front/modal.php',
+                ],
+            ],
+        ];
+    }
+}
+


### PR DESCRIPTION
## Summary
- add domain services to wrap legacy Everblock ObjectModel logic for blocks, FAQ, flags, tabs, and modals
- expand Doctrine entities and repositories to support CRUD operations and translation persistence
- update the module entry point to consume the new block domain service through the Symfony container and document legacy model mappings

## Testing
- php -l src/Repository/EverBlockRepository.php
- php -l src/Repository/EverBlockFaqRepository.php
- php -l src/Repository/EverBlockModalRepository.php
- php -l src/Service/Domain/EverBlockDomainService.php
- php -l src/Service/Domain/EverBlockFaqDomainService.php
- php -l src/Service/Domain/EverBlockFlagDomainService.php
- php -l src/Service/Domain/EverBlockTabDomainService.php
- php -l src/Service/Domain/EverBlockModalDomainService.php
- php -l src/Service/Domain/LegacyModelMap.php
- php -l src/Entity/EverBlock.php
- php -l src/Entity/EverBlockFaq.php
- php -l src/Entity/EverBlockFlag.php
- php -l src/Entity/EverBlockTab.php
- php -l src/Entity/EverBlockModal.php

------
https://chatgpt.com/codex/tasks/task_e_68f3926b26588322bfa56a98551206f4