### PR TITLE
Add Symfony cart add controller and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Ever Block now exposes modal and shortcode data through dedicated Doctrine repos
 - `[everstore id="4"]`: Display store information for store ID 4 (several IDs can be separated with commas). Required parameter: `id`.
 - `[video url="https://www.youtube.com/embed/35kwlY_RR08?si=QfwsUt9sEukni0Gj"]`: Display a YouTube iframe of the video whose sharing URL is in the parameter. Required parameter: `url`.
 - `[everaddtocart ref="1234" text="Add me to cart"]`: Create an add to cart button for product reference 1234. Required parameter: `ref`. Optional parameter: `text`.
+  The generated link targets the Symfony route `/everblock/cart/add`, which accepts `id_product`, `id_product_attribute` and `qty` query parameters and redirects visitors to the cart summary. When the request is performed via AJAX the controller returns a JSON payload containing the operation status and the redirect URL.
 - `[everfaq tag="faq1"]`: Show FAQs related to the `tag`. Required parameter: `tag`.
 - `[productfeature id="2" nb="12" carousel="true"]`: Display products with feature ID 2. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.
 - `[productfeaturevalue id="2" nb="12" carousel="true"]`: Display products with feature value ID 2. Required parameter: `id`. Optional parameters: `nb`, `limit`, `carousel`, `orderby`, `orderway`.

--- a/config/routes.yml
+++ b/config/routes.yml
@@ -1,3 +1,7 @@
 everblock_admin:
     resource: "config/routes/everblock_admin.yml"
     prefix: /
+
+everblock_front:
+    resource: "config/routes/everblock_front.yml"
+    prefix: /

--- a/config/routes/everblock_front.yml
+++ b/config/routes/everblock_front.yml
@@ -1,0 +1,4 @@
+everblock_cart_add:
+    path: /everblock/cart/add
+    controller: Everblock\Tools\Controller\AddToCartController::add
+    methods: [GET, POST]

--- a/config/services.yml
+++ b/config/services.yml
@@ -211,6 +211,18 @@ services:
             $navigationBuilder: '@Everblock\\Tools\\Service\\Admin\\NavigationBuilder'
         tags: ['controller.service_arguments']
 
+    Everblock\Tools\Controller\AddToCartController:
+        arguments:
+            $cartManager: '@Everblock\\Tools\\Application\\Cart\\CartManager'
+            $router: '@router'
+        tags: ['controller.service_arguments']
+
+    Everblock\Tools\Application\Cart\CartManager:
+        arguments:
+            $context: '@prestashop.adapter.legacy.context'
+            $translator: '@translator'
+            $logger: '@?logger'
+
     Everblock\Tools\Shortcode\ShortcodeRenderer:
         public: true
         arguments:
@@ -635,11 +647,10 @@ services:
             - { name: 'everblock.shortcode_handler' }
 
     everblock.shortcode_handler.add_to_cart:
-        class: Everblock\Tools\Shortcode\Handler\CallbackShortcodeHandler
+        class: Everblock\Tools\Shortcode\Handler\AddToCartShortcodeHandler
         arguments:
-            $needle: '[everaddtocart'
-            $callback: ['EverblockTools', 'getAddToCartShortcode']
-            $argumentMap: ['context', 'module']
+            $router: '@router'
+            $translator: '@translator'
         tags:
             - { name: 'everblock.shortcode_handler' }
 

--- a/src/Application/Cart/CartManager.php
+++ b/src/Application/Cart/CartManager.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Everblock\Tools\Application\Cart;
+
+use Address;
+use Cart;
+use CartRule;
+use Context;
+use Exception;
+use Link;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class CartManager
+{
+    public function __construct(
+        private readonly Context $context,
+        private readonly TranslatorInterface $translator,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function addProduct(int $productId, int $productAttributeId = 0, int $quantity = 1): CartOperationResult
+    {
+        if ($productId <= 0) {
+            $message = $this->translator->trans('Unable to add the product to the cart.', [], 'Modules.Everblock.Shop');
+
+            return new CartOperationResult(false, $message, errors: [$message]);
+        }
+
+        $quantity = max(1, $quantity);
+
+        try {
+            $cart = $this->ensureCart();
+        } catch (Exception $exception) {
+            $this->logException($exception);
+            $message = $this->translator->trans('Unable to create a cart for this session.', [], 'Modules.Everblock.Shop');
+
+            $this->pushControllerError($message);
+
+            return new CartOperationResult(false, $message, errors: [$message]);
+        }
+
+        try {
+            $updated = $cart->updateQty($quantity, $productId, $productAttributeId);
+        } catch (Exception $exception) {
+            $this->logException($exception);
+            $updated = false;
+        }
+
+        if (!$updated) {
+            $message = $this->translator->trans('Unable to add the product to the cart.', [], 'Modules.Everblock.Shop');
+            $this->pushControllerError($message);
+
+            return new CartOperationResult(false, $message, errors: [$message]);
+        }
+
+        CartRule::autoRemoveFromCart($this->context);
+        CartRule::autoAddToCart($this->context);
+
+        $message = $this->translator->trans('Product added to cart successfully', [], 'Modules.Everblock.Shop');
+        $this->pushControllerSuccess($message);
+
+        return new CartOperationResult(true, $message, $this->resolveCartSummaryUrl());
+    }
+
+    private function ensureCart(): Cart
+    {
+        if (isset($this->context->cart) && $this->context->cart instanceof Cart && (int) $this->context->cart->id > 0) {
+            return $this->context->cart;
+        }
+
+        $cart = new Cart();
+        $cart->id_lang = (int) $this->context->language->id;
+        $cart->id_currency = (int) $this->context->currency->id;
+        $cart->id_shop_group = (int) $this->context->shop->id_shop_group;
+        $cart->id_shop = (int) $this->context->shop->id;
+        $cart->id_customer = (int) $this->context->customer->id;
+
+        if ($cart->id_customer > 0) {
+            $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+            $cart->id_address_invoice = (int) $cart->id_address_delivery;
+        } else {
+            $cart->id_address_delivery = 0;
+            $cart->id_address_invoice = 0;
+        }
+
+        if (!$cart->add()) {
+            throw new Exception('Failed to create cart');
+        }
+
+        $this->context->cart = $cart;
+
+        if (isset($this->context->cookie)) {
+            $this->context->cookie->id_cart = (int) $cart->id;
+            if (method_exists($this->context->cookie, 'write')) {
+                $this->context->cookie->write();
+            }
+        }
+
+        CartRule::autoRemoveFromCart($this->context);
+        CartRule::autoAddToCart($this->context);
+
+        return $cart;
+    }
+
+    private function resolveCartSummaryUrl(): ?string
+    {
+        $link = $this->context->link;
+
+        if ($link instanceof Link) {
+            return $link->getPageLink('cart', true, null, ['action' => 'show']);
+        }
+
+        return null;
+    }
+
+    private function pushControllerSuccess(string $message): void
+    {
+        if (!isset($this->context->controller)) {
+            return;
+        }
+
+        if (!is_array($this->context->controller->success ?? null)) {
+            $this->context->controller->success = [];
+        }
+
+        $this->context->controller->success[] = $message;
+    }
+
+    private function pushControllerError(string $message): void
+    {
+        if (!isset($this->context->controller)) {
+            return;
+        }
+
+        if (!is_array($this->context->controller->errors ?? null)) {
+            $this->context->controller->errors = [];
+        }
+
+        $this->context->controller->errors[] = $message;
+    }
+
+    private function logException(Exception $exception): void
+    {
+        if ($this->logger !== null) {
+            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+        }
+    }
+}

--- a/src/Application/Cart/CartOperationResult.php
+++ b/src/Application/Cart/CartOperationResult.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Everblock\Tools\Application\Cart;
+
+final class CartOperationResult
+{
+    /**
+     * @param string[] $errors
+     */
+    public function __construct(
+        private readonly bool $success,
+        private readonly string $message,
+        private readonly ?string $redirectUrl = null,
+        private readonly array $errors = []
+    ) {
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getRedirectUrl(): ?string
+    {
+        return $this->redirectUrl;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Controller/AddToCartController.php
+++ b/src/Controller/AddToCartController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Everblock\Tools\Controller;
+
+use Everblock\Tools\Application\Cart\CartManager;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Throwable;
+
+final class AddToCartController
+{
+    public function __construct(
+        private readonly CartManager $cartManager,
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    public function add(Request $request): Response
+    {
+        $productId = (int) $request->get('id_product', 0);
+        $productAttributeId = (int) $request->get('id_product_attribute', 0);
+        $quantity = (int) $request->get('qty', 1);
+
+        $result = $this->cartManager->addProduct($productId, $productAttributeId, $quantity);
+
+        if ($this->shouldReturnJson($request)) {
+            return new JsonResponse([
+                'success' => $result->isSuccess(),
+                'message' => $result->getMessage(),
+                'errors' => $result->getErrors(),
+                'redirect' => $result->getRedirectUrl(),
+            ], $result->isSuccess() ? Response::HTTP_OK : Response::HTTP_BAD_REQUEST);
+        }
+
+        $target = $result->getRedirectUrl();
+        if ($target === null || $target === '') {
+            $target = $request->headers->get('referer');
+        }
+
+        if ($target === null || $target === '') {
+            try {
+                $target = $this->router->generate('index', [], UrlGeneratorInterface::ABSOLUTE_PATH);
+            } catch (Throwable) {
+                $target = '/';
+            }
+        }
+
+        return new RedirectResponse($target);
+    }
+
+    private function shouldReturnJson(Request $request): bool
+    {
+        if ($request->isXmlHttpRequest()) {
+            return true;
+        }
+
+        $format = $request->getRequestFormat(null);
+        if ($format === 'json') {
+            return true;
+        }
+
+        $accept = $request->headers->get('Accept');
+        if (is_string($accept) && str_contains($accept, 'application/json')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Shortcode/Handler/AddToCartShortcodeHandler.php
+++ b/src/Shortcode/Handler/AddToCartShortcodeHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Everblock\Tools\Shortcode\Handler;
+
+use Db;
+use Everblock;
+use Everblock\Tools\Shortcode\ShortcodeHandlerInterface;
+use Everblock\Tools\Shortcode\ShortcodeRenderingContext;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AddToCartShortcodeHandler implements ShortcodeHandlerInterface
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function supports(string $content): bool
+    {
+        return str_contains($content, '[everaddtocart');
+    }
+
+    public function render(string $content, ShortcodeRenderingContext $context, Everblock $module): string
+    {
+        return (string) preg_replace_callback(
+            '/\[everaddtocart\s+ref="([^"]+)"(?:\s+text="([^"]*)")?\]/i',
+            function (array $matches) use ($module): string {
+                $reference = trim($matches[1]);
+                if ($reference === '') {
+                    return '';
+                }
+
+                $label = isset($matches[2]) && $matches[2] !== ''
+                    ? $matches[2]
+                    : $this->translator->trans('Add to cart', [], 'Modules.Everblock.Shop');
+
+                $productData = $this->findProductByReference($reference);
+                if ($productData === null) {
+                    return '';
+                }
+
+                $url = $this->router->generate(
+                    'everblock_cart_add',
+                    [
+                        'id_product' => $productData['product_id'],
+                        'id_product_attribute' => $productData['product_attribute_id'],
+                        'qty' => 1,
+                    ],
+                    UrlGeneratorInterface::ABSOLUTE_PATH
+                );
+
+                return sprintf(
+                    '<a href="%s" class="btn btn-primary ">%s</a>',
+                    htmlspecialchars($url, ENT_QUOTES, 'UTF-8'),
+                    htmlspecialchars($label, ENT_QUOTES, 'UTF-8')
+                );
+            },
+            $content
+        );
+    }
+
+    /**
+     * @return array{product_id: int, product_attribute_id: int}|null
+     */
+    private function findProductByReference(string $reference): ?array
+    {
+        $db = Db::getInstance();
+        $productId = (int) $db->getValue(
+            sprintf(
+                "SELECT `id_product` FROM `%sproduct` WHERE `reference` = '%s'",
+                _DB_PREFIX_,
+                pSQL($reference)
+            )
+        );
+
+        if ($productId > 0) {
+            return [
+                'product_id' => $productId,
+                'product_attribute_id' => 0,
+            ];
+        }
+
+        $result = $db->getRow(
+            sprintf(
+                "SELECT pa.`id_product`, pa.`id_product_attribute` FROM `%sproduct_attribute` pa WHERE pa.`reference` = '%s'",
+                _DB_PREFIX_,
+                pSQL($reference)
+            )
+        );
+
+        if ($result === false || !isset($result['id_product'])) {
+            return null;
+        }
+
+        return [
+            'product_id' => (int) $result['id_product'],
+            'product_attribute_id' => (int) $result['id_product_attribute'],
+        ];
+    }
+}

--- a/tests/Controller/AddToCartControllerTest.php
+++ b/tests/Controller/AddToCartControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Everblock\Tools\Tests\Controller;
+
+use Everblock\Tools\Application\Cart\CartManager;
+use Everblock\Tools\Application\Cart\CartOperationResult;
+use Everblock\Tools\Controller\AddToCartController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+final class AddToCartControllerTest extends TestCase
+{
+    public function testAjaxRequestReturnsJsonResponse(): void
+    {
+        $manager = $this->createMock(CartManager::class);
+        $manager->expects(self::once())
+            ->method('addProduct')
+            ->with(42, 11, 3)
+            ->willReturn(new CartOperationResult(true, 'ok', '/cart'));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::never())->method('generate');
+
+        $controller = new AddToCartController($manager, $router);
+        $request = new Request([
+            'id_product' => 42,
+            'id_product_attribute' => 11,
+            'qty' => 3,
+        ], [], [], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+
+        $response = $controller->add($request);
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame([
+            'success' => true,
+            'message' => 'ok',
+            'errors' => [],
+            'redirect' => '/cart',
+        ], $payload);
+    }
+
+    public function testRedirectUsesResultUrlWhenAvailable(): void
+    {
+        $manager = $this->createMock(CartManager::class);
+        $manager->expects(self::once())
+            ->method('addProduct')
+            ->with(51, 0, 1)
+            ->willReturn(new CartOperationResult(true, 'added', '/cart'));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::never())->method('generate');
+
+        $controller = new AddToCartController($manager, $router);
+        $request = new Request(['id_product' => 51]);
+
+        $response = $controller->add($request);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/cart', $response->getTargetUrl());
+    }
+
+    public function testRedirectFallsBackToRouterWhenNoReferer(): void
+    {
+        $manager = $this->createMock(CartManager::class);
+        $manager->expects(self::once())
+            ->method('addProduct')
+            ->with(19, 0, 1)
+            ->willReturn(new CartOperationResult(false, 'ko'));
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with('index', [], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/');
+
+        $controller = new AddToCartController($manager, $router);
+        $request = new Request(['id_product' => 19]);
+
+        $response = $controller->add($request);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/', $response->getTargetUrl());
+    }
+}


### PR DESCRIPTION
## Summary
- expose a new /everblock/cart/add route handled by AddToCartController and CartManager to centralise cart mutations
- update the everaddtocart shortcode to generate URLs with Symfony's router and document the new endpoint
- add functional tests for the controller response flow

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l src/Application/Cart/CartManager.php`
- `php -l src/Controller/AddToCartController.php`
- `php -l src/Shortcode/Handler/AddToCartShortcodeHandler.php`


------
https://chatgpt.com/codex/tasks/task_e_68f3cd7724808322bb2ee0784969e014