### PR TITLE
Add CSS alignment for center-bottom overlay positions

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -722,6 +722,11 @@
     align-items: flex-end;
     text-align: right;
 }
+.prettyblock-cover-overlay.position-desktop-center-bottom {
+    justify-content: flex-end;
+    align-items: center;
+    text-align: center;
+}
 
 @media (max-width: 767px) {
     .prettyblock-cover-item--parallax {
@@ -792,6 +797,11 @@
         justify-content: flex-end;
         align-items: flex-end;
         text-align: right;
+    }
+    .prettyblock-cover-overlay.position-mobile-center-bottom {
+        justify-content: flex-end;
+        align-items: center;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- add support for the center-bottom overlay alignment on desktop and mobile states

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f75c2c893c8322abc93a3e0d0aef75