### PR TITLE
Adjust spacing between Prettyblock cover columns

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -630,6 +630,10 @@
     flex-wrap: wrap;
 }
 
+.prettyblock-cover-row--spaced {
+    gap: var(--prettyblock-cover-columns-gap, 2rem);
+}
+
 .prettyblock-cover-row > .prettyblock-cover-item,
 .prettyblock-cover-row > .col {
     flex: 0 0 100%;

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -42,8 +42,8 @@
   {assign var='columns_row_classes' value=''}
   {assign var='columns_item_classes' value=''}
   {if $use_columns_layout}
-    {assign var='columns_row_classes' value="row row-cols-1 row-cols-md-"|cat:$cover_columns_count|cat:" g-0 prettyblock-cover-row prettyblock-cover-row--cols-"|cat:$cover_columns_count}
-    {assign var='columns_item_classes' value='col'}
+    {assign var='columns_row_classes' value="row row-cols-1 row-cols-md-"|cat:$cover_columns_count|cat:" g-0 prettyblock-cover-row prettyblock-cover-row--cols-"|cat:$cover_columns_count|cat:" prettyblock-cover-row--spaced"}
+    {assign var='columns_item_classes' value='col prettyblock-cover-item'}
   {/if}
   {if $use_slider}
     <div class="ever-cover-carousel">


### PR DESCRIPTION
## Summary
- add a dedicated spacing class to the Prettyblock cover row when rendering multiple columns
- define a default column gap so the cover block columns match the intended layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f76c74d89083229cf021c7150a2b82