### PR TITLE
Refactor EverblockTools into service

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -79,7 +79,7 @@ return [
     'src/Service/ShortcodeDocumentationProvider.php',
     'models/EverblockShortcode.php',
     'models/EverblockTabsClass.php',
-    'models/EverblockTools.php',
+    'src/Service/EverblockTools.php',
     'models/index.php',
     'output/index.php',
     'sql/index.php',

--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -20,8 +20,7 @@
 if (!defined('_PS_VERSION_')) {
     exit;
 }
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
-
+use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockController extends ModuleAdminController

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -21,9 +21,9 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
 
+use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockFaqController extends ModuleAdminController

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -21,8 +21,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
-
+use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockHookController extends ModuleAdminController

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -21,9 +21,9 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockShortcode.php';
 
+use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
 class AdminEverBlockShortcodeController extends ModuleAdminController

--- a/controllers/front/lookbook.php
+++ b/controllers/front/lookbook.php
@@ -21,6 +21,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Everblock\Tools\Service\EverblockTools;
+
 class EverblockLookbookModuleFrontController extends ModuleFrontController
 {
     public function initContent()

--- a/controllers/front/modal.php
+++ b/controllers/front/modal.php
@@ -22,6 +22,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Everblock\Tools\Service\EverblockTools;
+
 class EverblockmodalModuleFrontController extends ModuleFrontController
 {
     public function init()

--- a/controllers/front/videoproducts.php
+++ b/controllers/front/videoproducts.php
@@ -21,6 +21,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Everblock\Tools\Service\EverblockTools;
+
 class EverblockVideoproductsModuleFrontController extends ModuleFrontController
 {
     public function initContent()

--- a/everblock.php
+++ b/everblock.php
@@ -24,7 +24,6 @@ if (!defined('_PS_VERSION_')) {
 require_once('vendor/autoload.php');
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockShortcode.php';
-require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTools.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockTabsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFlagsClass.php';
 require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockFaq.php';
@@ -34,6 +33,7 @@ use \PrestaShop\PrestaShop\Core\Product\ProductPresenter;
 use Everblock\Tools\Checkout\EverblockCheckoutStep;
 use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockCache;
+use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ImportFile;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -42,6 +42,8 @@ use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\ProductExtraContent;
 use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 use ScssPhp\ScssPhp\Compiler;
+
+class_exists(EverblockTools::class);
 
 class Everblock extends Module
 {

--- a/src/Command/ExecuteAction.php
+++ b/src/Command/ExecuteAction.php
@@ -30,7 +30,7 @@ use Db;
 use DbQuery;
 use Everblock\Tools\Service\ImportFile;
 use Everblock\Tools\Service\EverblockCache;
-use EverblockTools;
+use Everblock\Tools\Service\EverblockTools;
 use Language;
 use Module;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;

--- a/src/Command/PrettyBlocksCommand.php
+++ b/src/Command/PrettyBlocksCommand.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Module;
 use Validate;
 use Db;
-use EverblockTools;
+use Everblock\Tools\Service\EverblockTools;
 
 class PrettyBlocksCommand extends Command
 {

--- a/src/Command/SearchReplaceCommand.php
+++ b/src/Command/SearchReplaceCommand.php
@@ -31,6 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use Module;
 use Configuration;
+use Everblock\Tools\Service\EverblockTools;
 
 class SearchReplaceCommand extends Command
 {
@@ -58,7 +59,7 @@ class SearchReplaceCommand extends Command
             $idShop = (int) Configuration::get('PS_SHOP_DEFAULT');
         }
 
-        $result = \EverblockTools::migrateUrls($search, $replace, (int) $idShop);
+        $result = EverblockTools::migrateUrls($search, $replace, (int) $idShop);
 
         foreach ($result['postErrors'] as $error) {
             $output->writeln('<error>' . $error . '</error>');

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -24,7 +24,7 @@ use Configuration;
 use EverBlockClass;
 use Everblock\Tools\Service\EverblockCache;
 use EverblockShortcode;
-use EverblockTools;
+use Everblock\Tools\Service\EverblockTools;
 use Hook;
 use Module;
 use PrettyBlocksModel;

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -17,16 +17,62 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
-use Everblock\Tools\Service\EverblockCache;
+
+namespace Everblock\Tools\Service;
+
+use Address;
+use Cart;
+use CartRule;
+use Category;
+use CMS;
+use Combination;
+use Configuration;
+use Context;
+use Country;
+use Customer;
+use Db;
+use DbQuery;
+use DirectoryIterator;
+use Everblock;
+use EverblockClass;
+use EverblockFaq;
+use EverblockShortcode;
+use Gender;
+use Hook;
+use Image;
+use ImageManager;
+use ImageType;
+use Language;
+use Link;
+use Media;
+use Module;
+use NewsletterProSubscription;
+use ObjectModel;
+use PrestaShop\Module\PrestashopCheckout\Order\PaymentStepCheckoutOrderBuilder;
+use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Adapter\Product\ProductPresenterFactory;
+use PrestaShop\PrestaShop\Adapter\StockManager as StockManagerAdapter;
+use PrestaShop\PrestaShop\Core\Product\ProductAssembler;
+use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
+use PrestaShop\PrestaShop\Core\Product\ProductPresenter;
+use PrestaShopDatabaseException;
+use PrestaShopException;
+use PrestaShopLogger;
+use Product;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use StockAvailable;
+use Store;
+use Tools;
+use Validate;
+use WebP;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
-use PrestaShop\PrestaShop\Core\Product\ProductPresenter;
-use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
-use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
-use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
-use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 
 class EverblockTools extends ObjectModel
 {
@@ -5785,3 +5831,5 @@ class EverblockTools extends ObjectModel
     }
 
 }
+
+class_alias(__NAMESPACE__ . '\\EverblockTools', 'EverblockTools');


### PR DESCRIPTION
## Summary
- move `EverblockTools` into `src/Service` under the module namespace and keep a global alias for legacy consumers
- update the module entry point, controllers, and console commands to import the service instead of requiring the old model file
- refresh the allow-list to point at the new service location

## Testing
- php -l src/Service/EverblockTools.php
- php -l controllers/front/modal.php
- php -l controllers/front/lookbook.php
- php -l controllers/front/videoproducts.php
- php -l src/Command/ExecuteAction.php
- php -l src/Command/PrettyBlocksCommand.php
- php -l src/Command/SearchReplaceCommand.php
- php -l controllers/admin/AdminEverBlockController.php

------
https://chatgpt.com/codex/tasks/task_e_68f65e6309f08322927be6f242491830