### PR TITLE
Fix cover block column layout configuration

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -32,7 +32,7 @@
     <div class="row">
   {/if}
 {if isset($block.states) && $block.states}
-  {assign var='cover_columns_count' value=$block.settings.default.columns|default:'1'}
+  {assign var='cover_columns_count' value=$block.settings.columns|default:$block.settings.default.columns|default:'1'}
   {assign var='cover_columns_count' value=$cover_columns_count|intval}
   {if $cover_columns_count < 1}
     {assign var='cover_columns_count' value=1}


### PR DESCRIPTION
## Summary
- ensure the cover block reads the column setting when rendering repeater items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f75559775083229acc2656f6e4c4b8