### PR TITLE
Refactor service wiring to avoid direct container lookups

### DIFF
--- a/controllers/front/modal.php
+++ b/controllers/front/modal.php
@@ -25,10 +25,17 @@ if (!defined('_PS_VERSION_')) {
 use Everblock\Tools\Entity\EverBlock;
 use Everblock\Tools\Entity\EverBlockTranslation;
 use Everblock\Tools\Repository\EverBlockRepository;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 class EverblockmodalModuleFrontController extends ModuleFrontController
 {
+    private ?EverBlockRepository $blockRepository;
+
+    public function __construct(?EverBlockRepository $blockRepository = null)
+    {
+        $this->blockRepository = $blockRepository;
+        parent::__construct();
+    }
+
     public function init()
     {
         parent::init();
@@ -189,17 +196,14 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
 
     private function getBlockRepository(): ?EverBlockRepository
     {
-        if (!class_exists(SymfonyContainer::class)) {
-            return null;
+        if ($this->blockRepository instanceof EverBlockRepository) {
+            return $this->blockRepository;
         }
 
-        $container = SymfonyContainer::getInstance();
-        if (null === $container || !$container->has(EverBlockRepository::class)) {
-            return null;
+        if ($this->module instanceof Everblock) {
+            $this->blockRepository = $this->module->getEverBlockRepository();
         }
 
-        $service = $container->get(EverBlockRepository::class);
-
-        return $service instanceof EverBlockRepository ? $service : null;
+        return $this->blockRepository instanceof EverBlockRepository ? $this->blockRepository : null;
     }
 }

--- a/models/EverblockClass.php
+++ b/models/EverblockClass.php
@@ -19,7 +19,6 @@
  */
 use DateTime;
 use Everblock\Tools\Service\EverBlockProvider;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use RuntimeException;
 
 if (!defined('_PS_VERSION_')) {
@@ -264,18 +263,6 @@ class EverBlockClass extends ObjectModel
         static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockProvider) {
             return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockProvider::class)) {
-                $provider = $container->get(EverBlockProvider::class);
-                if ($provider instanceof EverBlockProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
         }
 
         throw new RuntimeException('EverBlockProvider service is not available.');

--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -18,7 +18,6 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 use Everblock\Tools\Service\EverBlockFaqProvider;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -113,18 +112,6 @@ class EverblockFaq extends ObjectModel
         static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockFaqProvider) {
             return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockFaqProvider::class)) {
-                $provider = $container->get(EverBlockFaqProvider::class);
-                if ($provider instanceof EverBlockFaqProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
         }
 
         throw new \RuntimeException('EverBlockFaqProvider service is not available.');

--- a/models/EverblockFlagsClass.php
+++ b/models/EverblockFlagsClass.php
@@ -19,7 +19,6 @@
  */
 use Everblock\Tools\Service\EverBlockFlagProvider;
 use Everblock\Tools\Service\EverblockCache;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -88,18 +87,6 @@ class EverblockFlagsClass extends ObjectModel
         static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockFlagProvider) {
             return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockFlagProvider::class)) {
-                $provider = $container->get(EverBlockFlagProvider::class);
-                if ($provider instanceof EverBlockFlagProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
         }
 
         return null;

--- a/models/EverblockModal.php
+++ b/models/EverblockModal.php
@@ -18,7 +18,6 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 use Everblock\Tools\Service\EverBlockModalProvider;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -83,33 +82,24 @@ class EverblockModal extends ObjectModel
         static::$provider = $provider;
     }
 
-    protected static function getProvider(): EverBlockModalProvider
+    protected static function getProvider(?EverBlockModalProvider $provider = null): EverBlockModalProvider
     {
         static::triggerLegacyDeprecation(__METHOD__);
+        if ($provider instanceof EverBlockModalProvider) {
+            return $provider;
+        }
+
         if (static::$provider instanceof EverBlockModalProvider) {
             return static::$provider;
         }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockModalProvider::class)) {
-                $provider = $container->get(EverBlockModalProvider::class);
-                if ($provider instanceof EverBlockModalProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
-        }
-
         throw new \RuntimeException('EverBlockModalProvider service is not available.');
     }
 
-    public static function getByProductId(int $idProduct, int $idShop)
+    public static function getByProductId(int $idProduct, int $idShop, ?EverBlockModalProvider $provider = null)
     {
         static::triggerLegacyDeprecation(__METHOD__);
-        $provider = static::getProvider();
-        $modalId = $provider->findModalIdByProduct($idProduct, $idShop);
+        $resolvedProvider = static::getProvider($provider);
+        $modalId = $resolvedProvider->findModalIdByProduct($idProduct, $idShop);
         if (null !== $modalId) {
             return new self($modalId, null, $idShop);
         }

--- a/models/EverblockShortcode.php
+++ b/models/EverblockShortcode.php
@@ -18,7 +18,6 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 use Everblock\Tools\Service\EverBlockShortcodeProvider;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -84,18 +83,6 @@ class EverblockShortcode extends ObjectModel
         static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockShortcodeProvider) {
             return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockShortcodeProvider::class)) {
-                $provider = $container->get(EverBlockShortcodeProvider::class);
-                if ($provider instanceof EverBlockShortcodeProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
         }
 
         throw new \RuntimeException('EverBlockShortcodeProvider service is not available.');

--- a/models/EverblockTabsClass.php
+++ b/models/EverblockTabsClass.php
@@ -18,7 +18,6 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 use Everblock\Tools\Service\EverBlockTabProvider;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -87,18 +86,6 @@ class EverblockTabsClass extends ObjectModel
         static::triggerLegacyDeprecation(__METHOD__);
         if (static::$provider instanceof EverBlockTabProvider) {
             return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockTabProvider::class)) {
-                $provider = $container->get(EverBlockTabProvider::class);
-                if ($provider instanceof EverBlockTabProvider) {
-                    static::$provider = $provider;
-
-                    return $provider;
-                }
-            }
         }
 
         return null;

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -19,7 +19,6 @@
  */
 use Everblock\Tools\Service\EverBlockFaqProvider;
 use Everblock\Tools\Service\EverblockCache;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -955,18 +954,14 @@ class EverblockTools extends ObjectModel
         $templatePath = static::getTemplatePath('hook/faq.tpl', $module);
         $pattern = '/\[everfaq tag="([^"]+)"\]/';
 
-        $txt = preg_replace_callback($pattern, function ($matches) use ($context, $templatePath) {
+        $faqProvider = $module->getEverBlockFaqProvider();
+
+        $txt = preg_replace_callback($pattern, function ($matches) use ($context, $templatePath, $faqProvider) {
             $tagName = $matches[1];
 
             $faqs = [];
-            if (class_exists(SymfonyContainer::class)) {
-                $container = SymfonyContainer::getInstance();
-                if (null !== $container && $container->has(EverBlockFaqProvider::class)) {
-                    $provider = $container->get(EverBlockFaqProvider::class);
-                    if ($provider instanceof EverBlockFaqProvider) {
-                        $faqs = $provider->getFaqByTagName($context->shop->id, $context->language->id, $tagName);
-                    }
-                }
+            if ($faqProvider instanceof EverBlockFaqProvider) {
+                $faqs = $faqProvider->getFaqByTagName($context->shop->id, $context->language->id, $tagName);
             }
 
             $context->smarty->assign('everFaqs', $faqs);

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -22,7 +22,6 @@ namespace Everblock\Tools\Service;
 
 use Configuration;
 use Everblock\Tools\Service\EverblockCache;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use EverblockShortcode;
 use EverblockTools;
 use Hook;
@@ -55,44 +54,12 @@ class EverblockPrettyBlocks
 
     private static function resolveProvider(): ?EverBlockProvider
     {
-        if (static::$provider instanceof EverBlockProvider) {
-            return static::$provider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockProvider::class)) {
-                $resolved = $container->get(EverBlockProvider::class);
-                if ($resolved instanceof EverBlockProvider) {
-                    static::$provider = $resolved;
-
-                    return $resolved;
-                }
-            }
-        }
-
-        return null;
+        return static::$provider;
     }
 
     private static function resolveShortcodeProvider(): ?EverBlockShortcodeProvider
     {
-        if (static::$shortcodeProvider instanceof EverBlockShortcodeProvider) {
-            return static::$shortcodeProvider;
-        }
-
-        if (class_exists(SymfonyContainer::class)) {
-            $container = SymfonyContainer::getInstance();
-            if (null !== $container && $container->has(EverBlockShortcodeProvider::class)) {
-                $resolved = $container->get(EverBlockShortcodeProvider::class);
-                if ($resolved instanceof EverBlockShortcodeProvider) {
-                    static::$shortcodeProvider = $resolved;
-
-                    return $resolved;
-                }
-            }
-        }
-
-        return null;
+        return static::$shortcodeProvider;
     }
 
     public function registerBlockToZone($zone_name, $code, $id_lang, $id_shop)


### PR DESCRIPTION
## Summary
- bootstrap module dependencies via the PrestaShop container and expose public getters for consumers
- require explicit modal provider usage and remove SymfonyContainer fallbacks across legacy models and utilities
- inject the block repository into the modal front controller and rely on the module for shared services

## Testing
- `php -l controllers/front/modal.php`
- `php -l models/EverblockModal.php`
- `php -l models/EverblockClass.php`
- `php -l models/EverblockShortcode.php`
- `php -l models/EverblockTabsClass.php`
- `php -l models/EverblockFlagsClass.php`
- `php -l models/EverblockFaq.php`
- `php -l models/EverblockTools.php`
- `php -l src/Service/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68f39f55cbec83229b4498e657b43f42