### PR TITLE
Document handling of Google Places key and Place ID

### DIFF
--- a/views/templates/admin/config/docs/google_maps.tpl
+++ b/views/templates/admin/config/docs/google_maps.tpl
@@ -25,6 +25,10 @@
             <li>{l s='Generate an API key with Places and Maps JavaScript enabled so the autocomplete widget can work on CMS pages.' mod='everblock'}</li>
             <li>{l s='Upload your own SVG marker to match your branding. Leave it empty to keep the default pin.' mod='everblock'}</li>
             <li>{l s='Remember to clear the module cache after changing the marker if the old icon is still displayed.' mod='everblock'}</li>
+            <li>{l s='Paste the Google Places API key into the dedicated field and save the settings each time you rotate or restrict the key.' mod='everblock'}</li>
+            <li>{l s='Store your Google Place ID in the provided field so the reviews shortcode knows which location to display.' mod='everblock'}</li>
         </ul>
+        <p>{l s='Use the Google Place ID Finder from Google Maps Platform to retrieve the identifier that matches the location of your store, then copy it here.' mod='everblock'}</p>
+        <p>{l s='If your API key changes or you revoke access from the Google Cloud console, update the key in this tab to keep the autocomplete widget and reviews working.' mod='everblock'}</p>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- document how to manage the Google Places API key and store it in the module settings
- explain where to add the Google Place ID and how to retrieve it for reviews

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f6398cde1c83228144410a1cad035b