### PR TITLE
Add confirmation display helper to admin controllers

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -27,6 +27,26 @@ use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 class AdminEverBlockController extends ModuleAdminController
 {
     private $html;
+
+    protected function displayConfirmation($message)
+    {
+        if (is_array($message)) {
+            $message = implode('<br>', array_map(function ($item) {
+                return Tools::safeOutput((string) $item);
+            }, $message));
+        } else {
+            $message = Tools::safeOutput((string) $message);
+        }
+
+        if ('' === trim($message)) {
+            return '';
+        }
+
+        return '<div class="bootstrap"><div class="alert alert-success" role="alert">'
+            . $message
+            . '</div></div>';
+    }
+
     public function __construct()
     {
         $this->bootstrap = true;

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -30,6 +30,25 @@ class AdminEverBlockFaqController extends ModuleAdminController
 {
     private $html;
 
+    protected function displayConfirmation($message)
+    {
+        if (is_array($message)) {
+            $message = implode('<br>', array_map(function ($item) {
+                return Tools::safeOutput((string) $item);
+            }, $message));
+        } else {
+            $message = Tools::safeOutput((string) $message);
+        }
+
+        if ('' === trim($message)) {
+            return '';
+        }
+
+        return '<div class="bootstrap"><div class="alert alert-success" role="alert">'
+            . $message
+            . '</div></div>';
+    }
+
     public function __construct()
     {
         $this->bootstrap = true;

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -29,6 +29,25 @@ class AdminEverBlockHookController extends ModuleAdminController
 {
     private $html;
 
+    protected function displayConfirmation($message)
+    {
+        if (is_array($message)) {
+            $message = implode('<br>', array_map(function ($item) {
+                return Tools::safeOutput((string) $item);
+            }, $message));
+        } else {
+            $message = Tools::safeOutput((string) $message);
+        }
+
+        if ('' === trim($message)) {
+            return '';
+        }
+
+        return '<div class="bootstrap"><div class="alert alert-success" role="alert">'
+            . $message
+            . '</div></div>';
+    }
+
     public function __construct()
     {
         $this->bootstrap = true;

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -30,6 +30,25 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
 {
     private $html;
 
+    protected function displayConfirmation($message)
+    {
+        if (is_array($message)) {
+            $message = implode('<br>', array_map(function ($item) {
+                return Tools::safeOutput((string) $item);
+            }, $message));
+        } else {
+            $message = Tools::safeOutput((string) $message);
+        }
+
+        if ('' === trim($message)) {
+            return '';
+        }
+
+        return '<div class="bootstrap"><div class="alert alert-success" role="alert">'
+            . $message
+            . '</div></div>';
+    }
+
     public function __construct()
     {
         $this->bootstrap = true;


### PR DESCRIPTION
## Summary
- add a reusable confirmation renderer to each module admin controller
- sanitize messages and support string or array inputs before outputting success alerts

## Testing
- php -l controllers/admin/AdminEverBlockController.php
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l controllers/admin/AdminEverBlockHookController.php
- php -l controllers/admin/AdminEverBlockShortcodeController.php

------
https://chatgpt.com/codex/tasks/task_e_68f5dcec56c08322a697aee09217844a