### PR TITLE
Restore admin confirmation helper for PrestaShop 8

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -21,11 +21,14 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
+require_once _PS_MODULE_DIR_ . 'everblock/controllers/admin/EverblockConfirmationTrait.php';
 
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockController extends ModuleAdminController
 {
+    use EverblockConfirmationTrait;
+
     private $html;
     public function __construct()
     {

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -23,11 +23,14 @@ if (!defined('_PS_VERSION_')) {
 
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
+require_once _PS_MODULE_DIR_ . 'everblock/controllers/admin/EverblockConfirmationTrait.php';
 
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockFaqController extends ModuleAdminController
 {
+    use EverblockConfirmationTrait;
+
     private $html;
 
     public function __construct()

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -22,11 +22,14 @@ if (!defined('_PS_VERSION_')) {
 }
 
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
+require_once _PS_MODULE_DIR_ . 'everblock/controllers/admin/EverblockConfirmationTrait.php';
 
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockHookController extends ModuleAdminController
 {
+    use EverblockConfirmationTrait;
+
     private $html;
 
     public function __construct()

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -23,11 +23,14 @@ if (!defined('_PS_VERSION_')) {
 
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockShortcode.php';
+require_once _PS_MODULE_DIR_ . 'everblock/controllers/admin/EverblockConfirmationTrait.php';
 
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockShortcodeController extends ModuleAdminController
 {
+    use EverblockConfirmationTrait;
+
     private $html;
 
     public function __construct()

--- a/controllers/admin/EverblockConfirmationTrait.php
+++ b/controllers/admin/EverblockConfirmationTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+trait EverblockConfirmationTrait
+{
+    /**
+     * Restore the legacy displayConfirmation helper that was removed in newer PrestaShop versions.
+     *
+     * @param string|array $message
+     *
+     * @return string
+     */
+    protected function displayConfirmation($message)
+    {
+        if (!is_array($message)) {
+            $message = [$message];
+        }
+
+        $output = '';
+
+        foreach ($message as $item) {
+            if (empty($item)) {
+                continue;
+            }
+
+            $output .= '<div class="alert alert-success" role="alert">' . $item . '</div>';
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared trait that restores the legacy displayConfirmation helper that newer PrestaShop versions removed
- apply the trait to all module admin controllers so their notification rendering keeps working on PrestaShop 8

## Testing
- php -l controllers/admin/EverblockConfirmationTrait.php
- php -l controllers/admin/AdminEverBlockController.php
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l controllers/admin/AdminEverBlockHookController.php
- php -l controllers/admin/AdminEverBlockShortcodeController.php

------
https://chatgpt.com/codex/tasks/task_e_68f484c1ace8832295679d6f31534c9f