### PR TITLE
Fix Prettyblock cover columns layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -625,6 +625,48 @@
 }
 
 /* Cover block */
+.prettyblock-cover-row {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.prettyblock-cover-row .prettyblock-cover-item {
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
+@media (min-width: 768px) {
+    .prettyblock-cover-row--cols-1 .prettyblock-cover-item {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    .prettyblock-cover-row--cols-2 .prettyblock-cover-item {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+
+    .prettyblock-cover-row--cols-3 .prettyblock-cover-item {
+        flex: 0 0 33.3333%;
+        max-width: 33.3333%;
+    }
+
+    .prettyblock-cover-row--cols-4 .prettyblock-cover-item {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+
+    .prettyblock-cover-row--cols-5 .prettyblock-cover-item {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+
+    .prettyblock-cover-row--cols-6 .prettyblock-cover-item {
+        flex: 0 0 16.6667%;
+        max-width: 16.6667%;
+    }
+}
+
 .prettyblock-cover-item {
     position: relative;
     overflow: hidden;

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -42,7 +42,7 @@
   {assign var='columns_row_classes' value=''}
   {assign var='columns_item_classes' value=''}
   {if $use_columns_layout}
-    {assign var='columns_row_classes' value="row row-cols-1 row-cols-md-"|cat:$cover_columns_count|cat:" g-0 prettyblock-cover-row"}
+    {assign var='columns_row_classes' value="row row-cols-1 row-cols-md-"|cat:$cover_columns_count|cat:" g-0 prettyblock-cover-row prettyblock-cover-row--cols-"|cat:$cover_columns_count}
     {assign var='columns_item_classes' value='col'}
   {/if}
   {if $use_slider}


### PR DESCRIPTION
## Summary
- ensure the Prettyblock cover layout wrapper exposes the selected column count
- add responsive flex-based styles so cover items render in the configured number of columns even without Bootstrap helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f75ab09d208322a33b7194bfbdb894