### PR TITLE
Migrate Ever Block admin to Symfony stack

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -1,0 +1,66 @@
+admin_everblock_index:
+    path: /everblock/list
+    methods: [GET, POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::indexAction'
+        _legacy_controller: 'AdminEverBlock'
+        _legacy_link: 'AdminEverBlock'
+
+admin_everblock_create:
+    path: /everblock/new
+    methods: [GET, POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::createAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_edit:
+    path: /everblock/{everBlockId}/edit
+    requirements:
+        everBlockId: '\\d+'
+    methods: [GET, POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::editAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_delete:
+    path: /everblock/{everBlockId}/delete
+    requirements:
+        everBlockId: '\\d+'
+    methods: [POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::deleteAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_duplicate:
+    path: /everblock/{everBlockId}/duplicate
+    requirements:
+        everBlockId: '\\d+'
+    methods: [POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::duplicateAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_export:
+    path: /everblock/{everBlockId}/export
+    requirements:
+        everBlockId: '\\d+'
+    methods: [GET]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::exportAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_toggle_status:
+    path: /everblock/{everBlockId}/toggle-status
+    requirements:
+        everBlockId: '\\d+'
+    methods: [POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::toggleStatusAction'
+        _legacy_controller: 'AdminEverBlock'
+
+admin_everblock_bulk:
+    path: /everblock/bulk
+    methods: [POST]
+    defaults:
+        _controller: 'Everblock\\Tools\\Controller\\Admin\\EverBlockController::bulkAction'
+        _legacy_controller: 'AdminEverBlock'

--- a/config/services.yml
+++ b/config/services.yml
@@ -45,3 +45,46 @@ services:
         tags:
             - { name: 'console.command' }
 
+    Everblock\Tools\Grid\Definition\Factory\EverBlockGridDefinitionFactory: ~
+
+    Everblock\Tools\Grid\Query\EverBlockQueryBuilder:
+        arguments:
+            - '@doctrine.dbal.default_connection'
+            - '@prestashop.adapter.legacy.context'
+
+    Everblock\Tools\Grid\Data\EverBlockGridDataFactory:
+        arguments:
+            - '@Everblock\Tools\Grid\Query\EverBlockQueryBuilder'
+
+    Everblock\Tools\Grid\Filters\EverBlockFilters: ~
+
+    Everblock\Tools\Form\Admin\EverBlockFormDataProvider: ~
+
+    Everblock\Tools\Form\Admin\EverBlockFormHandler:
+        arguments:
+            - '@form.factory'
+            - '@Everblock\Tools\Form\Admin\EverBlockFormDataProvider'
+            - '@Everblock\Tools\Service\EverBlockManager'
+
+    Everblock\Tools\Service\EverBlockManager: ~
+
+    everblock.grid.factory:
+        class: PrestaShop\PrestaShop\Core\Grid\GridFactory
+        arguments:
+            - '@Everblock\Tools\Grid\Definition\Factory\EverBlockGridDefinitionFactory'
+            - '@Everblock\Tools\Grid\Data\EverBlockGridDataFactory'
+            - '@prestashop.core.grid.filter.form_factory'
+            - '@prestashop.core.grid.presenter.grid_presenter'
+
+    Everblock\Tools\Controller\Admin\EverBlockController:
+        class: Everblock\Tools\Controller\Admin\EverBlockController
+        arguments:
+            - '@everblock.grid.factory'
+            - '@prestashop.core.grid.presenter.grid_presenter'
+            - '@Everblock\Tools\Service\EverBlockManager'
+            - '@Everblock\Tools\Form\Admin\EverBlockFormHandler'
+            - '@prestashop.adapter.legacy.context'
+            - '@?prestashop.core.grid.filter.filters_builder'
+        tags:
+            - { name: controller.service_arguments }
+

--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -24,8 +24,27 @@ require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
+/**
+ * @deprecated since 5.0.0. Use the Symfony based controller instead.
+ */
 class AdminEverBlockController extends ModuleAdminController
 {
+    public function init()
+    {
+        parent::init();
+
+        $symfonyUrl = $this->context->link->getAdminLink(
+            'AdminEverBlock',
+            true,
+            [],
+            [
+                'route' => 'admin_everblock_index',
+            ]
+        );
+
+        Tools::redirectAdmin($symfonyUrl);
+    }
+
     private $html;
     public function __construct()
     {

--- a/everblock.php
+++ b/everblock.php
@@ -206,7 +206,7 @@ class Everblock extends Module
             && $this->registerHook('beforeRenderingEverblockSpecialEvent')
             && $this->installModuleTab('AdminEverBlockParent', 'IMPROVE', $this->l('Ever Block'))
             && $this->installModuleTab('AdminEverBlockConfiguration', 'AdminEverBlockParent', $this->l('Configuration'))
-            && $this->installModuleTab('AdminEverBlock', 'AdminEverBlockParent', $this->l('HTML Blocks'))
+            && $this->installModuleTab('AdminEverBlock', 'AdminEverBlockParent', $this->l('HTML Blocks'), 'admin_everblock_index')
             && $this->installModuleTab('AdminEverBlockHook', 'AdminEverBlockParent', $this->l('Hooks'))
             && $this->installModuleTab('AdminEverBlockShortcode', 'AdminEverBlockParent', $this->l('Shortcodes'))
             && $this->installModuleTab('AdminEverBlockFaq', 'AdminEverBlockParent', $this->l('FAQ'));
@@ -448,7 +448,7 @@ class Everblock extends Module
         );
     }
 
-    protected function installModuleTab($tabClass, $parent, $tabName)
+    protected function installModuleTab($tabClass, $parent, $tabName, $routeName = null)
     {
         $tab = new Tab();
         $tab->active = 1;
@@ -456,6 +456,9 @@ class Everblock extends Module
         $tab->id_parent = (int) Tab::getIdFromClassName($parent);
         $tab->position = Tab::getNewLastPosition($tab->id_parent);
         $tab->module = $this->name;
+        if ($routeName) {
+            $tab->route_name = $routeName;
+        }
         if ($tabClass == 'AdminEverBlockParent') {
             $tab->icon = 'icon-team-ever';
         }
@@ -649,10 +652,18 @@ class Everblock extends Module
             $tab->module = $this->name;
             $tab->id_parent = Tab::getIdFromClassName('AdminEverBlockParent');
             $tab->position = Tab::getNewLastPosition($tab->id_parent);
+            $tab->route_name = 'admin_everblock_index';
             foreach (Language::getLanguages(false) as $lang) {
-                $tab->name[(int) $lang['id_lang']] = $this->l('HTML blocks management');
+                $tab->name[(int) $lang['id_lang']] = $this->l('HTML Blocks');
             }
             $tab->add();
+        } else {
+            $tab = new Tab($id_tab);
+            $tab->route_name = 'admin_everblock_index';
+            foreach (Language::getLanguages(false) as $lang) {
+                $tab->name[(int) $lang['id_lang']] = $this->l('HTML Blocks');
+            }
+            $tab->update();
         }
         // Vérifier si l'onglet "Hook management" existe déjà
         $id_tab = Tab::getIdFromClassName('AdminEverBlockHook');

--- a/src/Tools/Controller/Admin/EverBlockController.php
+++ b/src/Tools/Controller/Admin/EverBlockController.php
@@ -1,0 +1,400 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Controller\Admin;
+
+use EverBlockClass;
+use Everblock\Tools\Form\Admin\EverBlockFormHandler;
+use Everblock\Tools\Grid\Filters\EverBlockFilters;
+use Everblock\Tools\Service\EverBlockManager;
+use Everblock\Tools\Service\ShortcodeDocumentationProvider;
+use Module;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Presenter\GridPresenterInterface;
+use PrestaShop\PrestaShop\Core\Search\Builder\FiltersBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class EverBlockController extends FrameworkBundleAdminController
+{
+    /** @var GridFactoryInterface */
+    private $gridFactory;
+
+    /** @var GridPresenterInterface */
+    private $gridPresenter;
+
+    /** @var EverBlockManager */
+    private $manager;
+
+    /** @var EverBlockFormHandler */
+    private $formHandler;
+
+    /** @var LegacyContext */
+    private $legacyContext;
+
+    /** @var FiltersBuilderInterface|null */
+    private $filtersBuilder;
+
+    public function __construct(
+        GridFactoryInterface $gridFactory,
+        GridPresenterInterface $gridPresenter,
+        EverBlockManager $manager,
+        EverBlockFormHandler $formHandler,
+        LegacyContext $legacyContext,
+        ?FiltersBuilderInterface $filtersBuilder = null
+    ) {
+        $this->gridFactory = $gridFactory;
+        $this->gridPresenter = $gridPresenter;
+        $this->manager = $manager;
+        $this->formHandler = $formHandler;
+        $this->legacyContext = $legacyContext;
+        $this->filtersBuilder = $filtersBuilder;
+    }
+
+    public function indexAction(Request $request)
+    {
+        $filters = $this->resolveFilters($request);
+
+        if ($request->isMethod('POST')) {
+            $bulkPayload = $this->extractBulkActionData($request);
+            if (null !== $bulkPayload) {
+                [$bulkAction, $selection] = $bulkPayload;
+                $this->handleBulkAction($bulkAction, $selection);
+
+                return $this->redirectToRoute('admin_everblock_index', $request->query->all());
+            }
+        }
+
+        $grid = $this->gridFactory->getGrid($filters);
+        $gridView = $this->gridPresenter->present($grid);
+
+        $context = $this->legacyContext->getContext();
+        $module = Module::getInstanceByName('everblock');
+
+        return $this->render('@Modules/everblock/views/templates/admin/everblock/index.html.twig', [
+            'grid' => $gridView,
+            'stats' => $this->getModuleStatistics(),
+            'module_version' => $module ? $module->version : '',
+            'module_name' => $module ? $module->displayName : 'Everblock',
+            'header_links' => $this->getHeaderLinks($module),
+            'shortcode_docs' => $module ? ShortcodeDocumentationProvider::getDocumentation($module) : [],
+            'can_add_block' => $context->employee && $context->employee->can('add', 'AdminEverBlock'),
+        ]);
+    }
+
+    public function createAction(Request $request)
+    {
+        list($form, $block) = $this->formHandler->handle($request);
+
+        if ($block instanceof EverBlockClass) {
+            $this->addFlash('success', $this->trans('Block successfully created.', 'Modules.Everblock.Admin'));
+
+            return $this->redirectToRoute('admin_everblock_edit', [
+                'everBlockId' => (int) $block->id,
+            ]);
+        }
+
+        return $this->render('@Modules/everblock/views/templates/admin/everblock/form.html.twig', [
+            'form' => $form->createView(),
+            'tabs' => $this->getFormTabs(),
+            'is_edit' => false,
+        ]);
+    }
+
+    public function editAction(Request $request, int $everBlockId)
+    {
+        list($form, $block) = $this->formHandler->handle($request, $everBlockId);
+
+        if ($block instanceof EverBlockClass) {
+            $this->addFlash('success', $this->trans('Block successfully updated.', 'Modules.Everblock.Admin'));
+
+            return $this->redirectToRoute('admin_everblock_edit', [
+                'everBlockId' => (int) $block->id,
+            ]);
+        }
+
+        return $this->render('@Modules/everblock/views/templates/admin/everblock/form.html.twig', [
+            'form' => $form->createView(),
+            'tabs' => $this->getFormTabs(),
+            'is_edit' => true,
+        ]);
+    }
+
+    public function deleteAction(int $everBlockId)
+    {
+        if ($this->manager->delete($everBlockId)) {
+            $this->addFlash('success', $this->trans('Block deleted successfully.', 'Modules.Everblock.Admin'));
+        } else {
+            $this->addFlash('error', $this->trans('Unable to delete the block.', 'Modules.Everblock.Admin'));
+        }
+
+        return $this->redirectToRoute('admin_everblock_index');
+    }
+
+    public function duplicateAction(int $everBlockId)
+    {
+        try {
+            $this->manager->duplicate($everBlockId);
+            $this->addFlash('success', $this->trans('Block duplicated successfully.', 'Modules.Everblock.Admin'));
+        } catch (\Exception $e) {
+            $this->addFlash('error', $this->trans('Unable to duplicate the block.', 'Modules.Everblock.Admin'));
+        }
+
+        return $this->redirectToRoute('admin_everblock_index');
+    }
+
+    public function exportAction(int $everBlockId)
+    {
+        try {
+            $sql = $this->manager->exportSql($everBlockId);
+        } catch (\Exception $exception) {
+            $this->addFlash('error', $this->trans('Unable to export the block.', 'Modules.Everblock.Admin'));
+
+            return $this->redirectToRoute('admin_everblock_index');
+        }
+
+        $response = new Response($sql);
+        $response->headers->set('Content-Type', 'application/sql');
+        $response->headers->set('Content-Disposition', 'attachment; filename="everblock_' . (int) $everBlockId . '.sql"');
+
+        return $response;
+    }
+
+    public function toggleStatusAction(int $everBlockId)
+    {
+        if ($this->manager->toggleStatus($everBlockId)) {
+            $this->addFlash('success', $this->trans('Status updated.', 'Modules.Everblock.Admin'));
+        } else {
+            $this->addFlash('error', $this->trans('Unable to update status.', 'Modules.Everblock.Admin'));
+        }
+
+        return $this->redirectToRoute('admin_everblock_index');
+    }
+
+    public function bulkAction(Request $request)
+    {
+        $bulkPayload = $this->extractBulkActionData($request);
+        if (null !== $bulkPayload) {
+            [$action, $selection] = $bulkPayload;
+            $this->handleBulkAction($action, $selection);
+        }
+
+        return $this->redirectToRoute('admin_everblock_index');
+    }
+
+    private function handleBulkAction(string $action, array $ids): void
+    {
+        switch ($action) {
+            case 'duplicate':
+                $this->manager->bulkDuplicate($ids);
+                $this->addFlash('success', $this->trans('Selected blocks duplicated.', 'Modules.Everblock.Admin'));
+                break;
+            case 'delete':
+                $this->manager->bulkDelete($ids);
+                $this->addFlash('success', $this->trans('Selected blocks deleted.', 'Modules.Everblock.Admin'));
+                break;
+            case 'enable':
+                $this->manager->bulkToggle($ids, true);
+                $this->addFlash('success', $this->trans('Selected blocks enabled.', 'Modules.Everblock.Admin'));
+                break;
+            case 'disable':
+                $this->manager->bulkToggle($ids, false);
+                $this->addFlash('success', $this->trans('Selected blocks disabled.', 'Modules.Everblock.Admin'));
+                break;
+            default:
+                $this->addFlash('error', $this->trans('Unknown bulk action.', 'Modules.Everblock.Admin'));
+        }
+    }
+
+    private function resolveFilters(Request $request): EverBlockFilters
+    {
+        if ($this->filtersBuilder instanceof FiltersBuilderInterface) {
+            try {
+                $filters = $this->filtersBuilder->buildFilters(
+                    EverBlockFilters::class,
+                    $request->query->all()
+                );
+
+                if ($filters instanceof EverBlockFilters) {
+                    return $filters;
+                }
+            } catch (Throwable $exception) {
+                // fall back to manual instantiation if the filters builder is not compatible
+            }
+        }
+
+        return new EverBlockFilters($request->query->all());
+    }
+
+    private function extractBulkActionData(Request $request): ?array
+    {
+        $action = $request->request->get('bulk_action');
+        $selection = $this->normalizeBulkSelection($request->request->all('bulk_selected'));
+
+        if ($action && !empty($selection)) {
+            return [$action, $selection];
+        }
+
+        $bulkFormPayloads = [];
+        $bulkFormPayloads[] = $request->request->get('grid', []);
+        $bulkFormPayloads[] = $request->request->get('ever_block', []);
+
+        foreach ($bulkFormPayloads as $payload) {
+            if (!is_array($payload) || empty($payload)) {
+                continue;
+            }
+
+            if (isset($payload['bulk_action']) && !$action) {
+                $action = (string) $payload['bulk_action'];
+            }
+
+            if (isset($payload['selected'])) {
+                $selection = $this->normalizeBulkSelection($payload['selected']);
+            }
+
+            if (isset($payload['bulk_selected'])) {
+                $selection = $this->normalizeBulkSelection($payload['bulk_selected']);
+            }
+
+            if (isset($payload['actions']['bulk']) && is_array($payload['actions']['bulk'])) {
+                foreach ($payload['actions']['bulk'] as $bulkConfig) {
+                    if (!$action && isset($bulkConfig['submit_action'])) {
+                        $action = (string) $bulkConfig['submit_action'];
+                    }
+                    if (isset($bulkConfig['selected'])) {
+                        $selection = $this->normalizeBulkSelection($bulkConfig['selected']);
+                    }
+                }
+            }
+        }
+
+        if ($action && !empty($selection)) {
+            return [$action, $selection];
+        }
+
+        return null;
+    }
+
+    private function normalizeBulkSelection($selection): array
+    {
+        if (!is_array($selection)) {
+            return [];
+        }
+
+        if (isset($selection['data']) && is_array($selection['data'])) {
+            $selection = $selection['data'];
+        }
+
+        if (isset($selection['ids']) && is_array($selection['ids'])) {
+            $selection = $selection['ids'];
+        }
+
+        if (isset($selection['selected']) && is_array($selection['selected'])) {
+            $selection = $selection['selected'];
+        }
+
+        $normalized = [];
+        foreach ($selection as $key => $value) {
+            if (is_array($value) && isset($value['id'])) {
+                $normalized[] = (int) $value['id'];
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $normalized[] = (int) $value;
+            }
+        }
+
+        return array_values(array_unique(array_filter($normalized, static function ($id) {
+            return $id > 0;
+        })));
+    }
+
+    private function getModuleStatistics(): array
+    {
+        $idShop = (int) $this->legacyContext->getContext()->shop->id;
+        $stats = [
+            'blocks_total' => $this->countTableRecords('everblock', 'id_shop = ' . $idShop),
+            'blocks_active' => $this->countTableRecords('everblock', 'id_shop = ' . $idShop . ' AND active = 1'),
+            'shortcodes' => $this->countTableRecords('everblock_shortcode', 'id_shop = ' . $idShop),
+            'faqs' => $this->countTableRecords('everblock_faq', 'id_shop = ' . $idShop),
+            'tabs' => $this->countTableRecords('everblock_tabs', 'id_shop = ' . $idShop),
+            'flags' => $this->countTableRecords('everblock_flags', 'id_shop = ' . $idShop),
+            'modals' => $this->countTableRecords('everblock_modal', 'id_shop = ' . $idShop),
+            'game_sessions' => $this->countTableRecords('everblock_game_play'),
+        ];
+
+        return $stats;
+    }
+
+    private function countTableRecords(string $table, string $whereClause = ''): int
+    {
+        if (!$this->moduleTableExists($table)) {
+            return 0;
+        }
+
+        $db = \Db::getInstance(_PS_USE_SQL_SLAVE_);
+        $tableName = _DB_PREFIX_ . $table;
+
+        $sql = 'SELECT COUNT(*) FROM `' . bqSQL($tableName) . '`';
+        if ($whereClause !== '') {
+            $sql .= ' WHERE ' . $whereClause;
+        }
+
+        return (int) $db->getValue($sql);
+    }
+
+    private function moduleTableExists(string $table): bool
+    {
+        $db = \Db::getInstance(_PS_USE_SQL_SLAVE_);
+        $tableName = _DB_PREFIX_ . $table;
+        $pattern = str_replace(['_', '%'], ['\\_', '\\%'], pSQL($tableName));
+        $sql = sprintf("SHOW TABLES LIKE '%s'", $pattern);
+
+        return (bool) $db->executeS($sql);
+    }
+
+    private function getHeaderLinks(?Module $module): array
+    {
+        $context = $this->legacyContext->getContext();
+        $links = [];
+
+        $links['modules'] = $context->link->getAdminLink('AdminModules');
+        $links['module_configuration'] = $context->link->getAdminLink('AdminModules', true, [], ['configure' => 'everblock']);
+        $links['block_admin'] = $context->link->getAdminLink('AdminEverBlock');
+        $links['faq_admin'] = $context->link->getAdminLink('AdminEverBlockFaq');
+        $links['hook_admin'] = $context->link->getAdminLink('AdminEverBlockHook');
+        $links['shortcode_admin'] = $context->link->getAdminLink('AdminEverBlockShortcode');
+        $links['donation'] = 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE';
+
+        return $links;
+    }
+
+    private function getFormTabs(): array
+    {
+        return [
+            'general' => $this->trans('General', 'Modules.Everblock.Admin'),
+            'targeting' => $this->trans('Targeting', 'Modules.Everblock.Admin'),
+            'display' => $this->trans('Display', 'Modules.Everblock.Admin'),
+            'modal' => $this->trans('Modal', 'Modules.Everblock.Admin'),
+            'schedule' => $this->trans('Schedule', 'Modules.Everblock.Admin'),
+        ];
+    }
+
+}

--- a/src/Tools/Form/Admin/EverBlockFormDataProvider.php
+++ b/src/Tools/Form/Admin/EverBlockFormDataProvider.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Form\Admin;
+
+use Category;
+use CMSCategory;
+use Context;
+use EverBlockClass;
+use Group;
+use Hook;
+use Language;
+use Manufacturer;
+use Supplier;
+
+class EverBlockFormDataProvider
+{
+    public function getData(?int $idEverBlock = null): array
+    {
+        $context = Context::getContext();
+        $languages = Language::getLanguages(false);
+
+        $data = [
+            'name' => '',
+            'content' => [],
+            'custom_code' => [],
+            'id_hook' => null,
+            'only_home' => false,
+            'only_category' => false,
+            'only_category_product' => false,
+            'only_manufacturer' => false,
+            'only_supplier' => false,
+            'only_cms_category' => false,
+            'obfuscate_link' => false,
+            'add_container' => true,
+            'lazyload' => false,
+            'categories' => [],
+            'manufacturers' => [],
+            'suppliers' => [],
+            'cms_categories' => [],
+            'groups' => [],
+            'position' => 0,
+            'background' => '',
+            'css_class' => '',
+            'data_attribute' => '',
+            'bootstrap_class' => 0,
+            'device' => 0,
+            'delay' => 0,
+            'timeout' => 0,
+            'modal' => 0,
+            'date_start' => null,
+            'date_end' => null,
+            'active' => true,
+        ];
+
+        foreach ($languages as $language) {
+            $idLang = (int) $language['id_lang'];
+            $data['content'][$idLang] = '';
+            $data['custom_code'][$idLang] = '';
+        }
+
+        if ($idEverBlock) {
+            $block = new EverBlockClass($idEverBlock);
+            if ($block->id) {
+                $data['name'] = $block->name;
+                $data['id_hook'] = $block->id_hook;
+                $data['only_home'] = (bool) $block->only_home;
+                $data['only_category'] = (bool) $block->only_category;
+                $data['only_category_product'] = (bool) $block->only_category_product;
+                $data['only_manufacturer'] = (bool) $block->only_manufacturer;
+                $data['only_supplier'] = (bool) $block->only_supplier;
+                $data['only_cms_category'] = (bool) $block->only_cms_category;
+                $data['obfuscate_link'] = (bool) $block->obfuscate_link;
+                $data['add_container'] = (bool) $block->add_container;
+                $data['lazyload'] = (bool) $block->lazyload;
+                $data['categories'] = $block->categories ? json_decode($block->categories, true) ?: [] : [];
+                $data['manufacturers'] = $block->manufacturers ? json_decode($block->manufacturers, true) ?: [] : [];
+                $data['suppliers'] = $block->suppliers ? json_decode($block->suppliers, true) ?: [] : [];
+                $data['cms_categories'] = $block->cms_categories ? json_decode($block->cms_categories, true) ?: [] : [];
+                $data['groups'] = $block->groups ? json_decode($block->groups, true) ?: [] : [];
+                $data['position'] = (int) $block->position;
+                $data['background'] = $block->background;
+                $data['css_class'] = $block->css_class;
+                $data['data_attribute'] = $block->data_attribute;
+                $data['bootstrap_class'] = (int) $block->bootstrap_class;
+                $data['device'] = (int) $block->device;
+                $data['delay'] = (int) $block->delay;
+                $data['timeout'] = (int) $block->timeout;
+                $data['modal'] = (int) $block->modal;
+                $data['date_start'] = $block->date_start;
+                $data['date_end'] = $block->date_end;
+                $data['active'] = (bool) $block->active;
+
+                foreach ($languages as $language) {
+                    $idLang = (int) $language['id_lang'];
+                    $data['content'][$idLang] = $block->content[$idLang] ?? '';
+                    $data['custom_code'][$idLang] = $block->custom_code[$idLang] ?? '';
+                }
+            }
+        }
+
+        if (empty($data['groups'])) {
+            $data['groups'] = array_map('intval', $this->getGroupIds($context));
+        }
+
+        return $data;
+    }
+
+    public function getOptions(): array
+    {
+        return [
+            'hooks' => $this->getHookChoices(),
+            'categories' => $this->getCategoryChoices(),
+            'manufacturers' => $this->getManufacturerChoices(),
+            'suppliers' => $this->getSupplierChoices(),
+            'cms_categories' => $this->getCmsCategoryChoices(),
+            'groups' => $this->getGroupChoices(),
+            'bootstrap_sizes' => $this->getBootstrapSizes(),
+            'devices' => $this->getDeviceChoices(),
+            'languages' => Language::getLanguages(false),
+        ];
+    }
+
+    private function getHookChoices(): array
+    {
+        $hooks = Hook::getHooks();
+        $choices = [];
+        foreach ($hooks as $hook) {
+            $label = sprintf('%s (%s)', $hook['name'], $hook['title']);
+            $choices[$label] = (int) $hook['id_hook'];
+        }
+
+        asort($choices);
+
+        return $choices;
+    }
+
+    private function getCategoryChoices(): array
+    {
+        $categories = Category::getCategories(false, true, false);
+        $choices = [];
+        foreach ($categories as $category) {
+            $choices[$category['id_category'] . ' - ' . $category['name']] = (int) $category['id_category'];
+        }
+
+        return $choices;
+    }
+
+    private function getManufacturerChoices(): array
+    {
+        $manufacturers = Manufacturer::getLiteManufacturersList((int) Context::getContext()->language->id);
+        $choices = [];
+        foreach ($manufacturers as $manufacturer) {
+            $choices[$manufacturer['name']] = (int) $manufacturer['id'];
+        }
+
+        return $choices;
+    }
+
+    private function getSupplierChoices(): array
+    {
+        $suppliers = Supplier::getLiteSuppliersList((int) Context::getContext()->language->id);
+        $choices = [];
+        foreach ($suppliers as $supplier) {
+            $choices[$supplier['name']] = (int) $supplier['id'];
+        }
+
+        return $choices;
+    }
+
+    private function getCmsCategoryChoices(): array
+    {
+        $categories = CMSCategory::getSimpleCategories((int) Context::getContext()->language->id);
+        $choices = [];
+        foreach ($categories as $category) {
+            $choices[$category['name']] = (int) $category['id_cms_category'];
+        }
+
+        return $choices;
+    }
+
+    private function getGroupChoices(): array
+    {
+        $context = Context::getContext();
+        $groups = Group::getGroups((int) $context->language->id, (int) $context->shop->id);
+        $choices = [];
+        foreach ($groups as $group) {
+            $choices[$group['name']] = (int) $group['id_group'];
+        }
+
+        return $choices;
+    }
+
+    private function getGroupIds(Context $context): array
+    {
+        $groups = Group::getGroups((int) $context->language->id, (int) $context->shop->id);
+        $ids = [];
+        foreach ($groups as $group) {
+            $ids[] = (int) $group['id_group'];
+        }
+
+        return $ids;
+    }
+
+    private function getBootstrapSizes(): array
+    {
+        $translator = Context::getContext()->getTranslator();
+
+        return [
+            $translator->trans('None', [], 'Modules.Everblock.Admin') => 0,
+            '100%' => 1,
+            '1/2' => 2,
+            '1/3' => 4,
+            '1/4' => 3,
+            '1/6' => 6,
+        ];
+    }
+
+    private function getDeviceChoices(): array
+    {
+        $translator = Context::getContext()->getTranslator();
+
+        return [
+            $translator->trans('All devices', [], 'Modules.Everblock.Admin') => 0,
+            $translator->trans('Only mobile devices', [], 'Modules.Everblock.Admin') => 4,
+            $translator->trans('Only tablet devices', [], 'Modules.Everblock.Admin') => 2,
+            $translator->trans('Only desktop devices', [], 'Modules.Everblock.Admin') => 1,
+        ];
+    }
+}

--- a/src/Tools/Form/Admin/EverBlockFormHandler.php
+++ b/src/Tools/Form/Admin/EverBlockFormHandler.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Form\Admin;
+
+use Everblock\Tools\Service\EverBlockManager;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class EverBlockFormHandler
+{
+    /** @var FormFactoryInterface */
+    private $formFactory;
+
+    /** @var EverBlockFormDataProvider */
+    private $dataProvider;
+
+    /** @var EverBlockManager */
+    private $manager;
+
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        EverBlockFormDataProvider $dataProvider,
+        EverBlockManager $manager
+    ) {
+        $this->formFactory = $formFactory;
+        $this->dataProvider = $dataProvider;
+        $this->manager = $manager;
+    }
+
+    public function getForm(Request $request, ?int $id = null): FormInterface
+    {
+        $data = $this->dataProvider->getData($id);
+        $options = $this->dataProvider->getOptions();
+
+        return $this->formFactory->create(EverBlockType::class, $data, $options);
+    }
+
+    public function handle(Request $request, ?int $id = null)
+    {
+        $form = $this->getForm($request, $id);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $normalized = $this->normalizeData($form->getData());
+            $block = $this->manager->updateBlock($normalized, $id);
+
+            return [$form, $block];
+        }
+
+        return [$form, null];
+    }
+
+    private function normalizeData(array $data): array
+    {
+        $booleanFields = [
+            'only_home',
+            'only_category',
+            'only_category_product',
+            'only_manufacturer',
+            'only_supplier',
+            'only_cms_category',
+            'obfuscate_link',
+            'add_container',
+            'lazyload',
+            'modal',
+            'active',
+        ];
+
+        foreach ($booleanFields as $field) {
+            $data[$field] = isset($data[$field]) ? (bool) $data[$field] : false;
+        }
+
+        $collectionFields = ['categories', 'manufacturers', 'suppliers', 'cms_categories', 'groups'];
+        foreach ($collectionFields as $field) {
+            if (!isset($data[$field]) || !is_array($data[$field])) {
+                $data[$field] = [];
+            }
+            $data[$field] = array_map('intval', $data[$field]);
+        }
+
+        $data['device'] = isset($data['device']) ? (int) $data['device'] : 0;
+        $data['bootstrap_class'] = isset($data['bootstrap_class']) ? (int) $data['bootstrap_class'] : 0;
+        $data['position'] = isset($data['position']) ? (int) $data['position'] : 0;
+        $data['delay'] = isset($data['delay']) ? (int) $data['delay'] : 0;
+        $data['timeout'] = isset($data['timeout']) ? (int) $data['timeout'] : 0;
+        $data['date_start'] = $data['date_start'] ?: null;
+        $data['date_end'] = $data['date_end'] ?: null;
+
+        return $data;
+    }
+}

--- a/src/Tools/Form/Admin/EverBlockType.php
+++ b/src/Tools/Form/Admin/EverBlockType.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Form\Admin;
+
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class EverBlockType extends AbstractType
+{
+    /** @var TranslatorInterface */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => $this->trans('Name'),
+                'required' => true,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('id_hook', ChoiceType::class, [
+                'label' => $this->trans('Hook'),
+                'choices' => $options['hooks'],
+                'placeholder' => $this->trans('Select a hook'),
+                'choice_translation_domain' => false,
+                'required' => true,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('content', TranslatableType::class, [
+                'label' => $this->trans('HTML block content'),
+                'required' => true,
+                'type' => TextareaType::class,
+                'options' => [
+                    'attr' => ['class' => 'autoload_rte'],
+                ],
+                'locales' => $options['languages'],
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('custom_code', TranslatableType::class, [
+                'label' => $this->trans('Custom code'),
+                'required' => false,
+                'type' => TextareaType::class,
+                'options' => [
+                    'attr' => ['rows' => 5],
+                ],
+                'locales' => $options['languages'],
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('bootstrap_class', ChoiceType::class, [
+                'label' => $this->trans('Bootstrap column'),
+                'choices' => $options['bootstrap_sizes'],
+                'choice_translation_domain' => false,
+                'required' => false,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('background', TextType::class, [
+                'label' => $this->trans('Background color'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('css_class', TextType::class, [
+                'label' => $this->trans('CSS classes'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('data_attribute', TextType::class, [
+                'label' => $this->trans('Data attributes'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'general'],
+            ])
+            ->add('only_home', SwitchType::class, [
+                'label' => $this->trans('Only on homepage'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('only_category', SwitchType::class, [
+                'label' => $this->trans('Only on categories'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('only_category_product', SwitchType::class, [
+                'label' => $this->trans('Only on products within categories'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('categories', ChoiceType::class, [
+                'label' => $this->trans('Limit to categories'),
+                'choices' => $options['categories'],
+                'required' => false,
+                'multiple' => true,
+                'expanded' => false,
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('only_manufacturer', SwitchType::class, [
+                'label' => $this->trans('Only on manufacturers'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('manufacturers', ChoiceType::class, [
+                'label' => $this->trans('Limit to manufacturers'),
+                'choices' => $options['manufacturers'],
+                'required' => false,
+                'multiple' => true,
+                'expanded' => false,
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('only_supplier', SwitchType::class, [
+                'label' => $this->trans('Only on suppliers'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('suppliers', ChoiceType::class, [
+                'label' => $this->trans('Limit to suppliers'),
+                'choices' => $options['suppliers'],
+                'required' => false,
+                'multiple' => true,
+                'expanded' => false,
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('only_cms_category', SwitchType::class, [
+                'label' => $this->trans('Only on CMS categories'),
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('cms_categories', ChoiceType::class, [
+                'label' => $this->trans('Limit to CMS categories'),
+                'choices' => $options['cms_categories'],
+                'required' => false,
+                'multiple' => true,
+                'expanded' => false,
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'targeting'],
+            ])
+            ->add('obfuscate_link', SwitchType::class, [
+                'label' => $this->trans('Obfuscate links'),
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('add_container', SwitchType::class, [
+                'label' => $this->trans('Add container'),
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('lazyload', SwitchType::class, [
+                'label' => $this->trans('Lazyload images'),
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('groups', ChoiceType::class, [
+                'label' => $this->trans('Customer groups'),
+                'choices' => $options['groups'],
+                'multiple' => true,
+                'expanded' => false,
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('device', ChoiceType::class, [
+                'label' => $this->trans('Devices'),
+                'choices' => $options['devices'],
+                'choice_translation_domain' => false,
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('position', IntegerType::class, [
+                'label' => $this->trans('Position'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'display'],
+            ])
+            ->add('modal', SwitchType::class, [
+                'label' => $this->trans('Display as modal'),
+                'row_attr' => ['data-tab' => 'modal'],
+            ])
+            ->add('delay', IntegerType::class, [
+                'label' => $this->trans('Modal delay (ms)'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'modal'],
+            ])
+            ->add('timeout', IntegerType::class, [
+                'label' => $this->trans('Modal timeout (ms)'),
+                'required' => false,
+                'row_attr' => ['data-tab' => 'modal'],
+            ])
+            ->add('date_start', TextType::class, [
+                'label' => $this->trans('Start date'),
+                'required' => false,
+                'attr' => ['class' => 'datetimepicker'],
+                'row_attr' => ['data-tab' => 'schedule'],
+            ])
+            ->add('date_end', TextType::class, [
+                'label' => $this->trans('End date'),
+                'required' => false,
+                'attr' => ['class' => 'datetimepicker'],
+                'row_attr' => ['data-tab' => 'schedule'],
+            ])
+            ->add('active', SwitchType::class, [
+                'label' => $this->trans('Active'),
+                'row_attr' => ['data-tab' => 'schedule'],
+            ]);
+    }
+
+    private function trans(string $message, array $parameters = []): string
+    {
+        return $this->translator->trans($message, $parameters, 'Modules.Everblock.Admin');
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired([
+            'hooks',
+            'categories',
+            'manufacturers',
+            'suppliers',
+            'cms_categories',
+            'groups',
+            'bootstrap_sizes',
+            'devices',
+            'languages',
+        ]);
+
+        $resolver->setDefaults([
+            'data_class' => null,
+        ]);
+    }
+}

--- a/src/Tools/Grid/Data/EverBlockGridDataFactory.php
+++ b/src/Tools/Grid/Data/EverBlockGridDataFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Grid\Data;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Everblock\Tools\Grid\Filters\EverBlockFilters;
+use Everblock\Tools\Grid\Query\EverBlockQueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+class EverBlockGridDataFactory implements GridDataFactoryInterface
+{
+    /** @var EverBlockQueryBuilder */
+    private $queryBuilder;
+
+    public function __construct(EverBlockQueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    public function getData(Filters $filters)
+    {
+        if (!$filters instanceof EverBlockFilters) {
+            $filters = new EverBlockFilters($filters->all());
+        }
+
+        $searchQuery = $this->queryBuilder->getSearchQueryBuilder($filters);
+        $records = $this->fetchAll($searchQuery);
+
+        $countQuery = $this->queryBuilder->getCountQueryBuilder($filters);
+        $totalRecords = (int) $this->fetchCount($countQuery);
+
+        return new GridData($records, $totalRecords);
+    }
+
+    private function fetchAll(QueryBuilder $queryBuilder)
+    {
+        $statement = method_exists($queryBuilder, 'executeQuery')
+            ? $queryBuilder->executeQuery()
+            : $queryBuilder->execute();
+
+        if (method_exists($statement, 'fetchAllAssociative')) {
+            return $statement->fetchAllAssociative();
+        }
+
+        return $statement->fetchAll();
+    }
+
+    private function fetchCount(QueryBuilder $queryBuilder)
+    {
+        $statement = method_exists($queryBuilder, 'executeQuery')
+            ? $queryBuilder->executeQuery()
+            : $queryBuilder->execute();
+
+        if (method_exists($statement, 'fetchOne')) {
+            return $statement->fetchOne();
+        }
+
+        if (method_exists($statement, 'fetchColumn')) {
+            return $statement->fetchColumn();
+        }
+
+        $result = $statement->fetch();
+        if (is_array($result)) {
+            return array_values($result)[0];
+        }
+
+        return 0;
+    }
+}

--- a/src/Tools/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
+++ b/src/Tools/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
@@ -1,0 +1,331 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\SimpleGridAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Type\Common\ChoiceType;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Type\Common\DateRangeType;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Type\Common\TextType;
+
+class EverBlockGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    private const GRID_ID = 'ever_block';
+
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    protected function getName()
+    {
+        return $this->trans('Ever Block', [], 'Modules.Everblock.Admin');
+    }
+
+    protected function getColumns()
+    {
+        $columns = new ColumnCollection();
+
+        $columns
+            ->add((new BulkActionColumn('bulk'))
+                ->setOptions([
+                    'bulk_field' => 'id_everblock',
+                ])
+            )
+            ->add((new DataColumn('id_everblock'))
+                ->setName($this->trans('ID', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'id_everblock',
+                ])
+            )
+            ->add((new DataColumn('name'))
+                ->setName($this->trans('Name', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'name',
+                ])
+            )
+            ->add((new DataColumn('hname'))
+                ->setName($this->trans('Hook', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'hname',
+                ])
+            )
+            ->add((new DataColumn('position'))
+                ->setName($this->trans('Position', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'position',
+                ])
+            )
+            ->add((new DataColumn('only_home'))
+                ->setName($this->trans('Home only', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'only_home',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new DataColumn('only_category'))
+                ->setName($this->trans('Category only', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'only_category',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new DataColumn('only_manufacturer'))
+                ->setName($this->trans('Manufacturer only', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'only_manufacturer',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new DataColumn('only_supplier'))
+                ->setName($this->trans('Supplier only', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'only_supplier',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new DataColumn('only_cms_category'))
+                ->setName($this->trans('CMS category only', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'only_cms_category',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new DataColumn('date_start'))
+                ->setName($this->trans('Date start', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'date_start',
+                ])
+            )
+            ->add((new DataColumn('date_end'))
+                ->setName($this->trans('Date end', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'date_end',
+                ])
+            )
+            ->add((new DataColumn('modal'))
+                ->setName($this->trans('Is modal', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'field' => 'modal',
+                    'is_bool' => true,
+                ])
+            )
+            ->add((new ToggleColumn('active'))
+                ->setName($this->trans('Status', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'active',
+                    'primary_field' => 'id_everblock',
+                    'route' => 'admin_everblock_toggle_status',
+                    'route_param_name' => 'everBlockId',
+                ])
+            );
+
+        return $columns;
+    }
+
+    protected function getFilters()
+    {
+        $filters = new FilterCollection();
+
+        $filters
+            ->add((new Filter('id_everblock', TextType::class))
+                ->setTypeOptions([
+                    'attr' => [
+                        'placeholder' => $this->trans('Search ID', [], 'Admin.Global'),
+                    ],
+                ])
+                ->setAssociatedColumn('id_everblock')
+            )
+            ->add((new Filter('name', TextType::class))
+                ->setAssociatedColumn('name')
+            )
+            ->add((new Filter('hname', TextType::class))
+                ->setAssociatedColumn('hname')
+            )
+            ->add((new Filter('only_home', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('only_home')
+            )
+            ->add((new Filter('only_category', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('only_category')
+            )
+            ->add((new Filter('only_manufacturer', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('only_manufacturer')
+            )
+            ->add((new Filter('only_supplier', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('only_supplier')
+            )
+            ->add((new Filter('only_cms_category', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('only_cms_category')
+            )
+            ->add((new Filter('modal', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('modal')
+            )
+            ->add((new Filter('active', ChoiceType::class))
+                ->setTypeOptions([
+                    'choices' => $this->getBooleanChoices(),
+                ])
+                ->setAssociatedColumn('active')
+            )
+            ->add((new Filter('date_start', DateRangeType::class))
+                ->setAssociatedColumn('date_start')
+            )
+            ->add((new Filter('date_end', DateRangeType::class))
+                ->setAssociatedColumn('date_end')
+            );
+
+        return $filters;
+    }
+
+    protected function getGridActions()
+    {
+        $collection = new GridActionCollection();
+        $collection->add(
+            (new SimpleGridAction('create'))
+                ->setName($this->trans('Add new block', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'route' => 'admin_everblock_create',
+                    'icon' => 'add_circle',
+                ])
+        );
+
+        return $collection;
+    }
+
+    protected function getRowActions()
+    {
+        $actions = new RowActionCollection();
+
+        $actions
+            ->add((new LinkRowAction('edit'))
+                ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                ->setIcon('edit')
+                ->setOptions([
+                    'route' => 'admin_everblock_edit',
+                    'route_param_name' => 'everBlockId',
+                    'route_param_field' => 'id_everblock',
+                ])
+            )
+            ->add((new SubmitRowAction('delete'))
+                ->setName($this->trans('Delete', [], 'Admin.Actions'))
+                ->setIcon('delete')
+                ->setOptions([
+                    'route' => 'admin_everblock_delete',
+                    'route_param_name' => 'everBlockId',
+                    'route_param_field' => 'id_everblock',
+                    'confirm_message' => $this->trans('Delete selected block?', [], 'Modules.Everblock.Admin'),
+                ])
+            )
+            ->add((new SubmitRowAction('duplicate'))
+                ->setName($this->trans('Duplicate', [], 'Admin.Actions'))
+                ->setIcon('content_copy')
+                ->setOptions([
+                    'route' => 'admin_everblock_duplicate',
+                    'route_param_name' => 'everBlockId',
+                    'route_param_field' => 'id_everblock',
+                ])
+            )
+            ->add((new LinkRowAction('export'))
+                ->setName($this->trans('Export SQL', [], 'Modules.Everblock.Admin'))
+                ->setIcon('file_download')
+                ->setOptions([
+                    'route' => 'admin_everblock_export',
+                    'route_param_name' => 'everBlockId',
+                    'route_param_field' => 'id_everblock',
+                    'new_tab' => true,
+                ])
+            );
+
+        return $actions;
+    }
+
+    protected function getBulkActions()
+    {
+        $bulkActions = new BulkActionCollection();
+
+        $bulkActions
+            ->add((new SubmitBulkAction('duplicate_all'))
+                ->setName($this->trans('Duplicate selection', [], 'Modules.Everblock.Admin'))
+                ->setOptions([
+                    'submit_action' => 'duplicate',
+                    'route' => 'admin_everblock_bulk',
+                    'confirm_message' => $this->trans('Duplicate selected blocks?', [], 'Modules.Everblock.Admin'),
+                ])
+            )
+            ->add((new SubmitBulkAction('delete_selection'))
+                ->setName($this->trans('Delete selection', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_action' => 'delete',
+                    'route' => 'admin_everblock_bulk',
+                    'confirm_message' => $this->trans('Delete selected blocks?', [], 'Modules.Everblock.Admin'),
+                ])
+            )
+            ->add((new SubmitBulkAction('enable_selection'))
+                ->setName($this->trans('Enable selection', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_action' => 'enable',
+                    'route' => 'admin_everblock_bulk',
+                ])
+            )
+            ->add((new SubmitBulkAction('disable_selection'))
+                ->setName($this->trans('Disable selection', [], 'Admin.Actions'))
+                ->setOptions([
+                    'submit_action' => 'disable',
+                    'route' => 'admin_everblock_bulk',
+                ])
+            );
+
+        return $bulkActions;
+    }
+
+    private function getBooleanChoices()
+    {
+        return [
+            $this->trans('Yes', [], 'Admin.Global') => 1,
+            $this->trans('No', [], 'Admin.Global') => 0,
+        ];
+    }
+}

--- a/src/Tools/Grid/Filters/EverBlockFilters.php
+++ b/src/Tools/Grid/Filters/EverBlockFilters.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Grid\Filters;
+
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+class EverBlockFilters extends Filters
+{
+    protected $filterId = 'ever_block';
+
+    protected $defaultLimit = 20;
+
+    protected $defaultOrderBy = 'sort_key';
+
+    protected $defaultOrderWay = 'asc';
+}

--- a/src/Tools/Grid/Query/EverBlockQueryBuilder.php
+++ b/src/Tools/Grid/Query/EverBlockQueryBuilder.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Grid\Query\QueryBuilderInterface;
+use PrestaShop\PrestaShop\Core\Search\SearchCriteriaInterface;
+
+class EverBlockQueryBuilder implements QueryBuilderInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var LegacyContext */
+    private $legacyContext;
+
+    public function __construct(Connection $connection, LegacyContext $legacyContext)
+    {
+        $this->connection = $connection;
+        $this->legacyContext = $legacyContext;
+    }
+
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
+    {
+        $qb = $this->getBaseQueryBuilder();
+
+        $this->applyFilters($qb, $searchCriteria);
+        $this->applySorting($qb, $searchCriteria);
+        $this->applyPagination($qb, $searchCriteria);
+
+        return $qb;
+    }
+
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('COUNT(eb.id_everblock)')
+            ->from(_DB_PREFIX_ . 'everblock', 'eb')
+            ->leftJoin('eb', _DB_PREFIX_ . 'hook', 'h', 'h.id_hook = eb.id_hook')
+            ->where('eb.id_shop = :id_shop')
+            ->setParameter('id_shop', (int) $this->getContext()->shop->id);
+
+        $this->applyRawFilters($qb, $searchCriteria);
+
+        return $qb;
+    }
+
+    private function getBaseQueryBuilder()
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select(
+            'eb.id_everblock',
+            'eb.name',
+            'h.title as hname',
+            'eb.position',
+            'eb.only_home',
+            'eb.only_category',
+            'eb.only_manufacturer',
+            'eb.only_supplier',
+            'eb.only_cms_category',
+            'eb.modal',
+            'eb.date_start',
+            'eb.date_end',
+            'eb.active'
+        )
+            ->from(_DB_PREFIX_ . 'everblock', 'eb')
+            ->leftJoin('eb', _DB_PREFIX_ . 'hook', 'h', 'h.id_hook = eb.id_hook')
+            ->where('eb.id_shop = :id_shop')
+            ->setParameter('id_shop', (int) $this->getContext()->shop->id);
+
+        return $qb;
+    }
+
+    private function applyFilters(QueryBuilder $qb, SearchCriteriaInterface $searchCriteria)
+    {
+        $filters = $searchCriteria->getFilters();
+
+        foreach ($filters as $filterName => $value) {
+            if (null === $value || $value === '' || $value === []) {
+                continue;
+            }
+
+            switch ($filterName) {
+                case 'id_everblock':
+                    $qb->andWhere('eb.id_everblock = :id_everblock');
+                    $qb->setParameter('id_everblock', (int) $value, ParameterType::INTEGER);
+                    break;
+                case 'name':
+                    $qb->andWhere('eb.name LIKE :name');
+                    $qb->setParameter('name', '%' . pSQL($value) . '%');
+                    break;
+                case 'hname':
+                    $qb->andWhere('h.title LIKE :hook_title');
+                    $qb->setParameter('hook_title', '%' . pSQL($value) . '%');
+                    break;
+                case 'only_home':
+                case 'only_category':
+                case 'only_manufacturer':
+                case 'only_supplier':
+                case 'only_cms_category':
+                case 'modal':
+                case 'active':
+                    $qb->andWhere(sprintf('eb.%s = :%s', $filterName, $filterName));
+                    $qb->setParameter($filterName, (int) $value, ParameterType::INTEGER);
+                    break;
+                case 'date_start':
+                case 'date_end':
+                    $this->applyDateFilter($qb, $filterName, $value);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private function applyRawFilters(QueryBuilder $qb, SearchCriteriaInterface $searchCriteria)
+    {
+        $filters = $searchCriteria->getFilters();
+        foreach ($filters as $filterName => $value) {
+            if (null === $value || $value === '' || $value === []) {
+                continue;
+            }
+
+            switch ($filterName) {
+                case 'id_everblock':
+                    $qb->andWhere('eb.id_everblock = :id_everblock');
+                    $qb->setParameter('id_everblock', (int) $value, ParameterType::INTEGER);
+                    break;
+                case 'name':
+                    $qb->andWhere('eb.name LIKE :name');
+                    $qb->setParameter('name', '%' . pSQL($value) . '%');
+                    break;
+                case 'hname':
+                    $qb->andWhere('h.title LIKE :hook_title');
+                    $qb->setParameter('hook_title', '%' . pSQL($value) . '%');
+                    break;
+                case 'only_home':
+                case 'only_category':
+                case 'only_manufacturer':
+                case 'only_supplier':
+                case 'only_cms_category':
+                case 'modal':
+                case 'active':
+                    $qb->andWhere(sprintf('eb.%s = :%s', $filterName, $filterName));
+                    $qb->setParameter($filterName, (int) $value, ParameterType::INTEGER);
+                    break;
+                case 'date_start':
+                case 'date_end':
+                    $this->applyDateFilter($qb, $filterName, $value);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private function applySorting(QueryBuilder $qb, SearchCriteriaInterface $searchCriteria)
+    {
+        $orderBy = $searchCriteria->getOrderBy();
+        if (!$orderBy) {
+            $orderBy = 'hname';
+        }
+
+        $orderWay = $searchCriteria->getOrderWay();
+        if (!$orderWay) {
+            $orderWay = 'ASC';
+        }
+
+        switch ($orderBy) {
+            case 'hname':
+                $qb->orderBy('h.title', $orderWay);
+                $qb->addOrderBy('eb.position', 'ASC');
+                break;
+            case 'position':
+                $qb->orderBy('eb.position', $orderWay);
+                break;
+            default:
+                $qb->orderBy('eb.' . pSQL($orderBy), $orderWay);
+        }
+    }
+
+    private function applyPagination(QueryBuilder $qb, SearchCriteriaInterface $searchCriteria)
+    {
+        $offset = $searchCriteria->getOffset();
+        if (null !== $offset) {
+            $qb->setFirstResult((int) $offset);
+        }
+
+        $limit = $searchCriteria->getLimit();
+        if (null !== $limit) {
+            $qb->setMaxResults((int) $limit);
+        }
+    }
+
+    private function applyDateFilter(QueryBuilder $qb, $field, $value)
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        if (!empty($value['from'])) {
+            $qb->andWhere(sprintf('eb.%s >= :%s_from', $field, $field));
+            $qb->setParameter($field . '_from', $value['from']);
+        }
+
+        if (!empty($value['to'])) {
+            $qb->andWhere(sprintf('eb.%s <= :%s_to', $field, $field));
+            $qb->setParameter($field . '_to', $value['to']);
+        }
+    }
+
+    private function getContext()
+    {
+        return $this->legacyContext->getContext();
+    }
+}

--- a/src/Tools/Service/EverBlockManager.php
+++ b/src/Tools/Service/EverBlockManager.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+namespace Everblock\Tools\Service;
+
+use Configuration;
+use Context;
+use Db;
+use EverBlockClass;
+use EverblockTools;
+use Everblock\Tools\Service\EverblockCache;
+use Group;
+use Hook;
+use Language;
+use Module;
+use PrestaShopException;
+use Tools;
+
+class EverBlockManager
+{
+    public function duplicate(int $idEverBlock): EverBlockClass
+    {
+        $source = new EverBlockClass($idEverBlock);
+        if (!$source->id) {
+            throw new PrestaShopException('Everblock not found');
+        }
+
+        $newBlock = new EverBlockClass();
+        $fields = $source->getFields();
+        foreach ($fields as $field => $value) {
+            if (in_array($field, ['id_everblock', 'id'])) {
+                continue;
+            }
+            $newBlock->{$field} = $value;
+        }
+
+        $newBlock->active = false;
+        $newBlock->id = null;
+        $newBlock->id_everblock = null;
+
+        $langFields = [];
+        foreach ($source->getFieldsLang() as $langRow) {
+            $langFields[(int) $langRow['id_lang']] = $langRow;
+        }
+        foreach (Language::getLanguages(false) as $language) {
+            $idLang = (int) $language['id_lang'];
+            $newBlock->content[$idLang] = isset($langFields[$idLang]['content']) ? $langFields[$idLang]['content'] : '';
+            $newBlock->custom_code[$idLang] = isset($langFields[$idLang]['custom_code']) ? $langFields[$idLang]['custom_code'] : '';
+        }
+
+        if (!$newBlock->add()) {
+            throw new PrestaShopException('Unable to duplicate everblock');
+        }
+
+        return $newBlock;
+    }
+
+    public function exportSql(int $idEverBlock): string
+    {
+        $sql = EverblockTools::exportBlockSQL($idEverBlock);
+        if (!$sql) {
+            throw new PrestaShopException('Unable to export block SQL');
+        }
+
+        return $sql;
+    }
+
+    public function toggleStatus(int $idEverBlock): bool
+    {
+        return Db::getInstance()->execute(
+            'UPDATE `' . _DB_PREFIX_ . 'everblock`'
+            . ' SET `active` = (1 - `active`)' .
+            ' WHERE `id_everblock` = ' . (int) $idEverBlock
+        );
+    }
+
+    public function updateBlock(array $data, ?int $idEverBlock = null): EverBlockClass
+    {
+        $context = Context::getContext();
+        $block = $idEverBlock ? new EverBlockClass($idEverBlock) : new EverBlockClass();
+
+        $block->name = $data['name'];
+        $block->id_shop = (int) $context->shop->id;
+        $block->id_hook = (int) $data['id_hook'];
+        $block->only_home = (int) $data['only_home'];
+        $block->only_category = (int) $data['only_category'];
+        $block->only_category_product = (int) $data['only_category_product'];
+        $block->only_manufacturer = (int) $data['only_manufacturer'];
+        $block->only_supplier = (int) $data['only_supplier'];
+        $block->only_cms_category = (int) $data['only_cms_category'];
+        $block->obfuscate_link = (int) $data['obfuscate_link'];
+        $block->add_container = (int) $data['add_container'];
+        $block->lazyload = (int) $data['lazyload'];
+        $block->categories = json_encode($data['categories']);
+        $block->manufacturers = json_encode($data['manufacturers']);
+        $block->suppliers = json_encode($data['suppliers']);
+        $block->cms_categories = json_encode($data['cms_categories']);
+        $block->position = (int) $data['position'];
+        $block->background = pSQL($data['background']);
+        $block->css_class = pSQL($data['css_class']);
+        $block->data_attribute = pSQL($data['data_attribute']);
+        $block->bootstrap_class = pSQL($data['bootstrap_class']);
+        $block->device = (int) $data['device'];
+        $block->delay = (int) $data['delay'];
+        $block->timeout = (int) $data['timeout'];
+        $block->modal = (int) $data['modal'];
+        $block->date_start = pSQL($data['date_start']);
+        $block->date_end = pSQL($data['date_end']);
+        $block->active = (int) $data['active'];
+
+        $groups = $data['groups'];
+        if (empty($groups)) {
+            $groups = [];
+            foreach (Group::getGroups((int) $context->language->id, (int) $context->shop->id) as $group) {
+                $groups[] = (int) $group['id_group'];
+            }
+        }
+        $block->groups = json_encode($groups);
+
+        foreach (Language::getLanguages(false) as $language) {
+            $idLang = (int) $language['id_lang'];
+            $originalContent = $data['content'][$idLang] ?? '';
+            $convertedContent = EverblockTools::convertImagesToWebP($originalContent);
+            $block->content[$idLang] = $convertedContent;
+            $block->custom_code[$idLang] = $data['custom_code'][$idLang] ?? '';
+        }
+
+        if ($block->id) {
+            $result = $block->update();
+        } else {
+            $result = $block->add();
+        }
+
+        if (!$result) {
+            throw new PrestaShopException('Unable to save everblock');
+        }
+
+        $module = Module::getInstanceByName('everblock');
+        if ($module) {
+            $hookName = Hook::getNameById($block->id_hook);
+            if ($hookName) {
+                $module->registerHook($hookName);
+            }
+        }
+
+        if ((bool) Configuration::get('EVERPSCSS_CACHE')) {
+            $this->clearCache();
+        }
+
+        return $block;
+    }
+
+    public function delete(int $idEverBlock): bool
+    {
+        $block = new EverBlockClass($idEverBlock);
+        if (!$block->id) {
+            return false;
+        }
+
+        return (bool) $block->delete();
+    }
+
+    public function bulkDelete(array $ids): void
+    {
+        foreach ($ids as $id) {
+            $this->delete((int) $id);
+        }
+    }
+
+    public function bulkDuplicate(array $ids): void
+    {
+        foreach ($ids as $id) {
+            $this->duplicate((int) $id);
+        }
+    }
+
+    public function bulkToggle(array $ids, bool $enabled): void
+    {
+        foreach ($ids as $id) {
+            $block = new EverBlockClass((int) $id);
+            if (!$block->id) {
+                continue;
+            }
+            $block->active = $enabled;
+            $block->save();
+        }
+    }
+
+    public function clearCache(): void
+    {
+        Tools::clearAllCache();
+
+        $patterns = [
+            'EverBlockClass_getAllBlocks_',
+            'EverBlockClass_getBlocks_',
+            'EverBlockClass_getBootstrapColClass_',
+            'everblock-id_hook-',
+            'everblock_google_reviews_',
+        ];
+
+        foreach ($patterns as $pattern) {
+            EverblockCache::cacheDropByPattern($pattern);
+        }
+    }
+}

--- a/views/templates/admin/everblock/form.html.twig
+++ b/views/templates/admin/everblock/form.html.twig
@@ -1,0 +1,83 @@
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block stylesheets %}
+  {{ parent() }}
+  {{ form_stylesheet(form) }}
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  {{ form_javascript(form) }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var dateInputs = document.querySelectorAll('.datetimepicker');
+      if (!dateInputs.length) {
+        return;
+      }
+
+      if (typeof window.jQuery !== 'undefined' && typeof jQuery.fn.datetimepicker === 'function') {
+        jQuery(dateInputs).datetimepicker({
+          format: 'Y-m-d H:i:s'
+        });
+        return;
+      }
+
+      if (typeof window.flatpickr === 'function') {
+        dateInputs.forEach(function (input) {
+          window.flatpickr(input, {
+            enableTime: true,
+            dateFormat: 'Y-m-d H:i:S'
+          });
+        });
+      }
+    });
+  </script>
+{% endblock %}
+
+{% block content %}
+  <div class="everblock-config-wrapper">
+    {{ include('@PrestaShop/Admin/Common/Alert/flash_messages.html.twig') }}
+    <div class="everblock-config__card everblock-config__card--form">
+      <div class="panel">
+        <div class="panel-heading">
+          <i class="material-icons">settings</i>
+          {% if is_edit %}
+            {{ 'Edit block'|trans({}, 'Modules.Everblock.Admin') }}
+          {% else %}
+            {{ 'Create block'|trans({}, 'Modules.Everblock.Admin') }}
+          {% endif %}
+        </div>
+        {{ form_start(form) }}
+          <ul class="nav nav-tabs" role="tablist">
+            {% for tabId, tabLabel in tabs %}
+              <li role="presentation" class="{% if loop.first %}active{% endif %}">
+                <a href="#tab-{{ tabId }}" aria-controls="tab-{{ tabId }}" role="tab" data-toggle="tab">{{ tabLabel }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+          <div class="tab-content">
+            {% for tabId, tabLabel in tabs %}
+              <div role="tabpanel" class="tab-pane {% if loop.first %}active{% endif %}" id="tab-{{ tabId }}">
+                {% for child in form %}
+                  {% if child.vars.row_attr['data-tab'] is defined and child.vars.row_attr['data-tab'] == tabId %}
+                    {{ form_row(child) }}
+                  {% endif %}
+                {% endfor %}
+              </div>
+            {% endfor %}
+          </div>
+          <div class="everblock-form-actions">
+            <button class="btn btn-primary" type="submit">
+              <i class="material-icons">save</i>
+              {{ 'Save'|trans({}, 'Modules.Everblock.Admin') }}
+            </button>
+            <a class="btn btn-default" href="{{ path('admin_everblock_index') }}">
+              <i class="material-icons">arrow_back</i>
+              {{ 'Back to list'|trans({}, 'Modules.Everblock.Admin') }}
+            </a>
+          </div>
+        {{ form_end(form) }}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/views/templates/admin/everblock/index.html.twig
+++ b/views/templates/admin/everblock/index.html.twig
@@ -1,0 +1,208 @@
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="everblock-config-wrapper">
+    {{ include('@PrestaShop/Admin/Common/Alert/flash_messages.html.twig') }}
+
+    <section class="everblock-config__hero">
+      <div class="everblock-config__hero-main">
+        <span class="everblock-config__badge">{{ 'Module'|trans({}, 'Modules.Everblock.Admin') }}</span>
+        <h2 class="everblock-config__hero-title">{{ module_name }}</h2>
+        <p class="everblock-config__hero-description">
+          {{ 'Fine-tune the behaviour, integrations and automation rules of Ever Block from a single, curated control centre.'|trans({}, 'Modules.Everblock.Admin') }}
+        </p>
+        <div class="everblock-config__hero-meta">
+          <span class="everblock-chip">
+            <i class="icon-tag"></i>
+            {{ 'Version'|trans({}, 'Modules.Everblock.Admin') }} {{ module_version }}
+          </span>
+          <span class="everblock-chip">
+            <i class="icon-check"></i>
+            {{ 'Content managed today'|trans({}, 'Modules.Everblock.Admin') }}: {{ stats.blocks_total|default(0) }}
+          </span>
+          {% if shortcode_docs is not empty %}
+            <button type="button" class="btn btn-info" data-toggle="modal" data-target="#everblockShortcodeModal">
+              <i class="icon-book"></i>
+              {{ 'Shortcode documentation'|trans({}, 'Modules.Everblock.Admin') }}
+            </button>
+          {% endif %}
+        </div>
+      </div>
+      <div class="everblock-config__hero-stats">
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.blocks_active|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Active blocks'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.shortcodes|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Shortcodes'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.flags|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Flags'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.tabs|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Product tabs'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+      </div>
+    </section>
+
+    <div class="everblock-config__layout">
+      <div class="everblock-config__main">
+        <div class="everblock-config__card everblock-config__card--form">
+          <div class="everblock-grid-toolbar">
+            {% if can_add_block %}
+              <a class="btn btn-primary" href="{{ path('admin_everblock_create') }}">
+                <i class="material-icons">add_circle</i>
+                {{ 'Add new block'|trans({}, 'Modules.Everblock.Admin') }}
+              </a>
+            {% endif %}
+            <a class="btn btn-default" href="{{ header_links.module_configuration }}">
+              <i class="material-icons">settings</i>
+              {{ 'Module configuration'|trans({}, 'Modules.Everblock.Admin') }}
+            </a>
+          </div>
+          {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {grid: grid} %}
+        </div>
+      </div>
+      <aside class="everblock-config__aside">
+        <div class="everblock-sidecard">
+          <h3 class="everblock-sidecard__title">
+            <i class="icon-th-large"></i>
+            {{ 'Quick actions'|trans({}, 'Modules.Everblock.Admin') }}
+          </h3>
+          <ul class="everblock-sidecard__actions">
+            <li>
+              <a class="everblock-sidecard__link" href="{{ header_links.block_admin }}">
+                <span class="everblock-sidecard__icon"><i class="icon-puzzle-piece"></i></span>
+                <span>
+                  <strong>{{ 'Legacy block manager'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Access the historical back office for reference.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ header_links.shortcode_admin }}">
+                <span class="everblock-sidecard__icon"><i class="icon-code"></i></span>
+                <span>
+                  <strong>{{ 'Shortcodes'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Manage reusable snippets.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ header_links.faq_admin }}">
+                <span class="everblock-sidecard__icon"><i class="icon-question-sign"></i></span>
+                <span>
+                  <strong>{{ 'FAQ'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Adjust customer facing answers.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ header_links.hook_admin }}">
+                <span class="everblock-sidecard__icon"><i class="icon-sitemap"></i></span>
+                <span>
+                  <strong>{{ 'Hooks'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Control placements across your shop.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="everblock-sidecard">
+          <h3 class="everblock-sidecard__title">
+            <i class="icon-bullhorn"></i>
+            {{ 'Support & resources'|trans({}, 'Modules.Everblock.Admin') }}
+          </h3>
+          <ul class="everblock-sidecard__badges">
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="icon-bar-chart"></i>
+                {{ 'Total blocks: %count%'|trans({'%count%': stats.blocks_total|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="icon-comments"></i>
+                {{ 'FAQ entries: %count%'|trans({'%count%': stats.faqs|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="icon-gamepad"></i>
+                {{ 'Gamification sessions: %count%'|trans({'%count%': stats.game_sessions|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+          </ul>
+          <a class="everblock-sidecard__cta" href="{{ header_links.donation }}" target="_blank">
+            <i class="icon-heart"></i>
+            {{ 'Support ongoing development'|trans({}, 'Modules.Everblock.Admin') }}
+          </a>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  {% if shortcode_docs is not empty %}
+    <div class="modal fade" id="everblockShortcodeModal" tabindex="-1" role="dialog" aria-labelledby="everblockShortcodeModalLabel">
+      <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Modules.Everblock.Admin') }}">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h4 class="modal-title" id="everblockShortcodeModalLabel">
+              <i class="icon-code"></i>
+              {{ 'Available shortcodes'|trans({}, 'Modules.Everblock.Admin') }}
+            </h4>
+          </div>
+          <div class="modal-body">
+            {% for category in shortcode_docs %}
+              <div class="panel panel-default everblock-shortcode-panel">
+                <div class="panel-heading">
+                  <strong>{{ category.title }}</strong>
+                </div>
+                <div class="panel-body">
+                  {% if category.entries is defined %}
+                    <ul class="list-unstyled everblock-shortcode-list">
+                      {% for entry in category.entries %}
+                        <li class="everblock-shortcode-list__item">
+                          <div class="everblock-shortcode-list__header">
+                            <code class="everblock-shortcode-list__code">{{ entry.code }}</code>
+                          </div>
+                          <p class="everblock-shortcode-list__description">{{ entry.description }}</p>
+                          {% if entry.parameters is defined %}
+                            <ul class="list-unstyled everblock-shortcode-params">
+                              {% for parameter in entry.parameters %}
+                                <li class="everblock-shortcode-params__item">
+                                  <span class="label {{ parameter.required ? 'label-primary' : 'label-default' }}">
+                                    {{ parameter.required ? 'Required'|trans({}, 'Modules.Everblock.Admin') : 'Optional'|trans({}, 'Modules.Everblock.Admin') }}
+                                  </span>
+                                  <strong class="everblock-shortcode-params__name">{{ parameter.name }}</strong>
+                                  {% if parameter.description %}
+                                    <span class="everblock-shortcode-params__description">- {{ parameter.description }}</span>
+                                  {% endif %}
+                                </li>
+                              {% endfor %}
+                            </ul>
+                          {% endif %}
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              {{ 'Close'|trans({}, 'Modules.Everblock.Admin') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Symfony routes, controller, grid, form handler and dedicated services for the Ever Block back office
- replace legacy Smarty listing/form views with Twig equivalents and register the tab on the new route
- redirect the legacy ModuleAdminController and expose duplication/cache/export logic through a manager service

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4dd34d6c48322b1f4ec96bda1fe8f