### PR TITLE
Fix mobile fallback for Prettyblock image slider

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
@@ -157,6 +157,10 @@
                 {assign var='desktopImageJpgUrl' value=$desktopImageUrl|replace:'.webp':'.jpg'}
                 {assign var='mobileImageUrl' value=$state.image_mobile.url|default:''}
                 {assign var='mobileImageJpgUrl' value=$mobileImageUrl|replace:'.webp':'.jpg'}
+                {if $mobileImageUrl eq '' && $desktopImageUrl ne ''}
+                  {assign var='mobileImageUrl' value=$desktopImageUrl}
+                  {assign var='mobileImageJpgUrl' value=$desktopImageJpgUrl}
+                {/if}
                 {assign var='fallbackImageUrl' value=$desktopImageUrl}
                 {assign var='fallbackImageJpgUrl' value=$desktopImageJpgUrl}
                 {if $fallbackImageUrl eq ''}


### PR DESCRIPTION
## Summary
- ensure the Prettyblock image slider reuses the desktop asset when no mobile image is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7a60388ec8322b288b791b314bccc