### PR TITLE
Adjust column class for Prettyblock cover layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -692,7 +692,8 @@
     min-height: 300px;
 }
 
-.prettyblock-cover-item img.prettyblock-cover-image {
+.prettyblock-cover-item img.prettyblock-cover-image,
+.prettyblock-cover-row > .col img.prettyblock-cover-image {
     width: 100%;
     height: auto;
     display: block;

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -45,7 +45,7 @@
   {assign var='columns_item_classes' value=''}
   {if $use_columns_layout}
     {assign var='columns_row_classes' value="row row-cols-1 row-cols-md-"|cat:$cover_columns_count|cat:" g-0 prettyblock-cover-row prettyblock-cover-row--cols-"|cat:$cover_columns_count|cat:" prettyblock-cover-row--spaced"}
-    {assign var='columns_item_classes' value='col prettyblock-cover-item'}
+    {assign var='columns_item_classes' value='col'}
   {/if}
   {if $use_slider}
     <div class="ever-cover-carousel">


### PR DESCRIPTION
## Summary
- remove the `prettyblock-cover-item` class from column layouts in the Prettyblock cover block
- ensure cover images inside column layouts retain their responsive sizing styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f79a0368fc83228d9bc8d6ed7487e2