### PR TITLE
Refactor shortcode data access into dedicated repositories

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -156,6 +156,21 @@ services:
             $connection: '@doctrine.dbal.default_connection'
             $cache: '@cache.app'
 
+    Everblock\Tools\Infrastructure\Repository\ProductTagRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+
+    Everblock\Tools\Infrastructure\Repository\SalesRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+
+    Everblock\Tools\Infrastructure\Repository\StockRepository:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $salesRepository: '@Everblock\\Tools\\Infrastructure\\Repository\\SalesRepository'
+
+    Everblock\Tools\Infrastructure\Repository\ProductRepository: ~
+
     Everblock\Tools\Service\Domain\EverBlockDomainService: ~
     Everblock\Tools\Service\Domain\EverBlockFaqDomainService: ~
     Everblock\Tools\Service\Domain\LegacyModelMap: ~
@@ -202,6 +217,14 @@ services:
             $handlers: !tagged_iterator everblock.shortcode_handler
 
     Everblock\Tools\Shortcode\Handler\FaqShortcodeHandler:
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    Everblock\Tools\Shortcode\Handler\ProductsByTagShortcodeHandler:
+        tags:
+            - { name: 'everblock.shortcode_handler' }
+
+    Everblock\Tools\Shortcode\Handler\LowStockShortcodeHandler:
         tags:
             - { name: 'everblock.shortcode_handler' }
 
@@ -472,23 +495,6 @@ services:
         tags:
             - { name: 'everblock.shortcode_handler' }
 
-    everblock.shortcode_handler.products_by_tag:
-        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
-        arguments:
-            $needle: '[products_by_tag'
-            $callback: ['EverblockTools', 'getProductsByTagShortcode']
-            $argumentMap: ['context', 'module']
-        tags:
-            - { name: 'everblock.shortcode_handler' }
-
-    everblock.shortcode_handler.low_stock:
-        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
-        arguments:
-            $needle: '[low_stock'
-            $callback: ['EverblockTools', 'getLowStockShortcode']
-            $argumentMap: ['context', 'module']
-        tags:
-            - { name: 'everblock.shortcode_handler' }
 
     everblock.shortcode_handler.cart:
         class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -23,6 +23,7 @@ use Everblock\Tools\Service\EverBlockFaqProvider;
 use Everblock\Tools\Service\EverBlockShortcodeProvider;
 use Everblock\Tools\Service\EverblockCache;
 use Everblock\Tools\Shortcode\ShortcodeRenderer;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -48,7 +49,9 @@ class EverblockTools extends ObjectModel
         $renderer = static::resolveShortcodeRenderer($module);
 
         if ($renderer instanceof ShortcodeRenderer) {
-            return $renderer->render($txt, $context, $module);
+            $renderContext = ShortcodeRenderingContext::fromContext($context);
+
+            return $renderer->render($txt, $renderContext, $module);
         }
 
         Hook::exec('displayBeforeRenderingShortcodes', ['html' => &$txt]);

--- a/src/Dto/Product/LowStockFilters.php
+++ b/src/Dto/Product/LowStockFilters.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+final class LowStockFilters
+{
+    public const GRANULARITY_PRODUCT = 'product';
+    public const GRANULARITY_COMBINATION = 'combination';
+
+    /**
+     * @param int[] $categoryIds
+     * @param int[] $manufacturerIds
+     * @param string[] $visibilities
+     */
+    public function __construct(
+        public readonly int $shopId,
+        public readonly int $shopGroupId,
+        public readonly int $languageId,
+        public readonly int $threshold,
+        public readonly string $comparisonOperator,
+        public readonly int $limit,
+        public readonly int $offset,
+        public readonly string $orderBy,
+        public readonly string $orderDirection,
+        public readonly int $days,
+        public readonly array $categoryIds,
+        public readonly array $manufacturerIds,
+        public readonly array $visibilities,
+        public readonly bool $availableOnly,
+        public readonly string $granularity,
+    ) {
+    }
+
+    public function orderBySales(): bool
+    {
+        return $this->orderBy === 'sales';
+    }
+
+    public function orderRandomly(): bool
+    {
+        return $this->orderBy === 'rand';
+    }
+
+    public function isCombinationLevel(): bool
+    {
+        return $this->granularity === self::GRANULARITY_COMBINATION;
+    }
+}

--- a/src/Dto/Product/LowStockProduct.php
+++ b/src/Dto/Product/LowStockProduct.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+final class LowStockProduct
+{
+    public function __construct(
+        private readonly int $productId,
+        private readonly ?int $productAttributeId,
+        private readonly int $quantity,
+        private readonly ?int $soldQuantity
+    ) {
+    }
+
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    public function getProductAttributeId(): ?int
+    {
+        return $this->productAttributeId;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function getSoldQuantity(): ?int
+    {
+        return $this->soldQuantity;
+    }
+}

--- a/src/Dto/Product/LowStockProductCollection.php
+++ b/src/Dto/Product/LowStockProductCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * @implements IteratorAggregate<int, LowStockProduct>
+ */
+final class LowStockProductCollection implements IteratorAggregate, Countable
+{
+    /**
+     * @param LowStockProduct[] $products
+     */
+    public function __construct(private readonly array $products)
+    {
+    }
+
+    /**
+     * @return ArrayIterator<int, LowStockProduct>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->products);
+    }
+
+    public function count(): int
+    {
+        return count($this->products);
+    }
+
+    /**
+     * @return LowStockProduct[]
+     */
+    public function toArray(): array
+    {
+        return $this->products;
+    }
+}

--- a/src/Dto/Product/ProductIdCollection.php
+++ b/src/Dto/Product/ProductIdCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+use Countable;
+use IteratorAggregate;
+use ArrayIterator;
+
+/**
+ * @implements IteratorAggregate<int, int>
+ */
+final class ProductIdCollection implements IteratorAggregate, Countable
+{
+    /**
+     * @param int[] $productIds
+     */
+    public function __construct(private readonly array $productIds)
+    {
+    }
+
+    /**
+     * @return ArrayIterator<int, int>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->productIds);
+    }
+
+    public function count(): int
+    {
+        return count($this->productIds);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function toArray(): array
+    {
+        return $this->productIds;
+    }
+}

--- a/src/Dto/Product/ProductTagFilters.php
+++ b/src/Dto/Product/ProductTagFilters.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+final class ProductTagFilters
+{
+    public const MATCH_ANY = 'any';
+    public const MATCH_ALL = 'all';
+
+    /**
+     * @param string[] $tagNames
+     * @param int[] $tagIds
+     * @param string[] $visibilities
+     */
+    public function __construct(
+        public readonly int $shopId,
+        public readonly int $languageId,
+        public readonly array $tagNames,
+        public readonly array $tagIds,
+        public readonly string $match,
+        public readonly int $offset,
+        public readonly int $limit,
+        public readonly string $orderBy,
+        public readonly string $orderDirection,
+        public readonly array $visibilities,
+    ) {
+    }
+}

--- a/src/Dto/Product/ProductView.php
+++ b/src/Dto/Product/ProductView.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+final class ProductView
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(private readonly array $data)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Dto/Product/ProductViewCollection.php
+++ b/src/Dto/Product/ProductViewCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Everblock\Tools\Dto\Product;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * @implements IteratorAggregate<int, ProductView>
+ */
+final class ProductViewCollection implements IteratorAggregate, Countable
+{
+    /**
+     * @param ProductView[] $products
+     */
+    public function __construct(private readonly array $products)
+    {
+    }
+
+    /**
+     * @return ArrayIterator<int, ProductView>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->products);
+    }
+
+    public function count(): int
+    {
+        return count($this->products);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(static fn (ProductView $product): array => $product->toArray(), $this->products);
+    }
+}

--- a/src/Dto/Sales/SalesAggregation.php
+++ b/src/Dto/Sales/SalesAggregation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Everblock\Tools\Dto\Sales;
+
+final class SalesAggregation
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function __construct(private readonly string $sql, private readonly array $parameters)
+    {
+    }
+
+    public function getSql(): string
+    {
+        return $this->sql;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Infrastructure/Repository/ProductRepository.php
+++ b/src/Infrastructure/Repository/ProductRepository.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Everblock\Tools\Infrastructure\Repository;
+
+use Everblock\Tools\Dto\Product\ProductIdCollection;
+use Everblock\Tools\Dto\Product\ProductView;
+use Everblock\Tools\Dto\Product\ProductViewCollection;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
+use Everblock\Tools\Service\EverblockCache;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Product\ProductPresenterFactory;
+use Product;
+use ProductAssembler;
+use Validate;
+use Exception;
+
+final class ProductRepository
+{
+    public function presentProducts(ProductIdCollection $productIds, ShortcodeRenderingContext $context): ProductViewCollection
+    {
+        $ids = $productIds->toArray();
+        $resultHash = md5(json_encode($ids));
+        $cacheId = 'everblock_product_presentations_'
+            . $context->getShopId() . '_'
+            . $context->getLanguageId() . '_'
+            . $resultHash;
+
+        if (EverblockCache::isCacheStored($cacheId)) {
+            $cached = EverblockCache::cacheRetrieve($cacheId);
+            if (is_array($cached)) {
+                return new ProductViewCollection(array_map(static fn (array $product): ProductView => new ProductView($product), $cached));
+            }
+        }
+
+        $presentations = [];
+
+        if ($ids !== []) {
+            $psContext = $context->getPrestashopContext();
+            $assembler = new ProductAssembler($psContext);
+            $presenterFactory = new ProductPresenterFactory($psContext);
+            $presentationSettings = $presenterFactory->getPresentationSettings();
+            $presentationSettings->showPrices = true;
+
+            if (class_exists(\PrestaShop\PrestaShop\Core\Product\ProductListingPresenter::class)) {
+                $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                    new ImageRetriever($psContext->link),
+                    $psContext->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $psContext->getTranslator()
+                );
+            } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter::class)) {
+                $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter(
+                    new ImageRetriever($psContext->link),
+                    $psContext->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $psContext->getTranslator()
+                );
+            } else {
+                throw new Exception('No suitable product presenter class found for this PrestaShop version.');
+            }
+
+            foreach ($ids as $productId) {
+                $productId = (int) $productId;
+                if ($productId <= 0) {
+                    continue;
+                }
+
+                $psProduct = new Product($productId);
+                if (!Validate::isLoadedObject($psProduct) || !(bool) $psProduct->active) {
+                    continue;
+                }
+
+                $rawProduct = [
+                    'id_product' => $productId,
+                    'id_lang' => $context->getLanguageId(),
+                    'id_shop' => $context->getShopId(),
+                ];
+
+                $assembled = $assembler->assembleProduct($rawProduct);
+
+                if (Product::checkAccessStatic($productId, $context->getCustomerId())) {
+                    $presentations[] = $presenter->present(
+                        $presentationSettings,
+                        $assembled,
+                        $psContext->language
+                    );
+                }
+            }
+        }
+
+        EverblockCache::cacheStore($cacheId, $presentations);
+
+        return new ProductViewCollection(array_map(static fn (array $product): ProductView => new ProductView($product), $presentations));
+    }
+}

--- a/src/Infrastructure/Repository/ProductTagRepository.php
+++ b/src/Infrastructure/Repository/ProductTagRepository.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Everblock\Tools\Infrastructure\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Everblock\Tools\Dto\Product\ProductIdCollection;
+use Everblock\Tools\Dto\Product\ProductTagFilters;
+
+final class ProductTagRepository
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function findProductIds(ProductTagFilters $filters): ProductIdCollection
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('pt.id_product')
+            ->from(_DB_PREFIX_ . 'product_tag', 'pt')
+            ->innerJoin('pt', _DB_PREFIX_ . 'product_shop', 'ps', 'ps.id_product = pt.id_product AND ps.id_shop = :shopId AND ps.active = 1')
+            ->innerJoin('pt', _DB_PREFIX_ . 'product_lang', 'pl', 'pl.id_product = pt.id_product AND pl.id_shop = :shopId AND pl.id_lang = :langId')
+            ->innerJoin('pt', _DB_PREFIX_ . 'product', 'p', 'p.id_product = pt.id_product')
+            ->setParameter('shopId', $filters->shopId, ParameterType::INTEGER)
+            ->setParameter('langId', $filters->languageId, ParameterType::INTEGER);
+
+        if ($filters->tagNames !== []) {
+            $qb->innerJoin('pt', _DB_PREFIX_ . 'tag', 't', 't.id_tag = pt.id_tag AND t.id_lang = :langId');
+        }
+
+        if ($filters->visibilities !== []) {
+            $visibilityPlaceholders = [];
+            foreach ($filters->visibilities as $index => $visibility) {
+                $paramName = 'visibility_' . $index;
+                $visibilityPlaceholders[] = ':' . $paramName;
+                $qb->setParameter($paramName, $visibility);
+            }
+            $qb->andWhere('ps.visibility IN (' . implode(',', $visibilityPlaceholders) . ')');
+        }
+
+        $conditions = [];
+
+        if ($filters->tagIds !== []) {
+            $placeholders = [];
+            foreach ($filters->tagIds as $index => $tagId) {
+                $paramName = 'tagId_' . $index;
+                $placeholders[] = ':' . $paramName;
+                $qb->setParameter($paramName, $tagId, ParameterType::INTEGER);
+            }
+            $conditions[] = 'pt.id_tag IN (' . implode(',', $placeholders) . ')';
+        }
+
+        if ($filters->tagNames !== []) {
+            $placeholders = [];
+            foreach ($filters->tagNames as $index => $tagName) {
+                $paramName = 'tagName_' . $index;
+                $placeholders[] = ':' . $paramName;
+                $qb->setParameter($paramName, $tagName);
+            }
+            $conditions[] = 't.name IN (' . implode(',', $placeholders) . ')';
+        }
+
+        if ($conditions !== []) {
+            if (count($conditions) > 1) {
+                $qb->andWhere('(' . implode(' OR ', $conditions) . ')');
+            } else {
+                $qb->andWhere($conditions[0]);
+            }
+        }
+
+        $qb->groupBy('pt.id_product');
+
+        if ($filters->match === ProductTagFilters::MATCH_ALL) {
+            $tagCount = count(array_unique(array_merge($filters->tagIds, $filters->tagNames)));
+            if ($tagCount > 1) {
+                $qb->having('COUNT(DISTINCT pt.id_tag) = :tagCount');
+                $qb->setParameter('tagCount', $tagCount, ParameterType::INTEGER);
+            }
+        }
+
+        $orderByMap = [
+            'position' => 'ps.position',
+            'name' => 'pl.name',
+            'price' => 'ps.price',
+            'date_add' => 'p.date_add',
+            'rand' => 'RAND()',
+        ];
+
+        $orderBy = $orderByMap[$filters->orderBy] ?? 'ps.position';
+
+        if ($orderBy === 'RAND()') {
+            $qb->add('orderBy', $orderBy);
+        } else {
+            $direction = strtoupper($filters->orderDirection) === 'DESC' ? 'DESC' : 'ASC';
+            $qb->orderBy($orderBy, $direction);
+        }
+
+        $qb->setFirstResult($filters->offset)
+            ->setMaxResults($filters->limit);
+
+        $rows = $qb->executeQuery()->fetchFirstColumn();
+        $productIds = array_map('intval', $rows ?: []);
+
+        return new ProductIdCollection($productIds);
+    }
+}

--- a/src/Infrastructure/Repository/SalesRepository.php
+++ b/src/Infrastructure/Repository/SalesRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Everblock\Tools\Infrastructure\Repository;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use Everblock\Tools\Dto\Sales\SalesAggregation;
+use DateTimeInterface;
+
+final class SalesRepository
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function createSoldQuantityAggregation(?DateTimeInterface $dateLimit, bool $byCombination, string $aliasPrefix = 'sales'): SalesAggregation
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('od.product_id AS product_id')
+            ->from(_DB_PREFIX_ . 'order_detail', 'od')
+            ->innerJoin('od', _DB_PREFIX_ . 'orders', 'o', 'o.id_order = od.id_order')
+            ->where('o.valid = 1')
+            ->groupBy('od.product_id');
+
+        if ($byCombination) {
+            $qb->addSelect('od.product_attribute_id AS product_attribute_id');
+            $qb->addGroupBy('od.product_attribute_id');
+        }
+
+        $qb->addSelect('SUM(od.product_quantity) AS sold_qty');
+
+        $parameters = [];
+
+        if ($dateLimit instanceof DateTimeInterface) {
+            $paramName = $aliasPrefix . '_date_limit';
+            $qb->andWhere('o.date_add >= :' . $paramName);
+            $qb->setParameter($paramName, $dateLimit->format('Y-m-d H:i:s'), Types::DATETIME_MUTABLE);
+            $parameters[$paramName] = $dateLimit->format('Y-m-d H:i:s');
+        }
+
+        return new SalesAggregation($qb->getSQL(), $parameters);
+    }
+}

--- a/src/Infrastructure/Repository/StockRepository.php
+++ b/src/Infrastructure/Repository/StockRepository.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Everblock\Tools\Infrastructure\Repository;
+
+use DateInterval;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Everblock\Tools\Dto\Product\LowStockFilters;
+use Everblock\Tools\Dto\Product\LowStockProduct;
+use Everblock\Tools\Dto\Product\LowStockProductCollection;
+
+final class StockRepository
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly SalesRepository $salesRepository
+    ) {
+    }
+
+    public function findLowStockProducts(LowStockFilters $filters): LowStockProductCollection
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('p.id_product', 'sa.quantity AS quantity')
+            ->from(_DB_PREFIX_ . 'product', 'p')
+            ->innerJoin('p', _DB_PREFIX_ . 'product_shop', 'ps', 'ps.id_product = p.id_product AND ps.id_shop = :shopId')
+            ->innerJoin('p', _DB_PREFIX_ . 'product_lang', 'pl', 'pl.id_product = p.id_product AND pl.id_shop = :shopId AND pl.id_lang = :langId')
+            ->innerJoin(
+                'p',
+                _DB_PREFIX_ . 'stock_available',
+                'sa',
+                'sa.id_product = p.id_product'
+                . ' AND (sa.id_shop = :shopId OR (sa.id_shop IS NULL AND sa.id_shop_group = :shopGroupId))'
+            )
+            ->where('ps.active = 1')
+            ->andWhere('sa.quantity ' . $filters->comparisonOperator . ' :threshold')
+            ->setParameter('shopId', $filters->shopId, ParameterType::INTEGER)
+            ->setParameter('shopGroupId', $filters->shopGroupId, ParameterType::INTEGER)
+            ->setParameter('langId', $filters->languageId, ParameterType::INTEGER)
+            ->setParameter('threshold', $filters->threshold, ParameterType::INTEGER);
+
+        if ($filters->isCombinationLevel()) {
+            $qb->andWhere('sa.id_product_attribute > 0');
+            $qb->addSelect('sa.id_product_attribute');
+        } else {
+            $qb->andWhere('sa.id_product_attribute = 0');
+        }
+
+        if ($filters->visibilities !== []) {
+            $visibilityPlaceholders = [];
+            foreach ($filters->visibilities as $index => $visibility) {
+                $param = 'visibility_' . $index;
+                $visibilityPlaceholders[] = ':' . $param;
+                $qb->setParameter($param, $visibility);
+            }
+            $qb->andWhere('ps.visibility IN (' . implode(',', $visibilityPlaceholders) . ')');
+        }
+
+        if ($filters->availableOnly) {
+            $qb->andWhere('ps.available_for_order = 1');
+        }
+
+        if ($filters->days > 0) {
+            $dateLimit = (new DateTimeImmutable('now'))->sub(new DateInterval('P' . $filters->days . 'D'));
+            $qb->andWhere('p.date_add >= :productDateLimit');
+            $qb->setParameter('productDateLimit', $dateLimit->format('Y-m-d H:i:s'));
+            $salesAggregation = $this->salesRepository->createSoldQuantityAggregation($dateLimit, $filters->isCombinationLevel(), 'lowstock');
+        } else {
+            $salesAggregation = $this->salesRepository->createSoldQuantityAggregation(null, $filters->isCombinationLevel(), 'lowstock');
+        }
+
+        if ($filters->categoryIds !== []) {
+            $qb->leftJoin('p', _DB_PREFIX_ . 'category_product', 'cp', 'cp.id_product = p.id_product');
+            $placeholders = [];
+            foreach ($filters->categoryIds as $index => $categoryId) {
+                $param = 'category_' . $index;
+                $placeholders[] = ':' . $param;
+                $qb->setParameter($param, $categoryId, ParameterType::INTEGER);
+            }
+            $qb->andWhere('cp.id_category IN (' . implode(',', $placeholders) . ')');
+        }
+
+        if ($filters->manufacturerIds !== []) {
+            $placeholders = [];
+            foreach ($filters->manufacturerIds as $index => $manufacturerId) {
+                $param = 'manufacturer_' . $index;
+                $placeholders[] = ':' . $param;
+                $qb->setParameter($param, $manufacturerId, ParameterType::INTEGER);
+            }
+            $qb->andWhere('p.id_manufacturer IN (' . implode(',', $placeholders) . ')');
+        }
+
+        if ($filters->orderBySales()) {
+            $qb->addSelect('COALESCE(s.sold_qty, 0) AS sold_qty');
+            $qb->leftJoin(
+                'p',
+                '(' . $salesAggregation->getSql() . ')',
+                's',
+                $filters->isCombinationLevel()
+                    ? 's.product_id = p.id_product AND s.product_attribute_id = sa.id_product_attribute'
+                    : 's.product_id = p.id_product'
+            );
+        }
+
+        foreach ($salesAggregation->getParameters() as $name => $value) {
+            $qb->setParameter($name, $value);
+        }
+
+        $qb->groupBy('p.id_product');
+        if ($filters->isCombinationLevel()) {
+            $qb->addGroupBy('sa.id_product_attribute');
+        }
+
+        if ($filters->orderRandomly()) {
+            $qb->add('orderBy', 'RAND()');
+        } else {
+            $orderMap = [
+                'qty' => 'sa.quantity',
+                'date_add' => 'p.date_add',
+                'name' => 'pl.name',
+                'price' => 'ps.price',
+                'sales' => 'sold_qty',
+            ];
+            $orderBy = $orderMap[$filters->orderBy] ?? 'sa.quantity';
+            $direction = strtoupper($filters->orderDirection) === 'DESC' ? 'DESC' : 'ASC';
+            $qb->orderBy($orderBy, $direction);
+        }
+
+        $qb->setFirstResult($filters->offset)
+            ->setMaxResults($filters->limit);
+
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+        $products = [];
+
+        foreach ($rows as $row) {
+            $products[] = new LowStockProduct(
+                (int) $row['id_product'],
+                isset($row['id_product_attribute']) ? (int) $row['id_product_attribute'] : null,
+                (int) $row['quantity'],
+                array_key_exists('sold_qty', $row) ? (int) $row['sold_qty'] : null
+            );
+        }
+
+        return new LowStockProductCollection($products);
+    }
+}

--- a/src/Shortcode/Handler/CallbackShortcodeHandler.php
+++ b/src/Shortcode/Handler/CallbackShortcodeHandler.php
@@ -2,9 +2,9 @@
 
 namespace Everblock\Tools\Shortcode\Handler;
 
-use Context;
 use Everblock;
 use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
 
 final class CallbackShortcodeHandler implements ShortcodeHandlerInterface
 {
@@ -24,18 +24,22 @@ final class CallbackShortcodeHandler implements ShortcodeHandlerInterface
         return str_contains($content, $this->needle);
     }
 
-    public function render(string $content, Context $context, Everblock $module): string
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string
     {
         $arguments = [];
 
         foreach ($this->argumentMap as $argument) {
             switch ($argument) {
                 case 'context':
-                    $arguments[] = $context;
+                    $arguments[] = $context->getPrestashopContext();
 
                     break;
                 case 'module':
                     $arguments[] = $module;
+
+                    break;
+                case 'renderContext':
+                    $arguments[] = $context;
 
                     break;
             }

--- a/src/Shortcode/Handler/FaqShortcodeHandler.php
+++ b/src/Shortcode/Handler/FaqShortcodeHandler.php
@@ -2,11 +2,11 @@
 
 namespace Everblock\Tools\Shortcode\Handler;
 
-use Context;
 use Everblock;
 use EverblockTools;
 use Everblock\Tools\Service\EverBlockFaqProvider;
 use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
 
 final class FaqShortcodeHandler implements ShortcodeHandlerInterface
 {
@@ -19,7 +19,7 @@ final class FaqShortcodeHandler implements ShortcodeHandlerInterface
         return str_contains($content, '[everfaq');
     }
 
-    public function render(string $content, Context $context, Everblock $module): string
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string
     {
         $templatePath = EverblockTools::getTemplatePath('hook/faq.tpl', $module);
 
@@ -29,14 +29,14 @@ final class FaqShortcodeHandler implements ShortcodeHandlerInterface
                 $tagName = $matches[1];
 
                 $faqs = $this->faqProvider->getFaqByTagName(
-                    (int) $context->shop->id,
-                    (int) $context->language->id,
+                    $context->getShopId(),
+                    $context->getLanguageId(),
                     $tagName
                 );
 
-                $context->smarty->assign('everFaqs', $faqs);
+                $context->getSmarty()->assign('everFaqs', $faqs);
 
-                return $context->smarty->fetch($templatePath);
+                return $context->getSmarty()->fetch($templatePath);
             },
             $content
         );

--- a/src/Shortcode/Handler/LowStockShortcodeHandler.php
+++ b/src/Shortcode/Handler/LowStockShortcodeHandler.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Everblock\Tools\Shortcode\Handler;
+
+use Combination;
+use Db;
+use Everblock;
+use EverblockTools;
+use Everblock\Tools\Dto\Product\LowStockFilters;
+use Everblock\Tools\Dto\Product\ProductIdCollection;
+use Everblock\Tools\Infrastructure\Repository\ProductRepository;
+use Everblock\Tools\Infrastructure\Repository\StockRepository;
+use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Product\ProductPresenterFactory;
+use ProductAssembler;
+use Validate;
+
+final class LowStockShortcodeHandler implements ShortcodeHandlerInterface
+{
+    public function __construct(
+        private readonly StockRepository $stockRepository,
+        private readonly ProductRepository $productRepository
+    ) {
+    }
+
+    public function supports(string $content): bool
+    {
+        return str_contains($content, '[low_stock');
+    }
+
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string
+    {
+        return (string) preg_replace_callback(
+            '/\[low_stock(?:\s+([^\]]+))?\]/i',
+            function (array $matches) use ($context, $module) {
+                $attrs = $this->parseAttributes($matches[1] ?? '');
+
+                $limit = isset($attrs['limit']) ? max(1, (int) $attrs['limit']) : 10;
+                $offset = isset($attrs['offset']) ? max(0, (int) $attrs['offset']) : 0;
+                $threshold = isset($attrs['threshold']) ? (int) $attrs['threshold'] : 5;
+
+                $match = strtolower((string) ($attrs['match'] ?? 'lte'));
+                $operatorMap = [
+                    'lt' => '<',
+                    'lte' => '<=',
+                    'eq' => '=',
+                    'gt' => '>',
+                    'gte' => '>=',
+                ];
+                $comparisonOperator = $operatorMap[$match] ?? '<=';
+
+                $order = strtolower((string) ($attrs['order'] ?? 'qty'));
+                $allowedOrders = ['qty', 'date_add', 'name', 'price', 'sales', 'rand'];
+                if (!in_array($order, $allowedOrders, true)) {
+                    $order = 'qty';
+                }
+
+                $direction = strtolower((string) ($attrs['way'] ?? 'asc'));
+                $allowedDirections = ['asc', 'desc'];
+                if (!in_array($direction, $allowedDirections, true)) {
+                    $direction = 'asc';
+                }
+                if ($order === 'rand') {
+                    $direction = 'asc';
+                }
+
+                $days = isset($attrs['days']) ? max(0, (int) $attrs['days']) : 0;
+                $categoryIds = $this->normalizeIntList($attrs['id_category'] ?? []);
+                $manufacturerIds = $this->normalizeIntList($attrs['id_manufacturer'] ?? []);
+                $visibilities = $this->resolveVisibilities($attrs['visibility'] ?? 'both,catalog');
+                $availableOnly = isset($attrs['available_only']) ? (bool) (int) $attrs['available_only'] : true;
+                $granularity = strtolower((string) ($attrs['by'] ?? LowStockFilters::GRANULARITY_PRODUCT));
+                if (!in_array($granularity, [LowStockFilters::GRANULARITY_PRODUCT, LowStockFilters::GRANULARITY_COMBINATION], true)) {
+                    $granularity = LowStockFilters::GRANULARITY_PRODUCT;
+                }
+
+                $cols = isset($attrs['cols']) ? (int) $attrs['cols'] : 4;
+
+                $cacheKey = md5(json_encode([
+                    $attrs,
+                    $context->getShopId(),
+                    $context->getShopGroupId(),
+                    $context->getLanguageId(),
+                ]));
+
+                static $cache = [];
+
+                if (!isset($cache[$cacheKey])) {
+                    $filters = new LowStockFilters(
+                        $context->getShopId(),
+                        $context->getShopGroupId(),
+                        $context->getLanguageId(),
+                        $threshold,
+                        $comparisonOperator,
+                        $limit,
+                        $offset,
+                        $order,
+                        $direction,
+                        $days,
+                        $categoryIds,
+                        $manufacturerIds,
+                        $visibilities,
+                        $availableOnly,
+                        $granularity,
+                    );
+
+                    $lowStockProducts = $this->stockRepository->findLowStockProducts($filters);
+
+                    if (count($lowStockProducts) === 0) {
+                        $cache[$cacheKey] = ['products' => [], 'variants' => []];
+                    } elseif ($granularity === LowStockFilters::GRANULARITY_PRODUCT) {
+                        $productIds = new ProductIdCollection(array_map(
+                            static fn ($product) => $product->getProductId(),
+                            $lowStockProducts->toArray()
+                        ));
+
+                        $presentations = $this->productRepository->presentProducts($productIds, $context);
+                        $cache[$cacheKey] = ['products' => $presentations->toArray(), 'variants' => []];
+                    } else {
+                        $cache[$cacheKey] = $this->buildCombinationData($lowStockProducts->toArray(), $context);
+                    }
+                }
+
+                $data = $cache[$cacheKey];
+
+                if ($data['products'] === []) {
+                    return '';
+                }
+
+                $context->getSmarty()->assign([
+                    'products' => $data['products'],
+                    'variants' => $data['variants'],
+                    'cols' => $cols,
+                    'params' => $attrs,
+                ]);
+
+                $templatePath = EverblockTools::getTemplatePath('hook/low_stock.tpl', $module);
+
+                return $context->getSmarty()->fetch($templatePath);
+            },
+            $content
+        );
+    }
+
+    /**
+     * @param string $attrStr
+     * @return array<string, string|array<int, string>>
+     */
+    private function parseAttributes(string $attrStr): array
+    {
+        $attrs = [];
+        preg_match_all('/(\w+)\s*=\s*"([^"]*)"/', $attrStr, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $key = strtolower($match[1]);
+            $value = trim($match[2]);
+            if (strpos($value, '|') !== false || strpos($value, ',') !== false) {
+                $value = array_filter(array_map('trim', preg_split('/[|,]/', $value) ?: []));
+            }
+            $attrs[$key] = $value;
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * @param mixed $value
+     * @return int[]
+     */
+    private function normalizeIntList(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($value as $item) {
+            if ($item === '' || $item === null) {
+                continue;
+            }
+            $values[] = (int) $item;
+        }
+
+        return array_values(array_filter($values, static fn (int $id): bool => $id > 0));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string[]
+     */
+    private function resolveVisibilities(mixed $value): array
+    {
+        $raw = $value;
+        if (is_string($raw)) {
+            $raw = array_map('trim', preg_split('/[|,]/', $raw) ?: []);
+        }
+
+        if (!is_array($raw)) {
+            return ['both', 'catalog'];
+        }
+
+        $allowed = ['both', 'catalog', 'search', 'none'];
+        $visibilities = array_values(array_intersect($raw, $allowed));
+
+        if ($visibilities === []) {
+            return ['both', 'catalog'];
+        }
+
+        return $visibilities;
+    }
+
+    /**
+     * @param array<int, \Everblock\Tools\Dto\Product\LowStockProduct> $products
+     * @return array{products: array<int, array<string, mixed>>, variants: array<int, array<string, mixed>>}
+     */
+    private function buildCombinationData(array $products, ShortcodeRenderingContext $context): array
+    {
+        $psContext = $context->getPrestashopContext();
+        $assembler = new ProductAssembler($psContext);
+        $presenterFactory = new ProductPresenterFactory($psContext);
+        $presentationSettings = $presenterFactory->getPresentationSettings();
+
+        if (class_exists(\PrestaShop\PrestaShop\Core\Product\ProductListingPresenter::class)) {
+            $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                new ImageRetriever($psContext->link),
+                $psContext->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $psContext->getTranslator()
+            );
+        } else {
+            $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter(
+                new ImageRetriever($psContext->link),
+                $psContext->link,
+                new PriceFormatter(),
+                new ProductColorsRetriever(),
+                $psContext->getTranslator()
+            );
+        }
+
+        $presentationSettings->showPrices = true;
+
+        $presented = [];
+        $variants = [];
+
+        foreach ($products as $product) {
+            $raw = [
+                'id_product' => $product->getProductId(),
+                'id_product_attribute' => $product->getProductAttributeId(),
+                'id_lang' => $context->getLanguageId(),
+                'id_shop' => $context->getShopId(),
+            ];
+
+            $assembled = $assembler->assembleProduct($raw);
+            $presentedProduct = $presenter->present($presentationSettings, $assembled, $psContext->language);
+            $presented[] = $presentedProduct;
+
+            $combination = new Combination((int) $product->getProductAttributeId());
+            $attributeNames = [];
+            if (Validate::isLoadedObject($combination)) {
+                $attributes = $combination->getAttributesName($context->getLanguageId());
+                foreach ($attributes as $attribute) {
+                    $attributeNames[] = $attribute['name'];
+                }
+            }
+
+            $imageId = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
+                'SELECT id_image FROM ' . _DB_PREFIX_ . 'product_attribute_image WHERE id_product_attribute = '
+                . (int) $product->getProductAttributeId() . ' ORDER BY id_image ASC'
+            );
+
+            $imageUrl = '';
+            if ($imageId && !empty($presentedProduct['link_rewrite'])) {
+                $imageUrl = $context->getLink()->getImageLink($presentedProduct['link_rewrite'], $imageId);
+            }
+
+            $variants[] = [
+                'id_product' => $product->getProductId(),
+                'id_product_attribute' => $product->getProductAttributeId(),
+                'attributes' => $attributeNames,
+                'url' => $context->getLink()->getProductLink(
+                    $product->getProductId(),
+                    null,
+                    null,
+                    null,
+                    $context->getLanguageId(),
+                    $context->getShopId(),
+                    $product->getProductAttributeId() ?? 0
+                ),
+                'image' => $imageUrl,
+            ];
+        }
+
+        return ['products' => $presented, 'variants' => $variants];
+    }
+}

--- a/src/Shortcode/Handler/ProductsByTagShortcodeHandler.php
+++ b/src/Shortcode/Handler/ProductsByTagShortcodeHandler.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Everblock\Tools\Shortcode\Handler;
+
+use Everblock;
+use EverblockTools;
+use Everblock\Tools\Dto\Product\ProductTagFilters;
+use Everblock\Tools\Infrastructure\Repository\ProductRepository;
+use Everblock\Tools\Infrastructure\Repository\ProductTagRepository;
+use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
+
+final class ProductsByTagShortcodeHandler implements ShortcodeHandlerInterface
+{
+    public function __construct(
+        private readonly ProductTagRepository $productTagRepository,
+        private readonly ProductRepository $productRepository
+    ) {
+    }
+
+    public function supports(string $content): bool
+    {
+        return str_contains($content, '[products_by_tag');
+    }
+
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string
+    {
+        return (string) preg_replace_callback(
+            '/\[products_by_tag\s+([^\]]+)\]/i',
+            function (array $matches) use ($context, $module) {
+                $attrs = $this->parseAttributes($matches[1] ?? '');
+
+                $tagNames = $this->normalizeStringList($attrs['tag'] ?? []);
+                $tagIds = $this->normalizeIntList($attrs['tag_id'] ?? []);
+
+                if ($tagNames === [] && $tagIds === []) {
+                    return '';
+                }
+
+                $match = strtolower((string) ($attrs['match'] ?? ProductTagFilters::MATCH_ANY));
+                if (!in_array($match, [ProductTagFilters::MATCH_ANY, ProductTagFilters::MATCH_ALL], true)) {
+                    $match = ProductTagFilters::MATCH_ANY;
+                }
+
+                $limit = isset($attrs['limit']) ? max(1, (int) $attrs['limit']) : 12;
+                $offset = isset($attrs['offset']) ? max(0, (int) $attrs['offset']) : 0;
+                $order = strtolower((string) ($attrs['order'] ?? 'position'));
+                $orderDirection = strtolower((string) ($attrs['way'] ?? 'asc'));
+                $cols = isset($attrs['cols']) ? (int) $attrs['cols'] : null;
+
+                $allowedOrders = ['position', 'name', 'price', 'date_add', 'rand'];
+                if (!in_array($order, $allowedOrders, true)) {
+                    $order = 'position';
+                }
+
+                $allowedDirections = ['asc', 'desc'];
+                if (!in_array($orderDirection, $allowedDirections, true)) {
+                    $orderDirection = 'asc';
+                }
+
+                $visibilities = $this->resolveVisibilities($attrs['visibility'] ?? 'both|catalog');
+
+                $cacheKey = md5(json_encode([
+                    $tagNames,
+                    $tagIds,
+                    $match,
+                    $limit,
+                    $offset,
+                    $order,
+                    $orderDirection,
+                    $visibilities,
+                    $context->getShopId(),
+                    $context->getLanguageId(),
+                ]));
+
+                static $cache = [];
+
+                if (!isset($cache[$cacheKey])) {
+                    $filters = new ProductTagFilters(
+                        $context->getShopId(),
+                        $context->getLanguageId(),
+                        $tagNames,
+                        $tagIds,
+                        $match,
+                        $offset,
+                        $limit,
+                        $order,
+                        $orderDirection,
+                        $visibilities,
+                    );
+
+                    $productIds = $this->productTagRepository->findProductIds($filters);
+
+                    if (count($productIds) === 0) {
+                        $cache[$cacheKey] = [];
+                    } else {
+                        $presentations = $this->productRepository->presentProducts($productIds, $context);
+                        $cache[$cacheKey] = $presentations->toArray();
+                    }
+                }
+
+                $products = $cache[$cacheKey];
+
+                if ($products === []) {
+                    return '';
+                }
+
+                $context->getSmarty()->assign([
+                    'products' => $products,
+                    'cols' => $cols,
+                    'total' => count($products),
+                    'params' => $attrs,
+                ]);
+
+                $templatePath = EverblockTools::getTemplatePath('hook/products_by_tag.tpl', $module);
+
+                return $context->getSmarty()->fetch($templatePath);
+            },
+            $content
+        );
+    }
+
+    /**
+     * @return array<string, string|array<int, string>>
+     */
+    private function parseAttributes(string $attrStr): array
+    {
+        $attrs = [];
+        preg_match_all('/(\w+)\s*=\s*"([^"]*)"/', $attrStr, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $key = strtolower($match[1]);
+            $value = trim($match[2]);
+            if (strpos($value, '|') !== false) {
+                $value = array_filter(array_map('trim', explode('|', $value)));
+            }
+            $attrs[$key] = $value;
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * @param mixed $value
+     * @return string[]
+     */
+    private function normalizeStringList(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($value as $item) {
+            if (!is_string($item)) {
+                continue;
+            }
+            $item = trim($item);
+            if ($item === '') {
+                continue;
+            }
+            $values[] = $item;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param mixed $value
+     * @return int[]
+     */
+    private function normalizeIntList(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($value as $item) {
+            if ($item === '' || $item === null) {
+                continue;
+            }
+            $values[] = (int) $item;
+        }
+
+        return array_values(array_filter($values, static fn (int $id): bool => $id > 0));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string[]
+     */
+    private function resolveVisibilities(mixed $value): array
+    {
+        $raw = $value;
+        if (is_string($raw)) {
+            $raw = array_map('trim', preg_split('/[|,]/', $raw) ?: []);
+        }
+
+        if (!is_array($raw)) {
+            return ['both', 'catalog'];
+        }
+
+        $allowed = ['both', 'catalog', 'search', 'none'];
+        $visibilities = array_values(array_intersect($raw, $allowed));
+
+        if ($visibilities === []) {
+            return ['both', 'catalog'];
+        }
+
+        return $visibilities;
+    }
+}

--- a/src/Shortcode/ShortcodeHandlerInterface.php
+++ b/src/Shortcode/ShortcodeHandlerInterface.php
@@ -2,12 +2,12 @@
 
 namespace Everblock\Tools\Shortcode;
 
-use Context;
 use Everblock;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
 
 interface ShortcodeHandlerInterface
 {
     public function supports(string $content): bool;
 
-    public function render(string $content, Context $context, Everblock $module): string;
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string;
 }

--- a/src/Shortcode/ShortcodeRenderingContext.php
+++ b/src/Shortcode/ShortcodeRenderingContext.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Everblock\Tools\Shortcode;
+
+use Cart;
+use Context;
+use Controller;
+use Link;
+use Smarty;
+
+final class ShortcodeRenderingContext
+{
+    private function __construct(private readonly Context $context)
+    {
+    }
+
+    public static function fromContext(Context $context): self
+    {
+        return new self($context);
+    }
+
+    public function getShopId(): int
+    {
+        return (int) $this->context->shop->id;
+    }
+
+    public function getShopGroupId(): int
+    {
+        return (int) $this->context->shop->id_shop_group;
+    }
+
+    public function getLanguageId(): int
+    {
+        return (int) $this->context->language->id;
+    }
+
+    public function getCustomerId(): int
+    {
+        return (int) $this->context->customer->id;
+    }
+
+    public function getSmarty(): Smarty
+    {
+        return $this->context->smarty;
+    }
+
+    public function getLink(): Link
+    {
+        return $this->context->link;
+    }
+
+    public function getCart(): ?Cart
+    {
+        return $this->context->cart instanceof Cart ? $this->context->cart : null;
+    }
+
+    public function getControllerType(): ?string
+    {
+        return $this->context->controller->controller_type ?? null;
+    }
+
+    public function getTemplateVarCustomer(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getTemplateVarCustomer() : null;
+    }
+
+    public function getTemplateVarCurrency(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getTemplateVarCurrency() : null;
+    }
+
+    public function getTemplateVarShop(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getTemplateVarShop() : null;
+    }
+
+    public function getTemplateVarUrls(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getTemplateVarUrls() : null;
+    }
+
+    public function getTemplateVarConfiguration(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getTemplateVarConfiguration() : null;
+    }
+
+    public function getBreadcrumb(): mixed
+    {
+        return $this->context->controller instanceof Controller ? $this->context->controller->getBreadcrumb() : null;
+    }
+
+    public function getPrestashopContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/tests/Infrastructure/Repository/ProductTagRepositoryTest.php
+++ b/tests/Infrastructure/Repository/ProductTagRepositoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Everblock\Tools\Tests\Infrastructure\Repository;
+
+use Doctrine\DBAL\DriverManager;
+use Everblock\Tools\Dto\Product\ProductTagFilters;
+use Everblock\Tools\Infrastructure\Repository\ProductTagRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ProductTagRepositoryTest extends TestCase
+{
+    public function testFindProductIdsByTagName(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_product (id_product, date_add) VALUES (1, '2024-01-01'), (2, '2024-01-02')");
+        $connection->executeStatement("INSERT INTO ps_product_shop (id_product, id_shop, active, visibility, price, position) VALUES (1, 1, 1, 'both', 10, 1), (2, 1, 1, 'catalog', 20, 2)");
+        $connection->executeStatement("INSERT INTO ps_product_lang (id_product, id_lang, id_shop, name) VALUES (1, 1, 1, 'First'), (2, 1, 1, 'Second')");
+        $connection->executeStatement("INSERT INTO ps_tag (id_tag, id_lang, name) VALUES (10, 1, 'featured'), (11, 1, 'summer')");
+        $connection->executeStatement("INSERT INTO ps_product_tag (id_product, id_tag) VALUES (1, 10), (1, 11), (2, 11)");
+
+        $repository = new ProductTagRepository($connection);
+
+        $filters = new ProductTagFilters(
+            shopId: 1,
+            languageId: 1,
+            tagNames: ['summer'],
+            tagIds: [],
+            match: ProductTagFilters::MATCH_ANY,
+            offset: 0,
+            limit: 10,
+            orderBy: 'position',
+            orderDirection: 'asc',
+            visibilities: ['both', 'catalog']
+        );
+
+        $result = $repository->findProductIds($filters);
+
+        self::assertSame([1, 2], $result->toArray());
+    }
+
+    public function testFindProductIdsWithMatchAll(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_product (id_product, date_add) VALUES (1, '2024-01-01'), (2, '2024-01-02')");
+        $connection->executeStatement("INSERT INTO ps_product_shop (id_product, id_shop, active, visibility, price, position) VALUES (1, 1, 1, 'both', 10, 1), (2, 1, 1, 'catalog', 20, 2)");
+        $connection->executeStatement("INSERT INTO ps_product_lang (id_product, id_lang, id_shop, name) VALUES (1, 1, 1, 'First'), (2, 1, 1, 'Second')");
+        $connection->executeStatement("INSERT INTO ps_tag (id_tag, id_lang, name) VALUES (10, 1, 'featured'), (11, 1, 'summer')");
+        $connection->executeStatement("INSERT INTO ps_product_tag (id_product, id_tag) VALUES (1, 10), (1, 11), (2, 11)");
+
+        $repository = new ProductTagRepository($connection);
+
+        $filters = new ProductTagFilters(
+            shopId: 1,
+            languageId: 1,
+            tagNames: ['featured', 'summer'],
+            tagIds: [],
+            match: ProductTagFilters::MATCH_ALL,
+            offset: 0,
+            limit: 10,
+            orderBy: 'position',
+            orderDirection: 'asc',
+            visibilities: ['both', 'catalog']
+        );
+
+        $result = $repository->findProductIds($filters);
+
+        self::assertSame([1], $result->toArray());
+    }
+
+    private function createSchema($connection): void
+    {
+        $connection->executeStatement('CREATE TABLE ps_product (id_product INTEGER PRIMARY KEY, date_add TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_product_shop (id_product INTEGER, id_shop INTEGER, active INTEGER, visibility TEXT, price REAL, position INTEGER)');
+        $connection->executeStatement('CREATE TABLE ps_product_lang (id_product INTEGER, id_lang INTEGER, id_shop INTEGER, name TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_product_tag (id_product INTEGER, id_tag INTEGER)');
+        $connection->executeStatement('CREATE TABLE ps_tag (id_tag INTEGER PRIMARY KEY, id_lang INTEGER, name TEXT)');
+    }
+}

--- a/tests/Infrastructure/Repository/SalesRepositoryTest.php
+++ b/tests/Infrastructure/Repository/SalesRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Everblock\Tools\Tests\Infrastructure\Repository;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\DriverManager;
+use Everblock\Tools\Infrastructure\Repository\SalesRepository;
+use PHPUnit\Framework\TestCase;
+
+final class SalesRepositoryTest extends TestCase
+{
+    public function testCreateSoldQuantityAggregationWithoutDateLimit(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_orders (id_order, valid, date_add) VALUES (1, 1, '2024-01-01'), (2, 0, '2024-01-02')");
+        $connection->executeStatement("INSERT INTO ps_order_detail (id_order, product_id, product_attribute_id, product_quantity) VALUES (1, 10, 0, 3), (1, 10, 0, 2), (2, 10, 0, 5)");
+
+        $repository = new SalesRepository($connection);
+        $aggregation = $repository->createSoldQuantityAggregation(null, false);
+
+        $rows = $connection->executeQuery('SELECT * FROM (' . $aggregation->getSql() . ') sales')->fetchAllAssociative();
+
+        self::assertCount(1, $rows);
+        self::assertSame(10, (int) $rows[0]['product_id']);
+        self::assertSame(5, (int) $rows[0]['sold_qty']);
+    }
+
+    public function testCreateSoldQuantityAggregationWithDateLimitAndCombination(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_orders (id_order, valid, date_add) VALUES (1, 1, '2024-01-05'), (2, 1, '2023-12-01')");
+        $connection->executeStatement("INSERT INTO ps_order_detail (id_order, product_id, product_attribute_id, product_quantity) VALUES (1, 20, 5, 4), (2, 20, 5, 10)");
+
+        $repository = new SalesRepository($connection);
+        $aggregation = $repository->createSoldQuantityAggregation(new DateTimeImmutable('2024-01-01'), true);
+
+        $rows = $connection->executeQuery('SELECT * FROM (' . $aggregation->getSql() . ') sales', $aggregation->getParameters())->fetchAllAssociative();
+
+        self::assertCount(1, $rows);
+        self::assertSame(20, (int) $rows[0]['product_id']);
+        self::assertSame(5, (int) $rows[0]['product_attribute_id']);
+        self::assertSame(4, (int) $rows[0]['sold_qty']);
+    }
+
+    private function createSchema($connection): void
+    {
+        $connection->executeStatement('CREATE TABLE ps_orders (id_order INTEGER PRIMARY KEY, valid INTEGER, date_add TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_order_detail (id_order INTEGER, product_id INTEGER, product_attribute_id INTEGER, product_quantity INTEGER)');
+    }
+}

--- a/tests/Infrastructure/Repository/StockRepositoryTest.php
+++ b/tests/Infrastructure/Repository/StockRepositoryTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Everblock\Tools\Tests\Infrastructure\Repository;
+
+use Doctrine\DBAL\DriverManager;
+use Everblock\Tools\Dto\Product\LowStockFilters;
+use Everblock\Tools\Infrastructure\Repository\SalesRepository;
+use Everblock\Tools\Infrastructure\Repository\StockRepository;
+use PHPUnit\Framework\TestCase;
+
+final class StockRepositoryTest extends TestCase
+{
+    public function testFindLowStockProductsByProduct(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_product (id_product, id_manufacturer, date_add) VALUES (1, 0, '2024-01-01'), (2, 0, '2024-01-02')");
+        $connection->executeStatement("INSERT INTO ps_product_shop (id_product, id_shop, active, visibility, available_for_order, price, position) VALUES (1, 1, 1, 'both', 1, 10, 1), (2, 1, 1, 'catalog', 1, 12, 2)");
+        $connection->executeStatement("INSERT INTO ps_product_lang (id_product, id_lang, id_shop, name) VALUES (1, 1, 1, 'First'), (2, 1, 1, 'Second')");
+        $connection->executeStatement("INSERT INTO ps_stock_available (id_product, id_product_attribute, id_shop, id_shop_group, quantity) VALUES (1, 0, 1, 1, 2), (2, 0, 1, 1, 6)");
+
+        $salesRepository = new SalesRepository($connection);
+        $repository = new StockRepository($connection, $salesRepository);
+
+        $filters = new LowStockFilters(
+            shopId: 1,
+            shopGroupId: 1,
+            languageId: 1,
+            threshold: 5,
+            comparisonOperator: '<=',
+            limit: 10,
+            offset: 0,
+            orderBy: 'qty',
+            orderDirection: 'asc',
+            days: 0,
+            categoryIds: [],
+            manufacturerIds: [],
+            visibilities: ['both', 'catalog'],
+            availableOnly: true,
+            granularity: LowStockFilters::GRANULARITY_PRODUCT,
+        );
+
+        $result = $repository->findLowStockProducts($filters);
+        $products = $result->toArray();
+
+        self::assertCount(1, $products);
+        self::assertSame(1, $products[0]->getProductId());
+        self::assertNull($products[0]->getProductAttributeId());
+        self::assertSame(2, $products[0]->getQuantity());
+    }
+
+    public function testFindLowStockProductsByCombinationOrderedBySales(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+        $this->createSchema($connection);
+
+        $connection->executeStatement("INSERT INTO ps_product (id_product, id_manufacturer, date_add) VALUES (10, 0, '2024-01-01')");
+        $connection->executeStatement("INSERT INTO ps_product_shop (id_product, id_shop, active, visibility, available_for_order, price, position) VALUES (10, 1, 1, 'both', 1, 15, 1)");
+        $connection->executeStatement("INSERT INTO ps_product_lang (id_product, id_lang, id_shop, name) VALUES (10, 1, 1, 'Variant')");
+        $connection->executeStatement("INSERT INTO ps_stock_available (id_product, id_product_attribute, id_shop, id_shop_group, quantity) VALUES (10, 5, 1, 1, 3), (10, 6, 1, 1, 8)");
+        $connection->executeStatement("INSERT INTO ps_orders (id_order, valid, date_add) VALUES (1, 1, '2024-01-01'), (2, 1, '2024-01-02')");
+        $connection->executeStatement("INSERT INTO ps_order_detail (id_order, product_id, product_attribute_id, product_quantity) VALUES (1, 10, 5, 4), (2, 10, 6, 10)");
+
+        $salesRepository = new SalesRepository($connection);
+        $repository = new StockRepository($connection, $salesRepository);
+
+        $filters = new LowStockFilters(
+            shopId: 1,
+            shopGroupId: 1,
+            languageId: 1,
+            threshold: 10,
+            comparisonOperator: '<=',
+            limit: 10,
+            offset: 0,
+            orderBy: 'sales',
+            orderDirection: 'desc',
+            days: 0,
+            categoryIds: [],
+            manufacturerIds: [],
+            visibilities: ['both', 'catalog'],
+            availableOnly: true,
+            granularity: LowStockFilters::GRANULARITY_COMBINATION,
+        );
+
+        $result = $repository->findLowStockProducts($filters);
+        $products = $result->toArray();
+
+        self::assertCount(1, $products);
+        self::assertSame(10, $products[0]->getProductId());
+        self::assertSame(5, $products[0]->getProductAttributeId());
+        self::assertSame(3, $products[0]->getQuantity());
+        self::assertSame(4, $products[0]->getSoldQuantity());
+    }
+
+    private function createSchema($connection): void
+    {
+        $connection->executeStatement('CREATE TABLE ps_product (id_product INTEGER PRIMARY KEY, id_manufacturer INTEGER, date_add TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_product_shop (id_product INTEGER, id_shop INTEGER, active INTEGER, visibility TEXT, available_for_order INTEGER, price REAL, position INTEGER)');
+        $connection->executeStatement('CREATE TABLE ps_product_lang (id_product INTEGER, id_lang INTEGER, id_shop INTEGER, name TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_stock_available (id_product INTEGER, id_product_attribute INTEGER, id_shop INTEGER, id_shop_group INTEGER, quantity INTEGER)');
+        $connection->executeStatement('CREATE TABLE ps_category_product (id_category INTEGER, id_product INTEGER)');
+        $connection->executeStatement('CREATE TABLE ps_orders (id_order INTEGER PRIMARY KEY, valid INTEGER, date_add TEXT)');
+        $connection->executeStatement('CREATE TABLE ps_order_detail (id_order INTEGER, product_id INTEGER, product_attribute_id INTEGER, product_quantity INTEGER)');
+    }
+}


### PR DESCRIPTION
## Summary
- introduce value objects for product identifiers, tag filters, and low stock results
- add DBAL repositories for tag-based product lookup, stock, sales aggregation, and product presentation
- migrate products-by-tag and low-stock shortcodes to new handlers using ShortcodeRenderingContext instead of legacy Context
- register new services and add targeted repository unit tests

## Testing
- ./vendor/bin/phpunit *(fails: binary unavailable because project dependencies are not installed in the lock file)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c36ab50c83228e85dc2defcec10f