### PR TITLE
Clarify Everblock total content statistic label

### DIFF
--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -39,7 +39,7 @@
                 </span>
                 <span class="everblock-chip">
                     <i class="icon-check"></i>
-                    {l s='Content managed today' mod='everblock'}: {$everblock_stats.blocks_total|intval}
+                    {l s='Content managed (total)' mod='everblock'}: {$everblock_stats.blocks_total|intval}
                 </span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- clarify the admin dashboard statistic label to indicate it represents total managed content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f506ab50148322babaac184e3af39c