### PR TITLE
Improve shortcode documentation modal UI

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -2177,3 +2177,359 @@
         font-size: 1.8rem;
     }
 }
+
+/* -------------------------------------------------------------------------- */
+/* Shortcode modal                                                             */
+/* -------------------------------------------------------------------------- */
+
+.everblock-shortcode-modal .modal-dialog {
+    width: 95%;
+    max-width: 1200px;
+    margin: 30px auto;
+}
+
+.everblock-shortcode-modal .modal-content {
+    border: none;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 24px 60px rgba(16, 30, 115, 0.18);
+    background: #f7f9fc;
+}
+
+.everblock-shortcode-modal__header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2.5rem 3rem 2rem;
+    background: linear-gradient(135deg, #152642, #1f4788);
+    color: #fff;
+}
+
+.everblock-shortcode-modal__icon {
+    width: 64px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 32px;
+}
+
+.everblock-shortcode-modal__title {
+    margin: 0 0 0.35rem;
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+.everblock-shortcode-modal__subtitle {
+    margin: 0;
+    opacity: 0.85;
+    font-size: 1rem;
+}
+
+.everblock-shortcode-modal__close {
+    position: absolute;
+    top: 1.4rem;
+    right: 1.8rem;
+    border: none;
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    font-size: 1.5rem;
+    line-height: 1;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.everblock-shortcode-modal__close:hover,
+.everblock-shortcode-modal__close:focus {
+    background: rgba(255, 255, 255, 0.35);
+    transform: scale(1.05);
+}
+
+.everblock-shortcode-modal__tools {
+    padding: 1.5rem 3rem 0.5rem;
+}
+
+.everblock-shortcode-search .input-group-addon {
+    background: #fff;
+    border: none;
+    border-radius: 999px 0 0 999px;
+    font-size: 1.1rem;
+    color: #1f4788;
+    padding: 0 1rem;
+}
+
+.everblock-shortcode-search .form-control {
+    border-radius: 0;
+    border: none;
+    box-shadow: 0 1px 4px rgba(21, 38, 66, 0.12);
+    height: 48px;
+    font-size: 1rem;
+    padding: 0 1.2rem;
+}
+
+.everblock-shortcode-search .input-group-btn .btn {
+    border-radius: 0 999px 999px 0;
+    border: none;
+    background: #fff;
+    color: #1f4788;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0 1.5rem;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.everblock-shortcode-search .input-group-btn .btn:hover,
+.everblock-shortcode-search .input-group-btn .btn:focus {
+    background: #1f4788;
+    color: #fff;
+}
+
+.everblock-shortcode-clear.is-disabled {
+    opacity: 0.45;
+    pointer-events: none;
+}
+
+.everblock-shortcode-modal__body {
+    max-height: 65vh;
+    overflow-y: auto;
+    padding: 1.5rem 3rem 2rem;
+    position: relative;
+}
+
+.everblock-shortcode-modal__empty {
+    display: none;
+    text-align: center;
+    padding: 2rem 0;
+    color: #1f4788;
+}
+
+.everblock-shortcode-modal__empty.is-visible {
+    display: block;
+}
+
+.everblock-shortcode-modal__empty i {
+    font-size: 2.4rem;
+    margin-bottom: 0.75rem;
+    display: block;
+}
+
+.everblock-shortcode-modal__empty .btn {
+    font-weight: 600;
+    color: #1f4788;
+}
+
+.everblock-shortcode-categories {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.everblock-shortcode-category-card {
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(8, 25, 71, 0.08);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.everblock-shortcode-category-card.is-hidden {
+    display: none !important;
+}
+
+.everblock-shortcode-category-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(8, 25, 71, 0.12);
+}
+
+.everblock-shortcode-category-card__title {
+    margin: 0;
+    font-weight: 600;
+    color: #1a2b4f;
+}
+
+.everblock-shortcode-category-card__entries {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.everblock-shortcode-category-card__empty {
+    margin: 0;
+    color: rgba(26, 43, 79, 0.65);
+}
+
+.everblock-shortcode-entry {
+    background: #f5f8ff;
+    border-radius: 14px;
+    padding: 1.1rem 1.1rem 1rem;
+    border: 1px solid rgba(32, 56, 102, 0.08);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.everblock-shortcode-entry:hover {
+    border-color: rgba(32, 56, 102, 0.22);
+    box-shadow: 0 12px 24px rgba(8, 25, 71, 0.12);
+}
+
+.everblock-shortcode-entry__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.everblock-shortcode-entry__code {
+    background: #1f4788;
+    color: #fff;
+    padding: 0.35rem 0.6rem;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+
+.everblock-shortcode-entry__copy {
+    padding: 0.35rem 0.6rem;
+    border-radius: 8px;
+    color: #1f4788;
+    font-weight: 600;
+    text-decoration: none !important;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.everblock-shortcode-entry__copy:hover,
+.everblock-shortcode-entry__copy:focus {
+    background: rgba(31, 71, 136, 0.12);
+    color: #0f1f3c;
+}
+
+.everblock-shortcode-entry__copy.is-active {
+    background: #1f4788;
+    color: #fff;
+}
+
+.everblock-shortcode-entry__description {
+    margin: 0 0 0.75rem;
+    color: rgba(14, 28, 52, 0.85);
+}
+
+.everblock-shortcode-entry__params {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.everblock-shortcode-entry__param {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: rgba(14, 28, 52, 0.75);
+}
+
+.everblock-shortcode-entry__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.everblock-shortcode-entry__badge.is-required {
+    background: rgba(19, 181, 134, 0.15);
+    color: #0a8662;
+}
+
+.everblock-shortcode-entry__badge.is-optional {
+    background: rgba(21, 38, 66, 0.12);
+    color: #1f4788;
+}
+
+.everblock-shortcode-entry__param-name {
+    font-weight: 600;
+    color: #152642;
+}
+
+.everblock-shortcode-entry__param-description {
+    color: rgba(14, 28, 52, 0.65);
+}
+
+.everblock-shortcode-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    padding: 1.25rem 3rem 2.5rem;
+    background: #f7f9fc;
+}
+
+.everblock-shortcode-modal__footer .btn {
+    min-width: 140px;
+    font-weight: 600;
+}
+
+.everblock-shortcode-copy-temp {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+    opacity: 0;
+}
+
+@media (max-width: 991.98px) {
+    .everblock-shortcode-modal .modal-dialog {
+        width: 100%;
+        margin: 10px auto;
+    }
+
+    .everblock-shortcode-modal__header,
+    .everblock-shortcode-modal__tools,
+    .everblock-shortcode-modal__body,
+    .everblock-shortcode-modal__footer {
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+    }
+
+    .everblock-shortcode-categories {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .everblock-shortcode-modal__header {
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 2rem 1.5rem 1.75rem;
+    }
+
+    .everblock-shortcode-modal__close {
+        position: static;
+        align-self: flex-end;
+        margin-top: -1rem;
+    }
+
+    .everblock-shortcode-entry__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .everblock-shortcode-entry__code {
+        white-space: normal;
+    }
+}

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -65,61 +65,95 @@
     </div>
 </div>
 {if isset($everblock_shortcode_docs) && $everblock_shortcode_docs}
-    <div class="modal fade" id="everblockShortcodeModal" tabindex="-1" role="dialog" aria-labelledby="everblockShortcodeModalLabel">
-        <div class="modal-dialog modal-lg" role="document">
+    <div class="modal fade everblock-shortcode-modal" id="everblockShortcodeModal" tabindex="-1" role="dialog" aria-labelledby="everblockShortcodeModalLabel">
+        <div class="modal-dialog" role="document">
             <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='everblock'}">
+                <div class="everblock-shortcode-modal__header">
+                    <div class="everblock-shortcode-modal__icon" aria-hidden="true">
+                        <i class="icon-code"></i>
+                    </div>
+                    <div class="everblock-shortcode-modal__intro">
+                        <h3 class="everblock-shortcode-modal__title" id="everblockShortcodeModalLabel">
+                            {l s='Available shortcodes' mod='everblock'}
+                        </h3>
+                        <p class="everblock-shortcode-modal__subtitle">
+                            {l s='Use these shortcodes inside your blocks, CMS pages or PrettyBlocks zones.' mod='everblock'}
+                        </p>
+                    </div>
+                    <button type="button" class="everblock-shortcode-modal__close" data-dismiss="modal" aria-label="{l s='Close' mod='everblock'}">
                         <span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title" id="everblockShortcodeModalLabel">
-                        <i class="icon-code"></i> {l s='Available shortcodes' mod='everblock'}
-                    </h4>
                 </div>
-                <div class="modal-body">
-                    <p class="text-muted">
-                        {l s='Use these shortcodes inside your blocks, CMS pages or PrettyBlocks zones.' mod='everblock'}
-                    </p>
-                    {foreach from=$everblock_shortcode_docs item=everblock_shortcode_category}
-                        <div class="panel panel-default everblock-shortcode-panel">
-                            <div class="panel-heading">
-                                <strong>{$everblock_shortcode_category.title|escape:'htmlall':'UTF-8'}</strong>
-                            </div>
-                            <div class="panel-body">
+                <div class="everblock-shortcode-modal__tools">
+                    <label for="everblockShortcodeSearch" class="sr-only">
+                        {l s='Search shortcodes' mod='everblock'}
+                    </label>
+                    <div class="everblock-shortcode-search input-group">
+                        <span class="input-group-addon"><i class="icon-search"></i></span>
+                        <input type="search" class="form-control" id="everblockShortcodeSearch" placeholder="{l s='Search shortcodes…' mod='everblock'}" autocomplete="off">
+                        <span class="input-group-btn">
+                            <button class="btn btn-default everblock-shortcode-clear" type="button">
+                                {l s='Clear' mod='everblock'}
+                            </button>
+                        </span>
+                    </div>
+                </div>
+                <div class="everblock-shortcode-modal__body">
+                    <div class="everblock-shortcode-modal__empty">
+                        <i class="icon-warning-sign" aria-hidden="true"></i>
+                        <p>{l s='No shortcode matches your search. Try different keywords or reset the filters.' mod='everblock'}</p>
+                        <button type="button" class="btn btn-link everblock-shortcode-reset">
+                            {l s='Show all shortcodes' mod='everblock'}
+                        </button>
+                    </div>
+                    <div class="everblock-shortcode-categories">
+                        {foreach from=$everblock_shortcode_docs item=everblock_shortcode_category}
+                            <article class="everblock-shortcode-category-card">
+                                <header class="everblock-shortcode-category-card__header">
+                                    <h4 class="everblock-shortcode-category-card__title">{$everblock_shortcode_category.title|escape:'htmlall':'UTF-8'}</h4>
+                                </header>
                                 {if isset($everblock_shortcode_category.entries) && $everblock_shortcode_category.entries}
-                                    <ul class="list-unstyled everblock-shortcode-list">
+                                    <div class="everblock-shortcode-category-card__entries">
                                         {foreach from=$everblock_shortcode_category.entries item=everblock_shortcode_entry}
-                                            <li class="everblock-shortcode-list__item">
-                                                <div class="everblock-shortcode-list__header">
-                                                    <code class="everblock-shortcode-list__code">{$everblock_shortcode_entry.code|escape:'htmlall':'UTF-8'}</code>
+                                            <section class="everblock-shortcode-entry" data-everblock-shortcode-entry data-filter-text="{$everblock_shortcode_entry.code|escape:'htmlall':'UTF-8'} {$everblock_shortcode_entry.description|escape:'htmlall':'UTF-8'}{if isset($everblock_shortcode_entry.parameters) && $everblock_shortcode_entry.parameters}{foreach from=$everblock_shortcode_entry.parameters item=everblock_shortcode_param} {$everblock_shortcode_param.name|escape:'htmlall':'UTF-8'} {$everblock_shortcode_param.description|escape:'htmlall':'UTF-8'}{/foreach}{/if}">
+                                                <div class="everblock-shortcode-entry__header">
+                                                    <code class="everblock-shortcode-entry__code">{$everblock_shortcode_entry.code|escape:'htmlall':'UTF-8'}</code>
+                                                    <button type="button" class="btn btn-link everblock-shortcode-entry__copy" data-everblock-copy="{$everblock_shortcode_entry.code|escape:'htmlall':'UTF-8'}" title="{l s='Copy shortcode' mod='everblock'}">
+                                                        <i class="icon-files-o" aria-hidden="true"></i>
+                                                        <span class="sr-only">{l s='Copy shortcode' mod='everblock'}</span>
+                                                    </button>
                                                 </div>
-                                                <p class="everblock-shortcode-list__description">
+                                                <p class="everblock-shortcode-entry__description">
                                                     {$everblock_shortcode_entry.description|escape:'htmlall':'UTF-8'}
                                                 </p>
                                                 {if isset($everblock_shortcode_entry.parameters) && $everblock_shortcode_entry.parameters}
-                                                    <ul class="list-unstyled everblock-shortcode-params">
+                                                    <ul class="everblock-shortcode-entry__params">
                                                         {foreach from=$everblock_shortcode_entry.parameters item=everblock_shortcode_param}
-                                                            <li class="everblock-shortcode-params__item">
-                                                                <span class="label {if $everblock_shortcode_param.required}label-primary{else}label-default{/if}">
+                                                            <li class="everblock-shortcode-entry__param">
+                                                                <span class="everblock-shortcode-entry__badge {if $everblock_shortcode_param.required}is-required{else}is-optional{/if}">
                                                                     {if $everblock_shortcode_param.required}{l s='Required' mod='everblock'}{else}{l s='Optional' mod='everblock'}{/if}
                                                                 </span>
-                                                                <strong class="everblock-shortcode-params__name">{$everblock_shortcode_param.name|escape:'htmlall':'UTF-8'}</strong>
+                                                                <span class="everblock-shortcode-entry__param-name">{$everblock_shortcode_param.name|escape:'htmlall':'UTF-8'}</span>
                                                                 {if $everblock_shortcode_param.description}
-                                                                    <span class="everblock-shortcode-params__description">- {$everblock_shortcode_param.description|escape:'htmlall':'UTF-8'}</span>
+                                                                    <span class="everblock-shortcode-entry__param-description">{$everblock_shortcode_param.description|escape:'htmlall':'UTF-8'}</span>
                                                                 {/if}
                                                             </li>
                                                         {/foreach}
                                                     </ul>
                                                 {/if}
-                                            </li>
+                                            </section>
                                         {/foreach}
-                                    </ul>
+                                    </div>
+                                {else}
+                                    <p class="everblock-shortcode-category-card__empty">
+                                        {l s='No shortcodes are currently registered in this category.' mod='everblock'}
+                                    </p>
                                 {/if}
-                            </div>
-                        </div>
-                    {/foreach}
+                            </article>
+                        {/foreach}
+                    </div>
                 </div>
-                <div class="modal-footer">
+                <div class="everblock-shortcode-modal__footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">
                         {l s='Close' mod='everblock'}
                     </button>
@@ -127,4 +161,134 @@
             </div>
         </div>
     </div>
+    <script type="text/javascript">
+        (function ($) {
+            $(function () {
+                var $modal = $('#everblockShortcodeModal');
+                var $search = $('#everblockShortcodeSearch');
+                var $clearBtn = $modal.find('.everblock-shortcode-clear');
+                var $resetBtn = $modal.find('.everblock-shortcode-reset');
+                var $entries = $modal.find('[data-everblock-shortcode-entry]');
+                var $categories = $modal.find('.everblock-shortcode-category-card');
+                var $emptyState = $modal.find('.everblock-shortcode-modal__empty');
+
+                var updateClearButtonState = function () {
+                    var hasValue = $.trim($search.val()).length > 0;
+                    $clearBtn.prop('disabled', !hasValue).toggleClass('is-disabled', !hasValue);
+                };
+
+                var toggleEmptyState = function () {
+                    var visibleEntries = $entries.filter(':visible').length;
+                    if (visibleEntries === 0) {
+                        $emptyState.addClass('is-visible');
+                    } else {
+                        $emptyState.removeClass('is-visible');
+                    }
+                };
+
+                var refreshCategoriesVisibility = function () {
+                    $categories.each(function () {
+                        var $category = $(this);
+                        var totalEntries = $category.find('[data-everblock-shortcode-entry]').length;
+                        if (totalEntries === 0) {
+                            $category.removeClass('is-hidden');
+                            return;
+                        }
+                        var hasVisible = $category.find('[data-everblock-shortcode-entry]:visible').length > 0;
+                        $category.toggleClass('is-hidden', !hasVisible);
+                    });
+                };
+
+                var performSearch = function (query) {
+                    var term = $.trim(query).toLowerCase();
+                    if (term.length === 0) {
+                        $entries.show();
+                    } else {
+                        $entries.each(function () {
+                            var $entry = $(this);
+                            var text = ($entry.data('filterText') || '').toLowerCase();
+                            $entry.toggle(text.indexOf(term) !== -1);
+                        });
+                    }
+
+                    refreshCategoriesVisibility();
+                    toggleEmptyState();
+                    updateClearButtonState();
+                };
+
+                var resetSearch = function () {
+                    $search.val('');
+                    performSearch('');
+                    $search.focus();
+                };
+
+                $search.on('input', function () {
+                    performSearch($(this).val());
+                });
+
+                $clearBtn.on('click', function (event) {
+                    event.preventDefault();
+                    resetSearch();
+                });
+
+                $resetBtn.on('click', function (event) {
+                    event.preventDefault();
+                    resetSearch();
+                });
+
+                $modal.on('shown.bs.modal', function () {
+                    resetSearch();
+                });
+
+                var showCopyFeedback = function ($button, message) {
+                    var original = $button.data('originalLabel');
+                    if (!original) {
+                        original = $button.html();
+                        $button.data('originalLabel', original);
+                    }
+                    $button.addClass('is-active').html('<i class="icon-ok" aria-hidden="true"></i> ' + message);
+                    setTimeout(function () {
+                        $button.removeClass('is-active').html(original);
+                    }, 2000);
+                };
+
+                $modal.on('click', '[data-everblock-copy]', function (event) {
+                    event.preventDefault();
+                    var $button = $(this);
+                    var shortcode = $button.data('everblockCopy');
+                    if (!shortcode) {
+                        return;
+                    }
+
+                    var feedback = function (success) {
+                        var message = success ? "{l s='Copied!' mod='everblock' js=1}" : "{l s='Press Ctrl+C to copy' mod='everblock' js=1}";
+                        showCopyFeedback($button, message);
+                    };
+
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(shortcode).then(function () {
+                            feedback(true);
+                        }).catch(function () {
+                            feedback(false);
+                        });
+                    } else {
+                        var temp = $('<input type="text" class="everblock-shortcode-copy-temp" />');
+                        temp.val(shortcode).appendTo('body');
+                        temp[0].select();
+                        try {
+                            var success = document.execCommand('copy');
+                            feedback(success);
+                        } catch (error) {
+                            feedback(false);
+                        }
+                        temp.remove();
+                    }
+                });
+
+                refreshCategoriesVisibility();
+                toggleEmptyState();
+                updateClearButtonState();
+            });
+        })(jQuery);
+    </script>
 {/if}


### PR DESCRIPTION
## Summary
- redesign the available shortcodes modal with a modern hero header and prominent search tools
- lay out shortcode categories in responsive cards with rich parameter styling and copy buttons
- add JavaScript filtering, copy-to-clipboard feedback, and dedicated styles for the modal

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f5eb5cb1f88322acd3bb6be731c974