### PR TITLE
Rename Google Maps tab and move Places credentials

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1030,7 +1030,7 @@ class Everblock extends Module
             'settings' => $this->l('Réglages'),
             'stats' => $this->l('Statistiques'),
             'meta_tools' => $this->l('Meta Tools'),
-            'google_maps' => $this->l('Google Maps'),
+            'google_maps' => $this->l('Google Tools'),
             'migration' => $this->l('Migration des URL'),
             'tools' => $this->l('Outils'),
             'files' => $this->l('Gestionnaire de fichiers'),
@@ -1378,18 +1378,6 @@ class Everblock extends Module
             ],
             [
                 'type' => 'text',
-                'label' => $this->l('Google Places API key'),
-                'desc' => $this->l('API key used to retrieve reviews from Google Places.'),
-                'name' => 'EVERBLOCK_GOOGLE_API_KEY',
-            ],
-            [
-                'type' => 'text',
-                'label' => $this->l('Google Place ID'),
-                'desc' => $this->l('Place identifier for your business listing.'),
-                'name' => 'EVERBLOCK_GOOGLE_PLACE_ID',
-            ],
-            [
-                'type' => 'text',
                 'label' => $this->l('Maximum number of reviews'),
                 'desc' => $this->l('Number of reviews to display (minimum 1).'),
                 'name' => 'EVERBLOCK_GOOGLE_REVIEWS_LIMIT',
@@ -1499,6 +1487,18 @@ class Everblock extends Module
                 'name' => 'anchor_everblock_google_maps',
                 'html_content' => '<span id="everblock_google_maps"></span>',
                 'form_group_class' => 'hidden everblock-anchor',
+            ],
+            [
+                'type' => 'text',
+                'label' => $this->l('Google Places API key'),
+                'desc' => $this->l('API key used to retrieve reviews from Google Places.'),
+                'name' => 'EVERBLOCK_GOOGLE_API_KEY',
+            ],
+            [
+                'type' => 'text',
+                'label' => $this->l('Google Place ID'),
+                'desc' => $this->l('Place identifier for your business listing.'),
+                'name' => 'EVERBLOCK_GOOGLE_PLACE_ID',
             ],
             [
                 'type' => 'text',

--- a/views/templates/admin/config/docs/google_maps.tpl
+++ b/views/templates/admin/config/docs/google_maps.tpl
@@ -18,9 +18,9 @@
     <div class="card-body">
         <h3 class="card-title">
             <i class="icon-map-marker"></i>
-            {l s='Google Maps settings' mod='everblock'}
+            {l s='Google Tools settings' mod='everblock'}
         </h3>
-        <p>{l s='Configure the Google Maps integration used by the store locator shortcode.' mod='everblock'}</p>
+        <p>{l s='Configure the Google APIs used by the store locator and reviews shortcodes.' mod='everblock'}</p>
         <ul>
             <li>{l s='Generate an API key with Places and Maps JavaScript enabled so the autocomplete widget can work on CMS pages.' mod='everblock'}</li>
             <li>{l s='Upload your own SVG marker to match your branding. Leave it empty to keep the default pin.' mod='everblock'}</li>


### PR DESCRIPTION
## Summary
- rename the module configuration tab from Google Maps to Google Tools
- move the Google Places API key and Place ID inputs into the Google Tools tab
- refresh the configuration documentation text to reflect the new Google Tools scope

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f633096d908322afeb90a60f16ae5d