### PR TITLE
Revamp shortcode documentation modal styling

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -2183,8 +2183,8 @@
 /* -------------------------------------------------------------------------- */
 
 .everblock-shortcode-modal .modal-dialog {
-    width: 95%;
-    max-width: 1200px;
+    width: calc(100% - 3rem);
+    max-width: 1280px;
     margin: 30px auto;
 }
 
@@ -2194,6 +2194,9 @@
     overflow: hidden;
     box-shadow: 0 24px 60px rgba(16, 30, 115, 0.18);
     background: #f7f9fc;
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
 }
 
 .everblock-shortcode-modal__header {
@@ -2202,8 +2205,9 @@
     align-items: center;
     gap: 1.5rem;
     padding: 2.5rem 3rem 2rem;
-    background: linear-gradient(135deg, #152642, #1f4788);
+    background: radial-gradient(circle at top left, #3058a6, #1f3a71);
     color: #fff;
+    box-shadow: 0 10px 25px rgba(16, 30, 115, 0.45);
 }
 
 .everblock-shortcode-modal__icon {
@@ -2213,7 +2217,7 @@
     align-items: center;
     justify-content: center;
     border-radius: 18px;
-    background: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.14);
     font-size: 32px;
 }
 
@@ -2234,7 +2238,7 @@
     top: 1.4rem;
     right: 1.8rem;
     border: none;
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.16);
     color: #fff;
     width: 42px;
     height: 42px;
@@ -2251,43 +2255,67 @@
 }
 
 .everblock-shortcode-modal__tools {
-    padding: 1.5rem 3rem 0.5rem;
+    padding: 1.5rem 3rem 0.75rem;
+    background: linear-gradient(180deg, #f7f9fc 0%, #eff4ff 100%);
+    border-bottom: 1px solid rgba(15, 31, 60, 0.08);
+}
+
+.everblock-shortcode-search.input-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
 }
 
 .everblock-shortcode-search .input-group-addon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background: #fff;
     border: none;
-    border-radius: 999px 0 0 999px;
+    border-radius: 999px;
     font-size: 1.1rem;
     color: #1f4788;
     padding: 0 1rem;
+    box-shadow: 0 1px 3px rgba(21, 38, 66, 0.08);
 }
 
 .everblock-shortcode-search .form-control {
-    border-radius: 0;
-    border: none;
-    box-shadow: 0 1px 4px rgba(21, 38, 66, 0.12);
+    border-radius: 999px;
+    border: 1px solid rgba(21, 38, 66, 0.12);
+    box-shadow: inset 0 1px 2px rgba(15, 31, 60, 0.08);
     height: 48px;
     font-size: 1rem;
     padding: 0 1.2rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    flex: 1 1 auto;
+}
+
+.everblock-shortcode-search .form-control:focus {
+    border-color: rgba(31, 71, 136, 0.65);
+    box-shadow: 0 0 0 3px rgba(31, 71, 136, 0.15);
 }
 
 .everblock-shortcode-search .input-group-btn .btn {
-    border-radius: 0 999px 999px 0;
+    border-radius: 999px;
     border: none;
-    background: #fff;
-    color: #1f4788;
+    background: #1f4788;
+    color: #fff;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     padding: 0 1.5rem;
-    transition: background 0.2s ease, color 0.2s ease;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .everblock-shortcode-search .input-group-btn .btn:hover,
 .everblock-shortcode-search .input-group-btn .btn:focus {
-    background: #1f4788;
+    background: #152642;
     color: #fff;
+    box-shadow: 0 10px 18px rgba(21, 38, 66, 0.22);
+}
+
+.everblock-shortcode-search .input-group-btn {
+    display: flex;
 }
 
 .everblock-shortcode-clear.is-disabled {
@@ -2296,17 +2324,42 @@
 }
 
 .everblock-shortcode-modal__body {
-    max-height: 65vh;
+    flex: 1;
+    max-height: none;
     overflow-y: auto;
-    padding: 1.5rem 3rem 2rem;
+    padding: 1.75rem 3rem 2.5rem;
     position: relative;
+    background: linear-gradient(180deg, #f7f9fc 0%, #f4f7fd 35%, #f0f4ff 100%);
+    scroll-behavior: smooth;
+    scrollbar-gutter: stable both-edges;
+}
+
+.everblock-shortcode-modal__body::-webkit-scrollbar {
+    width: 10px;
+}
+
+.everblock-shortcode-modal__body::-webkit-scrollbar-track {
+    background: rgba(21, 38, 66, 0.05);
+    border-radius: 999px;
+}
+
+.everblock-shortcode-modal__body::-webkit-scrollbar-thumb {
+    background: rgba(31, 71, 136, 0.45);
+    border-radius: 999px;
+}
+
+.everblock-shortcode-modal__body::-webkit-scrollbar-thumb:hover {
+    background: rgba(21, 52, 110, 0.65);
 }
 
 .everblock-shortcode-modal__empty {
     display: none;
     text-align: center;
-    padding: 2rem 0;
+    padding: 3rem 1rem;
     color: #1f4788;
+    background: rgba(255, 255, 255, 0.85);
+    border: 1px dashed rgba(21, 38, 66, 0.25);
+    border-radius: 16px;
 }
 
 .everblock-shortcode-modal__empty.is-visible {
@@ -2322,23 +2375,27 @@
 .everblock-shortcode-modal__empty .btn {
     font-weight: 600;
     color: #1f4788;
+    text-decoration: underline;
 }
+
 
 .everblock-shortcode-categories {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
+    gap: 1.75rem;
 }
 
 .everblock-shortcode-category-card {
-    background: #fff;
-    border-radius: 16px;
+    position: relative;
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 18px;
     box-shadow: 0 10px 30px rgba(8, 25, 71, 0.08);
-    padding: 1.5rem;
+    padding: 1.75rem 1.75rem 1.6rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: 1px solid rgba(21, 38, 66, 0.05);
 }
 
 .everblock-shortcode-category-card.is-hidden {
@@ -2347,13 +2404,56 @@
 
 .everblock-shortcode-category-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 18px 40px rgba(8, 25, 71, 0.12);
+    box-shadow: 0 20px 48px rgba(8, 25, 71, 0.16);
+}
+
+.everblock-shortcode-category-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 18px;
+    pointer-events: none;
+    background: linear-gradient(135deg, rgba(49, 86, 170, 0.12), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.everblock-shortcode-category-card:hover::before {
+    opacity: 1;
+}
+
+.everblock-shortcode-category-card__header {
+    display: flex;
+    align-items: center;
+}
+
+.everblock-shortcode-category-card__heading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    justify-content: space-between;
 }
 
 .everblock-shortcode-category-card__title {
     margin: 0;
     font-weight: 600;
-    color: #1a2b4f;
+    color: #13244a;
+}
+
+.everblock-shortcode-category-card__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    height: 28px;
+    padding: 0 0.75rem;
+    border-radius: 999px;
+    background: rgba(31, 71, 136, 0.12);
+    color: #1f4788;
+    font-weight: 600;
+    font-size: 0.85rem;
+    box-shadow: inset 0 1px 2px rgba(15, 31, 60, 0.08);
 }
 
 .everblock-shortcode-category-card__entries {
@@ -2368,16 +2468,33 @@
 }
 
 .everblock-shortcode-entry {
-    background: #f5f8ff;
-    border-radius: 14px;
-    padding: 1.1rem 1.1rem 1rem;
+    position: relative;
+    background: linear-gradient(180deg, rgba(245, 248, 255, 0.95) 0%, rgba(237, 243, 255, 0.95) 100%);
+    border-radius: 16px;
+    padding: 1.2rem 1.2rem 1.15rem;
     border: 1px solid rgba(32, 56, 102, 0.08);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .everblock-shortcode-entry:hover {
-    border-color: rgba(32, 56, 102, 0.22);
-    box-shadow: 0 12px 24px rgba(8, 25, 71, 0.12);
+    border-color: rgba(32, 56, 102, 0.28);
+    box-shadow: 0 18px 38px rgba(8, 25, 71, 0.15);
+    transform: translateY(-2px);
+}
+
+.everblock-shortcode-entry::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(31, 71, 136, 0.16), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    pointer-events: none;
+}
+
+.everblock-shortcode-entry:hover::before {
+    opacity: 1;
 }
 
 .everblock-shortcode-entry__header {
@@ -2386,32 +2503,38 @@
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
+    position: relative;
 }
 
 .everblock-shortcode-entry__code {
-    background: #1f4788;
-    color: #fff;
-    padding: 0.35rem 0.6rem;
-    border-radius: 8px;
-    font-size: 0.95rem;
+    font-size: 1.05rem;
     font-weight: 600;
-    letter-spacing: 0.04em;
-    white-space: nowrap;
+    color: #13244a;
+    background: #fff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 10px;
+    box-shadow: inset 0 1px 2px rgba(21, 38, 66, 0.12);
+    font-family: "SFMono-Regular", "Menlo", "Monaco", "Consolas", monospace;
 }
 
 .everblock-shortcode-entry__copy {
-    padding: 0.35rem 0.6rem;
-    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
     color: #1f4788;
     font-weight: 600;
     text-decoration: none !important;
-    transition: background 0.2s ease, color 0.2s ease;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .everblock-shortcode-entry__copy:hover,
 .everblock-shortcode-entry__copy:focus {
     background: rgba(31, 71, 136, 0.12);
     color: #0f1f3c;
+    box-shadow: 0 8px 18px rgba(15, 31, 60, 0.16);
 }
 
 .everblock-shortcode-entry__copy.is-active {
@@ -2431,6 +2554,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+    border-top: 1px solid rgba(32, 56, 102, 0.12);
+    padding-top: 0.75rem;
 }
 
 .everblock-shortcode-entry__param {
@@ -2476,8 +2601,9 @@
 .everblock-shortcode-modal__footer {
     display: flex;
     justify-content: flex-end;
-    padding: 1.25rem 3rem 2.5rem;
-    background: #f7f9fc;
+    padding: 1.5rem 3rem 2.75rem;
+    background: linear-gradient(180deg, #f4f7fd 0%, #f7f9fc 100%);
+    border-top: 1px solid rgba(15, 31, 60, 0.06);
 }
 
 .everblock-shortcode-modal__footer .btn {
@@ -2494,8 +2620,8 @@
 
 @media (max-width: 991.98px) {
     .everblock-shortcode-modal .modal-dialog {
-        width: 100%;
-        margin: 10px auto;
+        width: calc(100% - 1.5rem);
+        margin: 15px auto;
     }
 
     .everblock-shortcode-modal__header,
@@ -2516,6 +2642,7 @@
         flex-direction: column;
         align-items: flex-start;
         padding: 2rem 1.5rem 1.75rem;
+        gap: 1rem;
     }
 
     .everblock-shortcode-modal__close {
@@ -2531,5 +2658,11 @@
 
     .everblock-shortcode-entry__code {
         white-space: normal;
+    }
+
+    .everblock-shortcode-category-card__heading {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
     }
 }

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -108,9 +108,22 @@
                     </div>
                     <div class="everblock-shortcode-categories">
                         {foreach from=$everblock_shortcode_docs item=everblock_shortcode_category}
+                            {assign var=shortcodeCount value=($everblock_shortcode_category.entries|default:[])|@count}
                             <article class="everblock-shortcode-category-card">
                                 <header class="everblock-shortcode-category-card__header">
-                                    <h4 class="everblock-shortcode-category-card__title">{$everblock_shortcode_category.title|escape:'htmlall':'UTF-8'}</h4>
+                                    <div class="everblock-shortcode-category-card__heading">
+                                        <h4 class="everblock-shortcode-category-card__title">{$everblock_shortcode_category.title|escape:'htmlall':'UTF-8'}</h4>
+                                        {if $shortcodeCount}
+                                            <span class="everblock-shortcode-category-card__count" aria-hidden="true">{$shortcodeCount}</span>
+                                            <span class="sr-only">
+                                                {if $shortcodeCount == 1}
+                                                    {l s='1 shortcode in this category' mod='everblock'}
+                                                {else}
+                                                    {l s='%d shortcodes in this category' sprintf=[$shortcodeCount] mod='everblock'}
+                                                {/if}
+                                            </span>
+                                        {/if}
+                                    </div>
                                 </header>
                                 {if isset($everblock_shortcode_category.entries) && $everblock_shortcode_category.entries}
                                     <div class="everblock-shortcode-category-card__entries">


### PR DESCRIPTION
## Summary
- modernize the shortcode documentation modal with a gradient hero header, expanded layout, and improved search tools
- refresh shortcode cards and entries with richer hover states, refined typography, and accessible category counters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5f2f4ea7c8322bc69a36332156e5e