### PR TITLE
Adjust cover block column item classes

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -630,44 +630,52 @@
     flex-wrap: wrap;
 }
 
-.prettyblock-cover-row .prettyblock-cover-item {
+.prettyblock-cover-row > .prettyblock-cover-item,
+.prettyblock-cover-row > .col {
     flex: 0 0 100%;
     max-width: 100%;
 }
 
 @media (min-width: 768px) {
-    .prettyblock-cover-row--cols-1 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-1 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-1 > .col {
         flex: 0 0 100%;
         max-width: 100%;
     }
 
-    .prettyblock-cover-row--cols-2 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-2 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-2 > .col {
         flex: 0 0 50%;
         max-width: 50%;
     }
 
-    .prettyblock-cover-row--cols-3 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-3 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-3 > .col {
         flex: 0 0 33.3333%;
         max-width: 33.3333%;
     }
 
-    .prettyblock-cover-row--cols-4 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-4 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-4 > .col {
         flex: 0 0 25%;
         max-width: 25%;
     }
 
-    .prettyblock-cover-row--cols-5 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-5 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-5 > .col {
         flex: 0 0 20%;
         max-width: 20%;
     }
 
-    .prettyblock-cover-row--cols-6 .prettyblock-cover-item {
+    .prettyblock-cover-row--cols-6 > .prettyblock-cover-item,
+    .prettyblock-cover-row--cols-6 > .col {
         flex: 0 0 16.6667%;
         max-width: 16.6667%;
     }
 }
 
-.prettyblock-cover-item {
+.prettyblock-cover-item,
+.prettyblock-cover-row > .col {
     position: relative;
     overflow: hidden;
 }

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -147,8 +147,12 @@
         {/if}
       {/capture}
       {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
+      {assign var='prettyblock_cover_item_base_class' value='prettyblock-cover-item'}
+      {if $use_columns_layout}
+        {assign var='prettyblock_cover_item_base_class' value=$columns_item_classes}
+      {/if}
       <div id="block-{$block.id_prettyblocks}-{$key}"
-           class="prettyblock-cover-item{if $columns_item_classes} {$columns_item_classes}{/if}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
+           class="{$prettyblock_cover_item_base_class}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
         {if isset($state.background_image.url) && $state.background_image.url}
           {if $state.parallax}
             {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}


### PR DESCRIPTION
## Summary
- ensure cover block column items output only the Bootstrap column class in the repeater
- update related styles so column items retain layout and positioning behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f75e65398883229901263de1729509