### PR TITLE
Refactor shortcode management to domain service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
       "models/EverblockFaq.php",
       "models/EverblockFlagsClass.php",
       "models/EverblockModal.php",
-      "models/EverblockShortcode.php",
       "models/EverblockTabsClass.php",
       "models/EverblockTools.php"
     ],

--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -108,7 +108,6 @@ return [
     'src/Controller/Admin/ShortcodesController.php',
     'src/Service/Admin/NavigationBuilder.php',
     'src/Service/Admin/StatisticsProvider.php',
-    'models/EverblockShortcode.php',
     'models/EverblockTabsClass.php',
     'models/EverblockTools.php',
     'models/index.php',

--- a/config/services.yml
+++ b/config/services.yml
@@ -105,7 +105,7 @@ services:
     Everblock\Tools\Form\DataProvider\ShortcodeFormDataProvider:
         arguments:
             $context: '@prestashop.adapter.legacy.context'
-            $shortcodeProvider: '@Everblock\\Tools\\Service\\EverBlockShortcodeProvider'
+            $shortcodeService: '@Everblock\\Tools\\Service\\Domain\\EverBlockShortcodeDomainService'
     Everblock\Tools\Form\DataProvider\FaqFormDataProvider:
         arguments:
             $context: '@prestashop.adapter.legacy.context'
@@ -162,6 +162,7 @@ services:
     Everblock\Tools\Service\Domain\EverBlockFlagDomainService: ~
     Everblock\Tools\Service\Domain\EverBlockTabDomainService: ~
     Everblock\Tools\Service\Domain\EverBlockModalDomainService: ~
+    Everblock\Tools\Service\Domain\EverBlockShortcodeDomainService: ~
 
     Everblock\Tools\Service\EverBlockProvider: ~
     Everblock\Tools\Service\EverBlockFaqProvider: ~

--- a/everblock.php
+++ b/everblock.php
@@ -29,12 +29,14 @@ use Everblock\Tools\Application\Command\EverBlock\UpsertEverBlockCommand;
 use Everblock\Tools\Application\EverBlockApplicationService;
 use Everblock\Tools\Checkout\EverblockCheckoutStep;
 use Everblock\Tools\Service\Domain\EverBlockDomainService;
+use Everblock\Tools\Service\Domain\EverBlockShortcodeDomainService;
 use Everblock\Tools\Service\EverBlockFaqProvider;
 use Everblock\Tools\Entity\EverBlock;
 use Everblock\Tools\Entity\EverBlockTranslation;
 use Everblock\Tools\Repository\EverBlockRepository;
 use Everblock\Tools\Service\EverBlockFlagProvider;
 use Everblock\Tools\Service\EverBlockProvider;
+use Everblock\Tools\Service\EverBlockShortcodeProvider;
 use Everblock\Tools\Service\EverBlockTabProvider;
 use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockCache;
@@ -73,6 +75,8 @@ class Everblock extends Module
     private ?EverBlockTabProvider $everBlockTabProvider = null;
     private ?EverBlockRepository $everBlockRepository = null;
     private ?EverBlockModalProvider $everBlockModalProvider = null;
+    private ?EverBlockShortcodeProvider $everBlockShortcodeProvider = null;
+    private ?EverBlockShortcodeDomainService $everBlockShortcodeDomainService = null;
     private bool $dependenciesBootstrapped = false;
 
     public function __construct(
@@ -83,7 +87,9 @@ class Everblock extends Module
         ?EverBlockFlagProvider $everBlockFlagProvider = null,
         ?EverBlockTabProvider $everBlockTabProvider = null,
         ?EverBlockRepository $everBlockRepository = null,
-        ?EverBlockModalProvider $everBlockModalProvider = null
+        ?EverBlockModalProvider $everBlockModalProvider = null,
+        ?EverBlockShortcodeProvider $everBlockShortcodeProvider = null,
+        ?EverBlockShortcodeDomainService $everBlockShortcodeDomainService = null
     ) {
         $this->name = 'everblock';
         $this->tab = 'front_office_features';
@@ -99,6 +105,8 @@ class Everblock extends Module
         $this->everBlockTabProvider = $everBlockTabProvider;
         $this->everBlockRepository = $everBlockRepository;
         $this->everBlockModalProvider = $everBlockModalProvider;
+        $this->everBlockShortcodeProvider = $everBlockShortcodeProvider;
+        $this->everBlockShortcodeDomainService = $everBlockShortcodeDomainService;
         parent::__construct();
         $this->displayName = $this->l('Ever Block');
         $this->description = $this->l('Add HTML block everywhere !');
@@ -107,6 +115,10 @@ class Everblock extends Module
             'min' => '1.7',
             'max' => _PS_VERSION_,
         ];
+        if ($this->everBlockShortcodeProvider instanceof EverBlockShortcodeProvider) {
+            EverblockPrettyBlocks::setShortcodeProvider($this->everBlockShortcodeProvider);
+            EverblockTools::setShortcodeProvider($this->everBlockShortcodeProvider);
+        }
         $this->bootstrapDependencies();
     }
 
@@ -150,6 +162,19 @@ class Everblock extends Module
             if (null === $this->everBlockModalProvider) {
                 $this->everBlockModalProvider = $this->resolveService($container, EverBlockModalProvider::class);
             }
+
+            if (null === $this->everBlockShortcodeProvider) {
+                $this->everBlockShortcodeProvider = $this->resolveService($container, EverBlockShortcodeProvider::class);
+            }
+
+            if (null === $this->everBlockShortcodeDomainService) {
+                $this->everBlockShortcodeDomainService = $this->resolveService($container, EverBlockShortcodeDomainService::class);
+            }
+        }
+
+        if ($this->everBlockShortcodeProvider instanceof EverBlockShortcodeProvider) {
+            EverblockPrettyBlocks::setShortcodeProvider($this->everBlockShortcodeProvider);
+            EverblockTools::setShortcodeProvider($this->everBlockShortcodeProvider);
         }
 
         $this->dependenciesBootstrapped = true;
@@ -217,6 +242,24 @@ class Everblock extends Module
         $this->bootstrapDependencies();
 
         return $this->everBlockFaqProvider;
+    }
+
+    public function getEverBlockShortcodeProvider(): ?EverBlockShortcodeProvider
+    {
+        $this->bootstrapDependencies();
+
+        return $this->everBlockShortcodeProvider;
+    }
+
+    public function getEverBlockShortcodeDomainService(): EverBlockShortcodeDomainService
+    {
+        $this->bootstrapDependencies();
+
+        if (!$this->everBlockShortcodeDomainService instanceof EverBlockShortcodeDomainService) {
+            throw new \RuntimeException('EverBlockShortcodeDomainService service is not available.');
+        }
+
+        return $this->everBlockShortcodeDomainService;
     }
 
     public function getEverBlockRepository(): ?EverBlockRepository

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -20,6 +20,7 @@
 use Everblock\Tools\Entity\EverBlock;
 use Everblock\Tools\Entity\EverBlockTranslation;
 use Everblock\Tools\Service\EverBlockFaqProvider;
+use Everblock\Tools\Service\EverBlockShortcodeProvider;
 use Everblock\Tools\Service\EverblockCache;
 
 if (!defined('_PS_VERSION_')) {
@@ -33,6 +34,13 @@ use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 
 class EverblockTools extends ObjectModel
 {
+    private static ?EverBlockShortcodeProvider $shortcodeProvider = null;
+
+    public static function setShortcodeProvider(EverBlockShortcodeProvider $provider): void
+    {
+        static::$shortcodeProvider = $provider;
+    }
+
     public static function renderShortcodes(string $txt, Context $context, Everblock $module): string
     {
         Hook::exec('displayBeforeRenderingShortcodes', ['html' => &$txt]);
@@ -4335,11 +4343,13 @@ class EverblockTools extends ObjectModel
 
     public static function getEverShortcodes(string $txt, Context $context): string
     {
-        $customShortcodes = EverblockShortcode::getAllShortcodes(
-            $context->shop->id,
-            $context->language->id
-        );
-        $returnedShortcodes = [];
+        $customShortcodes = [];
+        if (static::$shortcodeProvider instanceof EverBlockShortcodeProvider) {
+            $customShortcodes = static::$shortcodeProvider->getAllShortcodes(
+                (int) $context->shop->id,
+                (int) $context->language->id
+            );
+        }
         foreach ($customShortcodes as $sc) {
             $txt = str_replace($sc->shortcode, $sc->content, $txt);
         }

--- a/src/Form/DataProvider/ShortcodeFormDataProvider.php
+++ b/src/Form/DataProvider/ShortcodeFormDataProvider.php
@@ -21,7 +21,7 @@
 namespace Everblock\Tools\Form\DataProvider;
 
 use Context;
-use Everblock\Tools\Service\EverBlockShortcodeProvider;
+use Everblock\Tools\Service\Domain\EverBlockShortcodeDomainService;
 use Language;
 
 if (!defined('_PS_VERSION_') && php_sapi_name() !== 'cli') {
@@ -37,7 +37,7 @@ class ShortcodeFormDataProvider
 
     public function __construct(
         Context $context,
-        private readonly EverBlockShortcodeProvider $shortcodeProvider
+        private readonly EverBlockShortcodeDomainService $shortcodeService
     ) {
         $this->context = $context;
     }
@@ -73,7 +73,7 @@ class ShortcodeFormDataProvider
         $default = $this->getDefaultData();
 
         try {
-            $shortcode = $this->shortcodeProvider->getShortcodeForForm(
+            $shortcode = $this->shortcodeService->getShortcodeForForm(
                 $shortcodeId,
                 (int) $this->context->shop->id
             );

--- a/src/Service/Domain/EverBlockShortcodeDomainService.php
+++ b/src/Service/Domain/EverBlockShortcodeDomainService.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service\Domain;
+
+use Everblock\Tools\Service\EverBlockShortcodeProvider;
+
+class EverBlockShortcodeDomainService
+{
+    public function __construct(private readonly EverBlockShortcodeProvider $provider)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getShortcodeForForm(int $shortcodeId, int $shopId): array
+    {
+        return $this->provider->getShortcodeForForm($shortcodeId, $shopId);
+    }
+
+    /**
+     * @param array<int, array{title: string, content: string}> $translations
+     */
+    public function save(?int $shortcodeId, int $shopId, string $shortcode, array $translations): int
+    {
+        if (null === $shortcodeId) {
+            return $this->provider->createShortcode($shortcode, $shopId, $translations);
+        }
+
+        $this->provider->updateShortcode($shortcodeId, $shortcode, $shopId, $translations);
+
+        return $shortcodeId;
+    }
+
+    public function delete(int $shortcodeId, int $shopId): void
+    {
+        $this->provider->deleteShortcode($shortcodeId, $shopId);
+    }
+
+    /**
+     * @param array<int, int|string> $ids
+     */
+    public function bulkDelete(array $ids, int $shopId): int
+    {
+        $deleted = 0;
+
+        foreach ($ids as $id) {
+            try {
+                $this->delete((int) $id, $shopId);
+                ++$deleted;
+            } catch (\RuntimeException) {
+                continue;
+            }
+        }
+
+        return $deleted;
+    }
+
+    public function duplicate(int $shortcodeId, int $shopId, string $newShortcode): int
+    {
+        return $this->provider->duplicateShortcode($shortcodeId, $shopId, $newShortcode);
+    }
+}

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -22,7 +22,6 @@ namespace Everblock\Tools\Service;
 
 use Configuration;
 use Everblock\Tools\Service\EverblockCache;
-use EverblockShortcode;
 use EverblockTools;
 use Hook;
 use Module;
@@ -226,10 +225,7 @@ class EverblockPrettyBlocks
                     (int) $context->language->id
                 );
             } else {
-                $allShortcodes = EverblockShortcode::getAllShortcodes(
-                    (int) $context->shop->id,
-                    (int) $context->language->id
-                );
+                $allShortcodes = [];
             }
             $provider = $provider ?? static::resolveProvider();
             $everblocks = [];

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -7,11 +7,9 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
-    'EverBlockClass' => $baseDir . '/models/EverblockClass.php',
     'EverblockFaq' => $baseDir . '/models/EverblockFaq.php',
     'EverblockFlagsClass' => $baseDir . '/models/EverblockFlagsClass.php',
     'EverblockModal' => $baseDir . '/models/EverblockModal.php',
-    'EverblockShortcode' => $baseDir . '/models/EverblockShortcode.php',
     'EverblockTabsClass' => $baseDir . '/models/EverblockTabsClass.php',
     'EverblockTools' => $baseDir . '/models/EverblockTools.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -27,11 +27,9 @@ class ComposerStaticInitc44e5ac729cb9f81a689ee15bff0603d
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
-        'EverBlockClass' => __DIR__ . '/../..' . '/models/EverblockClass.php',
         'EverblockFaq' => __DIR__ . '/../..' . '/models/EverblockFaq.php',
         'EverblockFlagsClass' => __DIR__ . '/../..' . '/models/EverblockFlagsClass.php',
         'EverblockModal' => __DIR__ . '/../..' . '/models/EverblockModal.php',
-        'EverblockShortcode' => __DIR__ . '/../..' . '/models/EverblockShortcode.php',
         'EverblockTabsClass' => __DIR__ . '/../..' . '/models/EverblockTabsClass.php',
         'EverblockTools' => __DIR__ . '/../..' . '/models/EverblockTools.php',
     );


### PR DESCRIPTION
## Summary
- extend the shortcode repository/provider with create, update, delete, and duplication helpers and introduce an EverBlockShortcodeDomainService for orchestration
- refactor the back-office controller, form data provider, tools, and PrettyBlocks integration to rely on the injected domain service/provider instead of the legacy ObjectModel
- wire the new services through the module container, drop the legacy model from autoload/config, and add repository tests for the new write operations

## Testing
- `php -l src/Repository/EverBlockShortcodeRepository.php`
- `php -l src/Service/EverBlockShortcodeProvider.php`
- `php -l src/Controller/Admin/EverblockShortcodeController.php`
- `php -l src/Service/EverblockPrettyBlocks.php`


------
https://chatgpt.com/codex/tasks/task_e_68f3a7580f248322aa6861fdc57d8df4