### PR TITLE
Refactor Prettyblock image slider to Bootstrap

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1966,6 +1966,13 @@ class EverblockPrettyBlocks
                                 'url' => '',
                             ],
                         ],
+                        'image_mobile' => [
+                            'type' => 'fileupload',
+                            'label' => 'Mobile layout image',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'name' => [
                             'type' => 'text',
                             'label' => 'Image title',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -830,6 +830,100 @@
     right: 10px;
 }
 
+/* Prettyblocks image slider (Bootstrap) */
+.prettyblocks-image-slider-wrapper {
+    max-width: 100%;
+}
+
+.prettyblocks-image-slider.carousel {
+    --prettyblocks-transition-speed: 600ms;
+}
+
+.prettyblocks-image-slider.carousel .carousel-inner {
+    border-radius: 0.75rem;
+    overflow: hidden;
+}
+
+.prettyblocks-slider-item-inner {
+    position: relative;
+}
+
+.prettyblocks-slider-picture,
+.prettyblocks-slider-image {
+    display: block;
+    width: 100%;
+}
+
+.prettyblocks-slider-image {
+    height: auto;
+}
+
+.prettyblocks-image-slider .carousel-indicators {
+    bottom: 1rem;
+    gap: 0.5rem;
+}
+
+.prettyblocks-image-slider .carousel-indicators li {
+    width: 0.75rem;
+    height: 0.75rem;
+    background-color: rgba(255, 255, 255, 0.6);
+    border: 0;
+    border-radius: 50%;
+    transition: transform 0.3s ease, background-color 0.3s ease;
+}
+
+.prettyblocks-image-slider .carousel-indicators li.active,
+.prettyblocks-image-slider .carousel-indicators li:hover {
+    background-color: #ffffff;
+    transform: scale(1.15);
+}
+
+.prettyblocks-image-slider .carousel-control-prev,
+.prettyblocks-image-slider .carousel-control-next {
+    width: 3rem;
+    height: 3rem;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 1;
+    background-color: rgba(0, 0, 0, 0.45);
+    border-radius: 50%;
+    transition: background-color 0.3s ease, opacity 0.3s ease;
+}
+
+.prettyblocks-image-slider .carousel-control-prev:hover,
+.prettyblocks-image-slider .carousel-control-next:hover {
+    background-color: rgba(0, 0, 0, 0.65);
+}
+
+.prettyblocks-image-slider .carousel-control-prev-icon,
+.prettyblocks-image-slider .carousel-control-next-icon {
+    filter: invert(1);
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.prettyblocks-image-slider.carousel .carousel-item {
+    transition: transform var(--prettyblocks-transition-speed, 600ms) ease-in-out,
+        opacity var(--prettyblocks-transition-speed, 600ms) ease-in-out;
+}
+
+@media (max-width: 767.98px) {
+    .prettyblocks-image-slider-wrapper {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+
+    .prettyblocks-image-slider .carousel-control-prev,
+    .prettyblocks-image-slider .carousel-control-next {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+
+    .prettyblocks-image-slider .carousel-indicators {
+        bottom: 0.5rem;
+    }
+}
+
 /* Store locator adjustments */
 #store_search {
     max-width: 400px;

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -187,35 +187,54 @@ $(document).ready(function(){
                 }]
             });
         });
-        $('.prettyblocks-image-slider:not(.slick-initialised)').each(function(){
-            var $slider = $(this);
-            if ($slider.children().length <= 1) {
+        $('.prettyblocks-image-slider').each(function(){
+            var $carousel = $(this);
+            if ($carousel.hasClass('prettyblocks-carousel-initialised')) {
                 return;
             }
-            var autoplay = parseInt($slider.data('autoplay'), 10) === 1;
-            var autoplaySpeed = parseInt($slider.data('autoplaySpeed'), 10);
-            if (isNaN(autoplaySpeed) || autoplaySpeed < 0) {
+            var $slides = $carousel.find('.carousel-item');
+            if ($slides.length <= 1) {
+                $carousel.addClass('prettyblocks-carousel-initialised');
+                return;
+            }
+            var autoplay = parseInt($carousel.data('autoplay'), 10) === 1;
+            var autoplaySpeed = parseInt($carousel.data('autoplaySpeed'), 10);
+            if (isNaN(autoplaySpeed) || autoplaySpeed <= 0) {
                 autoplaySpeed = 5000;
             }
-            var transitionSpeed = parseInt($slider.data('transitionSpeed'), 10);
-            if (isNaN(transitionSpeed) || transitionSpeed < 0) {
-                transitionSpeed = 500;
+            var transitionSpeed = parseInt($carousel.data('transitionSpeed'), 10);
+            if (!isNaN(transitionSpeed) && transitionSpeed > 0) {
+                $carousel.css('--prettyblocks-transition-speed', transitionSpeed + 'ms');
             }
-            var pauseOnHover = parseInt($slider.data('pauseOnHover'), 10) !== 0;
-            var showArrows = parseInt($slider.data('showArrows'), 10) === 1;
-            var showDots = parseInt($slider.data('showDots'), 10) === 1;
-            $slider.slick({
-                slidesToShow: 1,
-                slidesToScroll: 1,
-                autoplay: autoplay,
-                autoplaySpeed: autoplaySpeed,
-                speed: transitionSpeed,
-                arrows: showArrows,
-                dots: showDots,
-                adaptiveHeight: true,
-                pauseOnHover: pauseOnHover,
-            });
-            $slider.addClass('slick-initialised');
+            var pauseOnHover = parseInt($carousel.data('pauseOnHover'), 10) !== 0 ? 'hover' : false;
+            var config = {
+                interval: autoplay ? autoplaySpeed : false,
+                pause: pauseOnHover,
+                ride: autoplay ? 'carousel' : false,
+                wrap: true,
+                keyboard: true,
+                touch: true
+            };
+            try {
+                if (typeof bootstrap !== 'undefined' && typeof bootstrap.Carousel !== 'undefined') {
+                    var existingInstance = bootstrap.Carousel.getInstance($carousel[0]);
+                    if (existingInstance) {
+                        existingInstance.dispose();
+                    }
+                    var newInstance = new bootstrap.Carousel($carousel[0], config);
+                    if (!autoplay && newInstance && typeof newInstance.pause === 'function') {
+                        newInstance.pause();
+                    }
+                } else if (typeof $carousel.carousel === 'function') {
+                    $carousel.carousel(config);
+                    if (!autoplay) {
+                        $carousel.carousel('pause');
+                    }
+                }
+            } catch (e) {
+                console.error('Prettyblocks carousel initialization failed', e);
+            }
+            $carousel.addClass('prettyblocks-carousel-initialised');
         });
     }
     $('.ever_instagram img').on('click', function() {

--- a/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
@@ -46,66 +46,179 @@
       {/if}
     {/if}
     {if $isStateVisible}
+      {if (not isset($state.image.url) or $state.image.url eq '') and (not isset($state.image_mobile.url) or $state.image_mobile.url eq '')}
+        {assign var=isStateVisible value=false}
+      {/if}
+    {/if}
+    {if $isStateVisible}
       {assign var=visibleStatesCount value=$visibleStatesCount+1}
     {/if}
   {/foreach}
 
   {if $visibleStatesCount > 0}
-    <section class="prettyblocks-slider container-fluid px-0 mt-3 {if $block.settings.default.container}container{/if}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    {assign var=autoplayEnabled value=(isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay)}
+    {assign var=autoplayDelay value=$block.settings.slider_autoplay_delay|default:5000|intval}
+    {if $autoplayDelay <= 0}
+      {assign var=autoplayDelay value=5000}
+    {/if}
+    {assign var=transitionSpeed value=$block.settings.slider_transition_speed|default:500|intval}
+    {if $transitionSpeed <= 0}
+      {assign var=transitionSpeed value=500}
+    {/if}
+    {assign var=pauseOnHover value=(isset($block.settings.slider_pause_on_hover) && $block.settings.slider_pause_on_hover)}
+    {assign var=showArrows value=(isset($block.settings.slider_show_arrows) && $block.settings.slider_show_arrows && $visibleStatesCount > 1)}
+    {assign var=showDots value=(isset($block.settings.slider_show_dots) && $block.settings.slider_show_dots && $visibleStatesCount > 1)}
+    {assign var='carouselId' value="prettyblocks-carousel-{$block.id_prettyblocks}"}
+
+    <section class="prettyblocks-slider container-fluid px-0 mt-3 {if $block.settings.default.container}container{/if}"
+             style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
       <div class="prettyblocks-image-slider-wrapper position-relative px-2 px-md-0 pb-2">
-        <div class="prettyblocks-image-slider"
-             data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
-             data-autoplay-speed="{$block.settings.slider_autoplay_delay|default:5000|intval}"
-             data-transition-speed="{$block.settings.slider_transition_speed|default:500|intval}"
-             data-pause-on-hover="{if isset($block.settings.slider_pause_on_hover) && $block.settings.slider_pause_on_hover}1{else}0{/if}"
-             data-show-arrows="{if isset($block.settings.slider_show_arrows) && $block.settings.slider_show_arrows}1{else}0{/if}"
-             data-show-dots="{if isset($block.settings.slider_show_dots) && $block.settings.slider_show_dots}1{else}0{/if}">
-          {foreach from=$block.states item=state}
-            {assign var=isStateVisible value=true}
-            {assign var=startDateStr value=$state.start_date|default:''}
-            {if $startDateStr ne ''}
-              {assign var=startTimestamp value=$startDateStr|@strtotime}
-              {if $startTimestamp && $everblockNow < $startTimestamp}
-                {assign var=isStateVisible value=false}
-              {/if}
-            {/if}
-            {if $isStateVisible}
-              {assign var=endDateStr value=$state.end_date|default:''}
-              {if $endDateStr ne ''}
-                {assign var=endTimestamp value=$endDateStr|@strtotime}
-                {if $endTimestamp && $everblockNow > $endTimestamp}
+        <div id="{$carouselId}"
+             class="prettyblocks-image-slider carousel slide"
+             {if $autoplayEnabled}data-ride="carousel" data-bs-ride="carousel"{/if}
+             data-autoplay="{if $autoplayEnabled}1{else}0{/if}"
+             data-autoplay-speed="{$autoplayDelay}"
+             data-transition-speed="{$transitionSpeed}"
+             data-pause-on-hover="{if $pauseOnHover}1{else}0{/if}"
+             data-show-arrows="{if $showArrows}1{else}0{/if}"
+             data-show-dots="{if $showDots}1{else}0{/if}"
+             data-interval="{if $autoplayEnabled}{$autoplayDelay}{else}false{/if}"
+             data-bs-interval="{if $autoplayEnabled}{$autoplayDelay}{else}false{/if}"
+             data-pause="{if $pauseOnHover}hover{else}false{/if}"
+             data-bs-pause="{if $pauseOnHover}hover{else}false{/if}"
+             style="--prettyblocks-transition-speed: {$transitionSpeed}ms;">
+          {if $showDots}
+            <ol class="carousel-indicators">
+              {assign var='indicatorIndex' value=0}
+              {foreach from=$block.states item=state}
+                {assign var=isStateVisible value=true}
+                {assign var=startDateStr value=$state.start_date|default:''}
+                {if $startDateStr ne ''}
+                  {assign var=startTimestamp value=$startDateStr|@strtotime}
+                  {if $startTimestamp && $everblockNow < $startTimestamp}
+                    {assign var=isStateVisible value=false}
+                  {/if}
+                {/if}
+                {if $isStateVisible}
+                  {assign var=endDateStr value=$state.end_date|default:''}
+                  {if $endDateStr ne ''}
+                    {assign var=endTimestamp value=$endDateStr|@strtotime}
+                    {if $endTimestamp && $everblockNow > $endTimestamp}
+                      {assign var=isStateVisible value=false}
+                    {/if}
+                  {/if}
+                {/if}
+                {if $isStateVisible}
+                  {if (not isset($state.image.url) or $state.image.url eq '') and (not isset($state.image_mobile.url) or $state.image_mobile.url eq '')}
+                    {assign var=isStateVisible value=false}
+                  {/if}
+                {/if}
+                {if $isStateVisible}
+                  <li data-target="#{$carouselId}"
+                      data-slide-to="{$indicatorIndex}"
+                      data-bs-target="#{$carouselId}"
+                      data-bs-slide-to="{$indicatorIndex}"
+                      class="{if $indicatorIndex == 0}active{/if}"
+                      aria-label="{$state.name|escape:'htmlall'}"
+                      aria-current="{if $indicatorIndex == 0}true{else}false{/if}"></li>
+                  {assign var='indicatorIndex' value=$indicatorIndex+1}
+                {/if}
+              {/foreach}
+            </ol>
+          {/if}
+          <div class="carousel-inner">
+            {assign var='slideIndex' value=0}
+            {foreach from=$block.states item=state}
+              {assign var=isStateVisible value=true}
+              {assign var=startDateStr value=$state.start_date|default:''}
+              {if $startDateStr ne ''}
+                {assign var=startTimestamp value=$startDateStr|@strtotime}
+                {if $startTimestamp && $everblockNow < $startTimestamp}
                   {assign var=isStateVisible value=false}
                 {/if}
               {/if}
-            {/if}
-            {if $isStateVisible}
-              {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_img_slider_state_spacing_style'}
-              <div class="prettyblocks-slider-item">
-                <div class="prettyblocks-slider-item-inner" style="{$prettyblock_img_slider_state_spacing_style}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
-                  {if $state.link}
-                    {if $state.obfuscate}
-                      {assign var="obflink" value=$state.link|base64_encode}
-                      <span class="obflink d-block" data-obflink="{$obflink}">
-                    {else}
-                      <a href="{$state.link}" title="{$state.name}" {if $state.target_blank}target="_blank"{/if} class="d-block">
-                    {/if}
+              {if $isStateVisible}
+                {assign var=endDateStr value=$state.end_date|default:''}
+                {if $endDateStr ne ''}
+                  {assign var=endTimestamp value=$endDateStr|@strtotime}
+                  {if $endTimestamp && $everblockNow > $endTimestamp}
+                    {assign var=isStateVisible value=false}
                   {/if}
-                        <picture>
-                          <source srcset="{$state.image.url}" type="image/webp">
-                          <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                          <img src="{$state.image.url|replace:'.webp':'.jpg'}" title="{$state.name}" alt="{$state.name}" class="img img-fluid w-100 lazyload" loading="lazy">
-                        </picture>
-                  {if $state.link}
-                    {if $state.obfuscate}
-                      </span>
-                    {else}
-                      </a>
+                {/if}
+              {/if}
+              {if $isStateVisible}
+                {if (not isset($state.image.url) or $state.image.url eq '') and (not isset($state.image_mobile.url) or $state.image_mobile.url eq '')}
+                  {assign var=isStateVisible value=false}
+                {/if}
+              {/if}
+              {if $isStateVisible}
+                {assign var='desktopImageUrl' value=$state.image.url|default:''}
+                {assign var='desktopImageJpgUrl' value=$desktopImageUrl|replace:'.webp':'.jpg'}
+                {assign var='mobileImageUrl' value=$state.image_mobile.url|default:''}
+                {assign var='mobileImageJpgUrl' value=$mobileImageUrl|replace:'.webp':'.jpg'}
+                {assign var='fallbackImageUrl' value=$desktopImageUrl}
+                {assign var='fallbackImageJpgUrl' value=$desktopImageJpgUrl}
+                {if $fallbackImageUrl eq ''}
+                  {assign var='fallbackImageUrl' value=$mobileImageUrl}
+                  {assign var='fallbackImageJpgUrl' value=$mobileImageJpgUrl}
+                {/if}
+                {assign var='fallbackWidth' value=''}
+                {assign var='fallbackHeight' value=''}
+                {if isset($state.image.width) && $state.image.width > 0}
+                  {assign var='fallbackWidth' value=$state.image.width|intval}
+                {elseif isset($state.image_mobile.width) && $state.image_mobile.width > 0}
+                  {assign var='fallbackWidth' value=$state.image_mobile.width|intval}
+                {/if}
+                {if isset($state.image.height) && $state.image.height > 0}
+                  {assign var='fallbackHeight' value=$state.image.height|intval}
+                {elseif isset($state.image_mobile.height) && $state.image_mobile.height > 0}
+                  {assign var='fallbackHeight' value=$state.image_mobile.height|intval}
+                {/if}
+                {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_img_slider_state_spacing_style'}
+                <div class="carousel-item prettyblocks-slider-item{if $slideIndex == 0} active{/if}">
+                  <div class="prettyblocks-slider-item-inner" style="{$prettyblock_img_slider_state_spacing_style}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+                    {if $state.link}
+                      {if $state.obfuscate}
+                        {assign var="obflink" value=$state.link|base64_encode}
+                        <span class="obflink d-block" data-obflink="{$obflink}">
+                      {else}
+                        <a href="{$state.link}" title="{$state.name}" {if $state.target_blank}target="_blank"{/if} class="d-block">
+                      {/if}
                     {/if}
-                  {/if}
+                      <picture class="prettyblocks-slider-picture d-block w-100">
+                        {if $mobileImageUrl ne ''}
+                          <source media="(max-width: 767.98px)" srcset="{$mobileImageUrl}" type="image/webp">
+                          <source media="(max-width: 767.98px)" srcset="{$mobileImageJpgUrl}" type="image/jpeg">
+                        {/if}
+                        {if $desktopImageUrl ne ''}
+                          <source media="(min-width: 768px)" srcset="{$desktopImageUrl}" type="image/webp">
+                          <source media="(min-width: 768px)" srcset="{$desktopImageJpgUrl}" type="image/jpeg">
+                        {/if}
+                        <img src="{$fallbackImageJpgUrl}" title="{$state.name}" alt="{$state.name}" class="img img-fluid w-100 prettyblocks-slider-image lazyload" loading="lazy"{if $fallbackWidth ne ''} width="{$fallbackWidth}"{/if}{if $fallbackHeight ne ''} height="{$fallbackHeight}"{/if}>
+                      </picture>
+                    {if $state.link}
+                      {if $state.obfuscate}
+                        </span>
+                      {else}
+                        </a>
+                      {/if}
+                    {/if}
+                  </div>
                 </div>
-              </div>
-            {/if}
-          {/foreach}
+                {assign var='slideIndex' value=$slideIndex+1}
+              {/if}
+            {/foreach}
+          </div>
+          {if $showArrows}
+            <a class="carousel-control-prev" href="#{$carouselId}" role="button" data-slide="prev" data-bs-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="sr-only visually-hidden">Previous</span>
+            </a>
+            <a class="carousel-control-next" href="#{$carouselId}" role="button" data-slide="next" data-bs-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="sr-only visually-hidden">Next</span>
+            </a>
+          {/if}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace the Prettyblock image slider markup to use Bootstrap's carousel instead of Slick
- update the front-end script and styling to match the Bootstrap carousel behaviour and improve responsiveness
- allow configuring a dedicated mobile image for each slide in the Prettyblock image slider

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f74a0b51c08322a3cd82106ed7e120