### PR TITLE
Handle ProductAssembler availability

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -55,7 +55,6 @@ use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\ProductPresenterFactory;
 use PrestaShop\PrestaShop\Adapter\StockManager as StockManagerAdapter;
-use PrestaShop\PrestaShop\Core\Product\ProductAssembler;
 use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Core\Product\ProductPresenter;
 use PrestaShopDatabaseException;
@@ -589,7 +588,7 @@ class EverblockTools extends ObjectModel
                         }, $rows);
                         $products = static::everPresentProducts($ids, $context);
                     } else {
-                        $assembler = new ProductAssembler($context);
+                        $assembler = static::createProductAssembler($context);
                         $presenterFactory = new ProductPresenterFactory($context);
                         $presentationSettings = $presenterFactory->getPresentationSettings();
                         $presenter = new ProductListingPresenter(
@@ -4667,7 +4666,7 @@ class EverblockTools extends ObjectModel
 
         if (!EverblockCache::isCacheStored($cacheId)) {
             if (!empty($result)) {
-                $assembler = new ProductAssembler($context);
+                $assembler = static::createProductAssembler($context);
                 $presenterFactory = new ProductPresenterFactory($context);
                 $presentationSettings = $presenterFactory->getPresentationSettings();
 
@@ -5792,6 +5791,23 @@ class EverblockTools extends ObjectModel
         $data = static::replaceUrlsRecursively($data, $oldUrl, $newUrl);
 
         return json_encode($data);
+    }
+
+    private static function createProductAssembler(Context $context)
+    {
+        if (class_exists(\PrestaShop\PrestaShop\Core\Product\ProductAssembler::class)) {
+            return new \PrestaShop\PrestaShop\Core\Product\ProductAssembler($context);
+        }
+
+        if (class_exists(\PrestaShop\PrestaShop\Adapter\Product\ProductAssembler::class)) {
+            return new \PrestaShop\PrestaShop\Adapter\Product\ProductAssembler($context);
+        }
+
+        if (class_exists(\PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductAssembler::class)) {
+            return new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductAssembler($context);
+        }
+
+        throw new \Exception('No suitable product assembler class found for this PrestaShop version.');
     }
 
     private static function replaceUrlsRecursively($data, $oldUrl, $newUrl)


### PR DESCRIPTION
## Summary
- add a compatibility helper that creates a ProductAssembler instance matching the available PrestaShop namespace
- update product retrieval flows to use the helper instead of the missing Core\Product class

## Testing
- php -l src/Service/EverblockTools.php

------
https://chatgpt.com/codex/tasks/task_e_68f7436e15348322ae0f8b3a310cedee