### PR TITLE
Refactor Everblock CRUD to Doctrine services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "psr-4": {
       "Everblock\\Tools\\": "src/"
     },
+    "classmap": [
+      "models/"
+    ],
     "exclude-from-classmap": []
   },
   "autoload-dev": {

--- a/config/services.yml
+++ b/config/services.yml
@@ -24,6 +24,8 @@ services:
     everblock.tools.execute_action:
         class: Everblock\Tools\Command\ExecuteAction
         public: true
+        arguments:
+            $blockRepository: '@Everblock\\Tools\\Repository\\EverBlockRepository'
         tags:
             - { name: 'console.command' }
 
@@ -94,6 +96,7 @@ services:
     Everblock\Tools\Form\DataProvider\EverblockFormDataProvider:
         arguments:
             $context: '@prestashop.adapter.legacy.context'
+            $blockRepository: '@Everblock\\Tools\\Repository\\EverBlockRepository'
 
     Everblock\Tools\Form\DataProvider\HookFormDataProvider:
         arguments:
@@ -110,6 +113,7 @@ services:
     Everblock\Tools\Form\Handler\EverblockFormHandler:
         arguments:
             $context: '@prestashop.adapter.legacy.context'
+            $applicationService: '@Everblock\\Tools\\Application\\EverBlockApplicationService'
 
     Everblock\Tools\Form\Handler\HookFormHandler:
         arguments:

--- a/src/Application/Command/EverBlock/EverBlockTranslationCommand.php
+++ b/src/Application/Command/EverBlock/EverBlockTranslationCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Application\Command\EverBlock;
+
+final class EverBlockTranslationCommand
+{
+    public function __construct(
+        private readonly int $languageId,
+        private readonly string $content,
+        private readonly string $customCode
+    ) {
+    }
+
+    public function getLanguageId(): int
+    {
+        return $this->languageId;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getCustomCode(): string
+    {
+        return $this->customCode;
+    }
+}

--- a/src/Application/Command/EverBlock/UpsertEverBlockCommand.php
+++ b/src/Application/Command/EverBlock/UpsertEverBlockCommand.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Application\Command\EverBlock;
+
+use DateTimeInterface;
+
+/**
+ * Command that carries all data required to create or update an Ever Block.
+ */
+final class UpsertEverBlockCommand
+{
+    /**
+     * @param array<int, EverBlockTranslationCommand> $translations
+     * @param array<int> $groups
+     * @param array<int> $categories
+     * @param array<int> $manufacturers
+     * @param array<int> $suppliers
+     * @param array<int> $cmsCategories
+     */
+    public function __construct(
+        private readonly ?int $id,
+        private readonly string $name,
+        private readonly int $hookId,
+        private readonly int $shopId,
+        private readonly bool $onlyHome,
+        private readonly bool $onlyCategory,
+        private readonly bool $onlyCategoryProduct,
+        private readonly bool $onlyManufacturer,
+        private readonly bool $onlySupplier,
+        private readonly bool $onlyCmsCategory,
+        private readonly bool $obfuscateLink,
+        private readonly bool $addContainer,
+        private readonly bool $lazyload,
+        private readonly array $groups,
+        private readonly array $categories,
+        private readonly array $manufacturers,
+        private readonly array $suppliers,
+        private readonly array $cmsCategories,
+        private readonly string $background,
+        private readonly string $cssClass,
+        private readonly string $dataAttribute,
+        private readonly string $bootstrapClass,
+        private readonly ?int $position,
+        private readonly int $device,
+        private readonly ?int $delay,
+        private readonly ?int $timeout,
+        private readonly bool $modal,
+        private readonly ?DateTimeInterface $dateStart,
+        private readonly ?DateTimeInterface $dateEnd,
+        private readonly bool $active,
+        private readonly array $translations,
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getHookId(): int
+    {
+        return $this->hookId;
+    }
+
+    public function getShopId(): int
+    {
+        return $this->shopId;
+    }
+
+    public function onlyHome(): bool
+    {
+        return $this->onlyHome;
+    }
+
+    public function onlyCategory(): bool
+    {
+        return $this->onlyCategory;
+    }
+
+    public function onlyCategoryProduct(): bool
+    {
+        return $this->onlyCategoryProduct;
+    }
+
+    public function onlyManufacturer(): bool
+    {
+        return $this->onlyManufacturer;
+    }
+
+    public function onlySupplier(): bool
+    {
+        return $this->onlySupplier;
+    }
+
+    public function onlyCmsCategory(): bool
+    {
+        return $this->onlyCmsCategory;
+    }
+
+    public function shouldObfuscateLink(): bool
+    {
+        return $this->obfuscateLink;
+    }
+
+    public function shouldAddContainer(): bool
+    {
+        return $this->addContainer;
+    }
+
+    public function shouldLazyload(): bool
+    {
+        return $this->lazyload;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getCategories(): array
+    {
+        return $this->categories;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getManufacturers(): array
+    {
+        return $this->manufacturers;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getSuppliers(): array
+    {
+        return $this->suppliers;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getCmsCategories(): array
+    {
+        return $this->cmsCategories;
+    }
+
+    public function getBackground(): string
+    {
+        return $this->background;
+    }
+
+    public function getCssClass(): string
+    {
+        return $this->cssClass;
+    }
+
+    public function getDataAttribute(): string
+    {
+        return $this->dataAttribute;
+    }
+
+    public function getBootstrapClass(): string
+    {
+        return $this->bootstrapClass;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function getDevice(): int
+    {
+        return $this->device;
+    }
+
+    public function getDelay(): ?int
+    {
+        return $this->delay;
+    }
+
+    public function getTimeout(): ?int
+    {
+        return $this->timeout;
+    }
+
+    public function isModal(): bool
+    {
+        return $this->modal;
+    }
+
+    public function getDateStart(): ?DateTimeInterface
+    {
+        return $this->dateStart;
+    }
+
+    public function getDateEnd(): ?DateTimeInterface
+    {
+        return $this->dateEnd;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * @return array<int, EverBlockTranslationCommand>
+     */
+    public function getTranslations(): array
+    {
+        return $this->translations;
+    }
+}

--- a/src/Application/EverBlockApplicationService.php
+++ b/src/Application/EverBlockApplicationService.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Application;
+
+use Configuration;
+use Everblock\Tools\Application\Command\EverBlock\EverBlockTranslationCommand;
+use Everblock\Tools\Application\Command\EverBlock\UpsertEverBlockCommand;
+use Everblock\Tools\Entity\EverBlock;
+use Everblock\Tools\Entity\EverBlockTranslation;
+use Everblock\Tools\Repository\EverBlockRepository;
+use EverblockTools;
+use Hook;
+use Module;
+use Tools;
+
+class EverBlockApplicationService
+{
+    public function __construct(private readonly EverBlockRepository $repository)
+    {
+    }
+
+    public function save(UpsertEverBlockCommand $command): EverBlock
+    {
+        $block = $this->hydrateBlockFromCommand($command);
+        $translations = $this->buildTranslationsPayload($command->getTranslations());
+
+        $block = $this->repository->save($block, $translations);
+
+        $this->registerHook($block->getHookId());
+        $this->clearCacheIfNeeded();
+
+        return $block;
+    }
+
+    public function duplicate(int $blockId, int $shopId, bool $activate = false): EverBlock
+    {
+        $source = $this->repository->findById($blockId, $shopId);
+        if (!$source instanceof EverBlock) {
+            throw new \RuntimeException(sprintf('EverBlock %d not found for shop %d.', $blockId, $shopId));
+        }
+
+        $duplicate = new EverBlock();
+        $duplicate->setShopId($source->getShopId());
+        $duplicate->setHookId($source->getHookId());
+        $duplicate->setName($source->getName());
+        $duplicate->setOnlyHome($source->getOnlyHome());
+        $duplicate->setOnlyCategory($source->getOnlyCategory());
+        $duplicate->setOnlyCategoryProduct($source->getOnlyCategoryProduct());
+        $duplicate->setOnlyManufacturer($source->getOnlyManufacturer());
+        $duplicate->setOnlySupplier($source->getOnlySupplier());
+        $duplicate->setOnlyCmsCategory($source->getOnlyCmsCategory());
+        $duplicate->setObfuscateLink($source->getObfuscateLink());
+        $duplicate->setAddContainer($source->getAddContainer());
+        $duplicate->setLazyload($source->getLazyload());
+        $duplicate->setCategories($source->getCategories());
+        $duplicate->setManufacturers($source->getManufacturers());
+        $duplicate->setSuppliers($source->getSuppliers());
+        $duplicate->setCmsCategories($source->getCmsCategories());
+        $duplicate->setGroups($source->getGroups());
+        $duplicate->setBackground((string) $source->getBackground());
+        $duplicate->setCssClass((string) $source->getCssClass());
+        $duplicate->setDataAttribute((string) $source->getDataAttribute());
+        $duplicate->setBootstrapClass((string) $source->getBootstrapClass());
+        $duplicate->setDelay($source->getDelay());
+        $duplicate->setTimeout($source->getTimeout());
+        $duplicate->setModal($source->isModal());
+        $duplicate->setDevice($source->getDevice());
+        $duplicate->setDateStart($source->getDateStart());
+        $duplicate->setDateEnd($source->getDateEnd());
+        $duplicate->setActive($activate);
+        $duplicate->setPosition($this->repository->getNextPosition($source->getHookId(), $source->getShopId()));
+
+        $translations = [];
+        foreach ($source->getTranslations() as $translation) {
+            if (!$translation instanceof EverBlockTranslation) {
+                continue;
+            }
+            $translations[$translation->getLanguageId()] = [
+                'content' => $translation->getContent(),
+                'custom_code' => $translation->getCustomCode(),
+            ];
+        }
+
+        $duplicate = $this->repository->save($duplicate, $translations);
+
+        $this->registerHook($duplicate->getHookId());
+        $this->clearCacheIfNeeded();
+
+        return $duplicate;
+    }
+
+    public function delete(int $blockId, int $shopId): void
+    {
+        $this->repository->delete($blockId, $shopId);
+        $this->clearCacheIfNeeded();
+    }
+
+    public function toggle(int $blockId, int $shopId): void
+    {
+        $block = $this->repository->findById($blockId, $shopId);
+        if (!$block instanceof EverBlock) {
+            throw new \RuntimeException(sprintf('EverBlock %d not found for shop %d.', $blockId, $shopId));
+        }
+
+        $block->setActive(!$block->isActive());
+
+        $translations = [];
+        foreach ($block->getTranslations() as $translation) {
+            if (!$translation instanceof EverBlockTranslation) {
+                continue;
+            }
+            $translations[$translation->getLanguageId()] = [
+                'content' => $translation->getContent(),
+                'custom_code' => $translation->getCustomCode(),
+            ];
+        }
+
+        $this->repository->save($block, $translations);
+        $this->clearCacheIfNeeded();
+    }
+
+    private function hydrateBlockFromCommand(UpsertEverBlockCommand $command): EverBlock
+    {
+        $block = null;
+        if (null !== $command->getId()) {
+            $block = $this->repository->findById($command->getId(), $command->getShopId());
+        }
+
+        if (!$block instanceof EverBlock) {
+            $block = new EverBlock();
+            $block->setShopId($command->getShopId());
+            $block->setPosition(
+                $command->getPosition() ?? $this->repository->getNextPosition($command->getHookId(), $command->getShopId())
+            );
+        } else {
+            $block->setPosition(
+                $command->getPosition() ?? $block->getPosition()
+            );
+        }
+
+        $block->setName($command->getName());
+        $block->setHookId($command->getHookId());
+        $block->setOnlyHome($command->onlyHome());
+        $block->setOnlyCategory($command->onlyCategory());
+        $block->setOnlyCategoryProduct($command->onlyCategoryProduct());
+        $block->setOnlyManufacturer($command->onlyManufacturer());
+        $block->setOnlySupplier($command->onlySupplier());
+        $block->setOnlyCmsCategory($command->onlyCmsCategory());
+        $block->setObfuscateLink($command->shouldObfuscateLink());
+        $block->setAddContainer($command->shouldAddContainer());
+        $block->setLazyload($command->shouldLazyload());
+        $block->setGroups($this->encodeArray($command->getGroups()));
+        $block->setCategories($this->encodeArray($command->getCategories()));
+        $block->setManufacturers($this->encodeArray($command->getManufacturers()));
+        $block->setSuppliers($this->encodeArray($command->getSuppliers()));
+        $block->setCmsCategories($this->encodeArray($command->getCmsCategories()));
+        $block->setBackground($command->getBackground() !== '' ? $command->getBackground() : null);
+        $block->setCssClass($command->getCssClass() !== '' ? $command->getCssClass() : null);
+        $block->setDataAttribute($command->getDataAttribute() !== '' ? $command->getDataAttribute() : null);
+        $block->setBootstrapClass($command->getBootstrapClass() !== '' ? $command->getBootstrapClass() : null);
+        $block->setDevice($command->getDevice());
+        $block->setDelay($command->getDelay() ?? 0);
+        $block->setTimeout($command->getTimeout() ?? 0);
+        $block->setModal($command->isModal());
+        $block->setDateStart($command->getDateStart());
+        $block->setDateEnd($command->getDateEnd());
+        $block->setActive($command->isActive());
+
+        return $block;
+    }
+
+    /**
+     * @param array<int, EverBlockTranslationCommand> $translations
+     *
+     * @return array<int, array<string, string|null>>
+     */
+    private function buildTranslationsPayload(array $translations): array
+    {
+        $payload = [];
+        foreach ($translations as $translationCommand) {
+            if (!$translationCommand instanceof EverBlockTranslationCommand) {
+                continue;
+            }
+
+            $content = EverblockTools::convertImagesToWebP($translationCommand->getContent());
+            $payload[$translationCommand->getLanguageId()] = [
+                'content' => $content,
+                'custom_code' => $translationCommand->getCustomCode(),
+            ];
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<int> $values
+     */
+    private function encodeArray(array $values): ?string
+    {
+        $filtered = array_values(array_filter($values, static fn ($value) => $value !== null));
+        if (empty($filtered)) {
+            return null;
+        }
+
+        return json_encode($filtered, JSON_THROW_ON_ERROR);
+    }
+
+    private function registerHook(int $hookId): void
+    {
+        $hookName = Hook::getNameById($hookId);
+        $module = Module::getInstanceByName('everblock');
+
+        if ($module && $hookName) {
+            $module->registerHook($hookName);
+        }
+    }
+
+    private function clearCacheIfNeeded(): void
+    {
+        if (Configuration::get('EVERPSCSS_CACHE')) {
+            Tools::clearAllCache();
+        }
+    }
+}

--- a/src/Repository/EverBlockRepository.php
+++ b/src/Repository/EverBlockRepository.php
@@ -188,6 +188,21 @@ class EverBlockRepository
         $this->clearCache();
     }
 
+    public function getNextPosition(int $hookId, int $shopId): int
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('MAX(position)')
+            ->from($this->getTableName('everblock'))
+            ->where('id_hook = :id_hook')
+            ->andWhere('id_shop = :id_shop')
+            ->setParameter('id_hook', $hookId, ParameterType::INTEGER)
+            ->setParameter('id_shop', $shopId, ParameterType::INTEGER);
+
+        $currentMax = (int) $qb->executeQuery()->fetchOne();
+
+        return $currentMax + 1;
+    }
+
     private function resolveBootstrapClass(int $colNumber): string
     {
         $class = 'col-';

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -21,7 +21,6 @@
 namespace Everblock\Tools\Service;
 
 use Configuration;
-use EverBlockClass;
 use Everblock\Tools\Service\EverblockCache;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use EverblockShortcode;

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -7,4 +7,11 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'EverBlockClass' => $baseDir . '/models/EverblockClass.php',
+    'EverblockFaq' => $baseDir . '/models/EverblockFaq.php',
+    'EverblockFlagsClass' => $baseDir . '/models/EverblockFlagsClass.php',
+    'EverblockModal' => $baseDir . '/models/EverblockModal.php',
+    'EverblockShortcode' => $baseDir . '/models/EverblockShortcode.php',
+    'EverblockTabsClass' => $baseDir . '/models/EverblockTabsClass.php',
+    'EverblockTools' => $baseDir . '/models/EverblockTools.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -27,6 +27,13 @@ class ComposerStaticInitc44e5ac729cb9f81a689ee15bff0603d
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'EverBlockClass' => __DIR__ . '/../..' . '/models/EverblockClass.php',
+        'EverblockFaq' => __DIR__ . '/../..' . '/models/EverblockFaq.php',
+        'EverblockFlagsClass' => __DIR__ . '/../..' . '/models/EverblockFlagsClass.php',
+        'EverblockModal' => __DIR__ . '/../..' . '/models/EverblockModal.php',
+        'EverblockShortcode' => __DIR__ . '/../..' . '/models/EverblockShortcode.php',
+        'EverblockTabsClass' => __DIR__ . '/../..' . '/models/EverblockTabsClass.php',
+        'EverblockTools' => __DIR__ . '/../..' . '/models/EverblockTools.php',
     );
 
     public static function getInitializer(ClassLoader $loader)


### PR DESCRIPTION
## Summary
- add an application service and DTO commands to centralize Everblock CRUD through the Doctrine repository
- rework admin forms, controllers, and console tooling to rely on the new service instead of legacy ObjectModel classes
- update the front modal controller, module helpers, and autoload configuration to fetch blocks via the repository and drop manual requires

## Testing
- composer dump-autoload
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68f39c10d8588322b5e0fb8228700f3d