### PR TITLE
Refactor shortcode rendering into dedicated service

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -195,3 +195,440 @@ services:
             $translator: '@translator'
             $navigationBuilder: '@Everblock\\Tools\\Service\\Admin\\NavigationBuilder'
         tags: ['controller.service_arguments']
+
+    Everblock\Tools\Shortcode\ShortcodeRenderer:
+        public: true
+        arguments:
+            $handlers: !tagged_iterator everblock.shortcode_handler
+
+    Everblock\Tools\Shortcode\Handler\FaqShortcodeHandler:
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.alert:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[alert'
+            $callback: ['EverblockTools', 'getAlertShortcode']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.instagram:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everinstagram]'
+            $callback: ['EverblockTools', 'getInstagramShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.product:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[product'
+            $callback: ['EverblockTools', 'getProductShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.product_image:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[product_image'
+            $callback: ['EverblockTools', 'getProductImageShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.product_feature:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[productfeature'
+            $callback: ['EverblockTools', 'getFeatureProductShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.product_feature_value:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[productfeaturevalue'
+            $callback: ['EverblockTools', 'getFeatureValueProductShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.category:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[category'
+            $callback: ['EverblockTools', 'getCategoryShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.manufacturer:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[manufacturer'
+            $callback: ['EverblockTools', 'getManufacturerShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.brands:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[brands'
+            $callback: ['EverblockTools', 'getBrandsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.storelocator:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[storelocator]'
+            $callback: ['EverblockTools', 'generateGoogleMap']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.evermap:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[evermap]'
+            $callback: ['EverblockTools', 'getEverMapShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.hook:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '{hook h='
+            $callback: ['EverblockTools', 'replaceHook']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.lorem:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[llorem]'
+            $callback: ['EverblockTools', 'generateLoremIpsum']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.everblock:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everblock'
+            $callback: ['EverblockTools', 'getEverBlockShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.subcategories:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[subcategories'
+            $callback: ['EverblockTools', 'getSubcategoriesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.everstore:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everstore'
+            $callback: ['EverblockTools', 'getStoreShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.video:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[video'
+            $callback: ['EverblockTools', 'getVideoShortcode']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.qcdacf:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[qcdacf'
+            $callback: ['EverblockTools', 'getQcdAcfCode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.qcdsvg:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[displayQcdSvg'
+            $callback: ['EverblockTools', 'getQcdSvgCode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.everimg:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everimg'
+            $callback: ['EverblockTools', 'getEverImgShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.wordpress:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[wordpress-posts]'
+            $callback: ['EverblockTools', 'getWordpressPostsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.google_reviews:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[googlereviews'
+            $callback: ['EverblockTools', 'getGoogleReviewsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.best_sales:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[best-sales'
+            $callback: ['EverblockTools', 'getBestSalesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.category_best_sales:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[categorybestsales'
+            $callback: ['EverblockTools', 'getCategoryBestSalesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.brand_best_sales:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[brandbestsales'
+            $callback: ['EverblockTools', 'getBrandBestSalesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.feature_best_sales:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[featurebestsales'
+            $callback: ['EverblockTools', 'getFeatureBestSalesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.feature_value_best_sales:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[featurevaluebestsales'
+            $callback: ['EverblockTools', 'getFeatureValueBestSalesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.last_products:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[last-products'
+            $callback: ['EverblockTools', 'getLastProductsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.recently_viewed:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[recently_viewed'
+            $callback: ['EverblockTools', 'getRecentlyViewedShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.promo_products:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[promo-products'
+            $callback: ['EverblockTools', 'getPromoProductsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.products_by_tag:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[products_by_tag'
+            $callback: ['EverblockTools', 'getProductsByTagShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.low_stock:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[low_stock'
+            $callback: ['EverblockTools', 'getLowStockShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.cart:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[evercart]'
+            $callback: ['EverblockTools', 'getCartShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.cart_total:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[cart_total]'
+            $callback: ['EverblockTools', 'getCartTotalShortcode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.cart_quantity:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[cart_quantity]'
+            $callback: ['EverblockTools', 'getCartQuantityShortcode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.shop_logo:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[shop_logo]'
+            $callback: ['EverblockTools', 'getShopLogoShortcode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.newsletter:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[newsletter_form]'
+            $callback: ['EverblockTools', 'getNewsletterFormShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.native_contact:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[nativecontact]'
+            $callback: ['EverblockTools', 'getNativeContactShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.form:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[evercontactform_open]'
+            $callback: ['EverblockTools', 'getFormShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.order_form:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everorderform_open]'
+            $callback: ['EverblockTools', 'getOrderFormShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.random_product:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[random_product'
+            $callback: ['EverblockTools', 'getRandomProductsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.accessories:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[accessories'
+            $callback: ['EverblockTools', 'getAccessoriesShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.linked_products:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[linkedproducts'
+            $callback: ['EverblockTools', 'getLinkedProductsShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.crosselling:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[crosselling'
+            $callback: ['EverblockTools', 'getCrossSellingShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.widget:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[widget'
+            $callback: ['EverblockTools', 'getWidgetShortcode']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.prettyblocks:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[prettyblocks'
+            $callback: ['EverblockTools', 'getPrettyblocksShortcodes']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.add_to_cart:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[everaddtocart'
+            $callback: ['EverblockTools', 'getAddToCartShortcode']
+            $argumentMap: ['context', 'module']
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    everblock.shortcode_handler.cms:
+        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        arguments:
+            $needle: '[cms'
+            $callback: ['EverblockTools', 'getCmsShortcode']
+            $argumentMap: ['context']
+        tags:
+            - { name: 'everblock.shortcode_handler' }

--- a/controllers/front/modal.php
+++ b/controllers/front/modal.php
@@ -224,11 +224,13 @@ class EverblockmodalModuleFrontController extends ModuleFrontController
             $fileRenderType = $this->resolveFileRenderType($fileExtension);
         }
 
-        $renderedContent = EverblockTools::renderShortcodes(
-            $content,
-            $this->context,
-            $this->module
-        );
+        $renderer = $this->module instanceof Everblock
+            ? $this->module->getShortcodeRenderer()
+            : null;
+
+        $renderedContent = $renderer instanceof \Everblock\Tools\Shortcode\ShortcodeRenderer
+            ? $renderer->render($content, $this->context, $this->module)
+            : EverblockTools::renderShortcodes($content, $this->context, $this->module);
 
         return new ModalDto(
             $renderedContent,

--- a/src/Shortcode/Handler/CallbackShortcodeHandler.php
+++ b/src/Shortcode/Handler/CallbackShortcodeHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Everblock\Tools\Shortcode\Handler;
+
+use Context;
+use Everblock;
+use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+
+final class CallbackShortcodeHandler implements ShortcodeHandlerInterface
+{
+    /**
+     * @param callable(string, mixed ...$args): string $callback
+     * @param array<int, string> $argumentMap
+     */
+    public function __construct(
+        private readonly string $needle,
+        private $callback,
+        private readonly array $argumentMap = []
+    ) {
+    }
+
+    public function supports(string $content): bool
+    {
+        return str_contains($content, $this->needle);
+    }
+
+    public function render(string $content, Context $context, Everblock $module): string
+    {
+        $arguments = [];
+
+        foreach ($this->argumentMap as $argument) {
+            switch ($argument) {
+                case 'context':
+                    $arguments[] = $context;
+
+                    break;
+                case 'module':
+                    $arguments[] = $module;
+
+                    break;
+            }
+        }
+
+        $result = ($this->callback)($content, ...$arguments);
+
+        return is_string($result) ? $result : (string) $result;
+    }
+}

--- a/src/Shortcode/Handler/FaqShortcodeHandler.php
+++ b/src/Shortcode/Handler/FaqShortcodeHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Everblock\Tools\Shortcode\Handler;
+
+use Context;
+use Everblock;
+use EverblockTools;
+use Everblock\Tools\Service\EverBlockFaqProvider;
+use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+
+final class FaqShortcodeHandler implements ShortcodeHandlerInterface
+{
+    public function __construct(private readonly EverBlockFaqProvider $faqProvider)
+    {
+    }
+
+    public function supports(string $content): bool
+    {
+        return str_contains($content, '[everfaq');
+    }
+
+    public function render(string $content, Context $context, Everblock $module): string
+    {
+        $templatePath = EverblockTools::getTemplatePath('hook/faq.tpl', $module);
+
+        return (string) preg_replace_callback(
+            '/\\[everfaq tag="([^"]+)"\\]/',
+            function (array $matches) use ($context, $templatePath) {
+                $tagName = $matches[1];
+
+                $faqs = $this->faqProvider->getFaqByTagName(
+                    (int) $context->shop->id,
+                    (int) $context->language->id,
+                    $tagName
+                );
+
+                $context->smarty->assign('everFaqs', $faqs);
+
+                return $context->smarty->fetch($templatePath);
+            },
+            $content
+        );
+    }
+}

--- a/src/Shortcode/ShortcodeHandlerInterface.php
+++ b/src/Shortcode/ShortcodeHandlerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Everblock\Tools\Shortcode;
+
+use Context;
+use Everblock;
+
+interface ShortcodeHandlerInterface
+{
+    public function supports(string $content): bool;
+
+    public function render(string $content, Context $context, Everblock $module): string;
+}

--- a/src/Shortcode/ShortcodeRenderer.php
+++ b/src/Shortcode/ShortcodeRenderer.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Everblock\Tools\Shortcode;
+
+use Context;
+use Customer;
+use Everblock;
+use EverblockTools;
+use Everblock\Tools\Service\EverBlockFaqProvider;
+use Everblock\Tools\Service\EverBlockShortcodeProvider;
+use Everblock\Tools\Service\EverblockPrettyBlocks;
+use Gender;
+use Hook;
+use Traversable;
+
+final class ShortcodeRenderer
+{
+    /** @var iterable<int, ShortcodeHandlerInterface> */
+    private iterable $handlers;
+
+    /**
+     * @param iterable<int, ShortcodeHandlerInterface> $handlers
+     */
+    public function __construct(
+        iterable $handlers,
+        private readonly EverBlockShortcodeProvider $shortcodeProvider,
+        private readonly EverBlockFaqProvider $faqProvider,
+        private readonly EverblockPrettyBlocks $prettyBlocks
+    ) {
+        $this->handlers = $handlers instanceof Traversable ? $handlers : (array) $handlers;
+
+        EverblockTools::setShortcodeProvider($this->shortcodeProvider);
+        EverblockPrettyBlocks::setShortcodeProvider($this->shortcodeProvider);
+    }
+
+    public function render(string $content, Context $context, Everblock $module): string
+    {
+        Hook::exec('displayBeforeRenderingShortcodes', ['html' => &$content]);
+
+        $content = $this->renderEverShortcodes($content, $context);
+        $content = $this->renderRegisteredHandlers($content, $context, $module);
+
+        if ($this->shouldRenderCustomerShortcodes($context)) {
+            $content = $this->renderCustomerShortcodes($content, $context);
+            $content = $this->obfuscateTextByClass($content);
+        }
+
+        $content = $this->renderSmartyVariables($content, $context);
+
+        Hook::exec('displayAfterRenderingShortcodes', ['html' => &$content]);
+
+        return $content;
+    }
+
+    public function getFaqProvider(): EverBlockFaqProvider
+    {
+        return $this->faqProvider;
+    }
+
+    public function getPrettyBlocksService(): EverblockPrettyBlocks
+    {
+        return $this->prettyBlocks;
+    }
+
+    public function renderEverShortcodes(string $content, Context $context): string
+    {
+        $customShortcodes = $this->shortcodeProvider->getAllShortcodes(
+            (int) $context->shop->id,
+            (int) $context->language->id
+        );
+
+        foreach ($customShortcodes as $shortcode) {
+            $content = str_replace($shortcode->shortcode, $shortcode->content, $content);
+        }
+
+        return $content;
+    }
+
+    public function renderRegisteredHandlers(string $content, Context $context, Everblock $module): string
+    {
+        foreach ($this->handlers as $handler) {
+            if (!$handler instanceof ShortcodeHandlerInterface) {
+                continue;
+            }
+
+            if (!$handler->supports($content)) {
+                continue;
+            }
+
+            $content = $handler->render($content, $context, $module);
+        }
+
+        return $content;
+    }
+
+    public function renderCustomerShortcodes(string $content, Context $context): string
+    {
+        $customer = new Customer((int) $context->customer->id);
+        $gender = new Gender((int) $customer->id_gender, (int) $context->language->id);
+
+        $replacements = [
+            '[entity_lastname]' => $customer->lastname,
+            '[entity_firstname]' => $customer->firstname,
+            '[entity_company]' => $customer->company,
+            '[entity_siret]' => $customer->siret,
+            '[entity_ape]' => $customer->ape,
+            '[entity_birthday]' => $customer->birthday,
+            '[entity_website]' => $customer->website,
+            '[entity_gender]' => $gender->name,
+        ];
+
+        foreach ($replacements as $placeholder => $value) {
+            $content = str_replace($placeholder, $value, $content);
+        }
+
+        return $content;
+    }
+
+    public function renderSmartyVariables(string $content, Context $context): string
+    {
+        if (!$this->shouldRenderCustomerShortcodes($context)) {
+            return $content;
+        }
+
+        $templateVars = [
+            'customer' => $context->controller->getTemplateVarCustomer(),
+            'currency' => $context->controller->getTemplateVarCurrency(),
+            'shop' => $context->controller->getTemplateVarShop(),
+            'urls' => $context->controller->getTemplateVarUrls(),
+            'configuration' => $context->controller->getTemplateVarConfiguration(),
+            'breadcrumb' => $context->controller->getBreadcrumb(),
+        ];
+
+        foreach ($templateVars as $key => $value) {
+            $search = '$' . $key;
+
+            if (is_array($value)) {
+                $content = $this->renderSmartyArray($content, $search, $value);
+
+                continue;
+            }
+
+            if (is_string($value)) {
+                $content = str_replace($search, $value, $content);
+            }
+        }
+
+        return $content;
+    }
+
+    private function renderSmartyArray(string $content, string $search, array $values): string
+    {
+        foreach ($values as $key => $value) {
+            $elementSearch = $search . '.' . $key;
+
+            if (is_array($value)) {
+                $content = $this->renderSmartyArray($content, $elementSearch, $value);
+
+                continue;
+            }
+
+            $content = str_replace($elementSearch, (string) $value, $content);
+        }
+
+        return $content;
+    }
+
+    private function shouldRenderCustomerShortcodes(Context $context): bool
+    {
+        $controllerType = $context->controller->controller_type ?? null;
+
+        return in_array($controllerType, ['front', 'modulefront'], true);
+    }
+
+    private function obfuscateTextByClass(string $text): string
+    {
+        $pattern = '/<a\\s+(.*?)>/i';
+        preg_match_all($pattern, $text, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $wholeTag = $match[0];
+            $attributesPart = $match[1];
+
+            if (!preg_match('/\\bclass="[^"]*\\bobfme\\b[^"]*"/', $wholeTag)
+                && !preg_match("/\\bclass='[^']*\\bobfme\\b[^']*'/", $wholeTag)
+            ) {
+                continue;
+            }
+
+            preg_match('/href="([^"]*)"/i', $wholeTag, $urlMatch);
+            $linkUrl = $urlMatch[1] ?? '';
+            $encodedLink = base64_encode($linkUrl);
+
+            $newClassAttribute = preg_replace_callback(
+                '/\\bclass=("|\')([^"\']*)("|\')/i',
+                static function ($classMatch) {
+                    return 'class=' . $classMatch[1] . $classMatch[2] . ' obflink' . $classMatch[3];
+                },
+                $attributesPart
+            );
+
+            $newAttributesPart = preg_replace(
+                '/href="([^"]*)"/i',
+                'data-obflink="' . $encodedLink . '"',
+                $newClassAttribute ?? $attributesPart
+            );
+
+            $newTag = '<span ' . $newAttributesPart . '>';
+            $text = str_replace($wholeTag, $newTag, $text);
+        }
+
+        return $text;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a ShortcodeRenderer service with tagged handler support and customer/smarty helpers
- register shortcode handlers as individual services replacing the legacy array-based dispatch
- update module entry points to resolve the renderer from the container instead of static helpers

## Testing
- php -l src/Shortcode/ShortcodeRenderer.php
- php -l src/Shortcode/Handler/CallbackShortcodeHandler.php
- php -l src/Shortcode/Handler/FaqShortcodeHandler.php
- php -l controllers/front/modal.php
- php -l models/EverblockTools.php

------
https://chatgpt.com/codex/tasks/task_e_68f3c09f0130832299894f3390453b5b