### PR TITLE
Add Symfony admin route and grid for Ever Block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   ],
   "autoload": {
     "psr-4": {
-      "Everblock\\Tools\\": "src/"
+      "Everblock\\Tools\\": "src/",
+      "Everblock\\PrestaShopBundle\\": "src/PrestaShopBundle/"
     },
     "exclude-from-classmap": []
   },

--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -168,6 +168,7 @@ return [
     'views/templates/admin/block/docs/schedule.tpl',
     'views/templates/admin/block/docs/targeting.tpl',
     'views/templates/admin/configure.tpl',
+    'views/templates/admin/everblock/index.html.twig',
     'views/templates/admin/customerConnect.tpl',
     'views/templates/admin/footer.tpl',
     'views/templates/admin/header.tpl',

--- a/config/routes/admin/ever_block.yml
+++ b/config/routes/admin/ever_block.yml
@@ -1,0 +1,7 @@
+admin_everblock_index:
+  path: /everblock
+  methods: [GET]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::indexAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'

--- a/config/services.yml
+++ b/config/services.yml
@@ -45,3 +45,27 @@ services:
         tags:
             - { name: 'console.command' }
 
+    everblock.grid.definition.factory.ever_block:
+        class: Everblock\PrestaShopBundle\Grid\Definition\Factory\EverBlockGridDefinitionFactory
+        public: true
+        arguments:
+            - '@translator'
+            - '@prestashop.core.hook.dispatcher'
+
+    everblock.grid.data.factory.ever_block:
+        class: Everblock\PrestaShopBundle\Grid\Data\Factory\EverBlockGridDataFactory
+        public: true
+        arguments:
+            - '@doctrine.dbal.default_connection'
+            - '@prestashop.adapter.legacy.context'
+            - '%database_prefix%'
+
+    everblock.grid.factory.ever_block:
+        class: PrestaShop\PrestaShop\Core\Grid\GridFactory
+        public: true
+        arguments:
+            - '@everblock.grid.definition.factory.ever_block'
+            - '@everblock.grid.data.factory.ever_block'
+            - '@prestashop.core.grid.filter.form_factory'
+            - '@prestashop.core.hook.dispatcher'
+

--- a/src/PrestaShopBundle/Controller/Admin/EverBlockController.php
+++ b/src/PrestaShopBundle/Controller/Admin/EverBlockController.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\PrestaShopBundle\Controller\Admin;
+
+use Everblock\PrestaShopBundle\Grid\Search\Filters\EverBlockFilters;
+use Everblock\Tools\Service\ShortcodeDocumentationProvider;
+use Module;
+use PrestaShop\PrestaShop\Core\Grid\GridFactoryInterface;
+use PrestaShop\PrestaShop\Core\Toolbar\Button\ButtonCollection;
+use PrestaShop\PrestaShop\Core\Toolbar\Button\LinkToolbarButton;
+use PrestaShop\PrestaShop\Core\Toolbar\Button\SimpleButton;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Security\AdminUrlGenerator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tools;
+
+class EverBlockController extends FrameworkBundleAdminController
+{
+    private const MODULE_NAME = 'everblock';
+    private const TRANSLATION_DOMAIN = 'Modules.Everblock.Admin';
+
+    public function indexAction(Request $request): Response
+    {
+        /** @var GridFactoryInterface $gridFactory */
+        $gridFactory = $this->get('everblock.grid.factory.ever_block');
+
+        $filters = new EverBlockFilters($request->query->get(EverBlockFilters::FILTER_ID, []));
+        $grid = $gridFactory->getGrid($filters);
+
+        $module = Module::getInstanceByName(self::MODULE_NAME);
+        $legacyContext = $this->get('prestashop.adapter.legacy.context')->getContext();
+
+        $presentedGrid = $this->presentGrid($grid);
+        $toolbarButtons = $this->presentToolbarButtons($this->buildToolbarButtons($module));
+
+        $templateVariables = [
+            'layoutTitle' => $this->trans('HTML blocks Configuration', self::TRANSLATION_DOMAIN),
+            'layoutHeaderToolbarButtons' => $toolbarButtons,
+            'grid' => $presentedGrid,
+            'notifications' => $this->collectNotifications(),
+            'module' => $this->buildModuleViewModel($module),
+            'stats' => $module->getModuleStatistics(),
+            'displayUpgrade' => $module->checkLatestEverModuleVersion(),
+            'shortcodeDocumentation' => ShortcodeDocumentationProvider::getDocumentation($module),
+            'modulePublicPath' => _MODULE_DIR_ . self::MODULE_NAME . '/',
+            'configurationLink' => $this->getConfigurationLink($module),
+        ];
+
+        return $this->render('@Modules/everblock/views/templates/admin/everblock/index.html.twig', $templateVariables);
+    }
+
+    private function buildToolbarButtons(Module $module): ButtonCollection
+    {
+        $collection = new ButtonCollection();
+        $context = $this->get('prestashop.adapter.legacy.context')->getContext();
+        $adminLink = $context->link->getAdminLink('AdminEverBlock', true, [], [
+            'configure' => $module->name,
+            'module_name' => $module->name,
+        ]);
+
+        $collection->add((new SimpleButton('add-everblock'))
+            ->setLabel($this->trans('New block', self::TRANSLATION_DOMAIN))
+            ->setIcon('add_circle_outline')
+            ->setHref($context->link->getAdminLink('AdminEverBlock', true, [], [
+                'addeverblock' => 1,
+            ]))
+        );
+
+        $collection->add((new SimpleButton('clear-cache-everblock'))
+            ->setLabel($this->trans('Clear cache', self::TRANSLATION_DOMAIN))
+            ->setIcon('refresh')
+            ->setHref($context->link->getAdminLink('AdminEverBlock', true, [], [
+                'clearcache' => 1,
+            ]))
+        );
+
+        $collection->add((new LinkToolbarButton('configure-everblock'))
+            ->setLabel($this->trans('Configuration', self::TRANSLATION_DOMAIN))
+            ->setIcon('settings')
+            ->setHref($adminLink)
+        );
+
+        $collection->add((new LinkToolbarButton('download-example-everblock'))
+            ->setLabel($this->trans('Download Excel tabs sample file', self::TRANSLATION_DOMAIN))
+            ->setIcon('cloud_download')
+            ->setHref($this->getExampleTabsUrl($module))
+        );
+
+        return $collection;
+    }
+
+    private function collectNotifications(): array
+    {
+        $context = $this->get('prestashop.adapter.legacy.context')->getContext();
+        $controller = $context->controller;
+
+        $notifications = [
+            'success' => [],
+            'error' => [],
+            'warning' => [],
+            'info' => [],
+        ];
+
+        if (null !== $controller) {
+            if (property_exists($controller, 'confirmations')) {
+                $notifications['success'] = (array) $controller->confirmations;
+            }
+
+            if (property_exists($controller, 'errors')) {
+                $notifications['error'] = (array) $controller->errors;
+            }
+
+            if (property_exists($controller, 'warnings')) {
+                $notifications['warning'] = (array) $controller->warnings;
+            }
+
+            if (property_exists($controller, 'informations')) {
+                $notifications['info'] = (array) $controller->informations;
+            }
+        }
+
+        $session = $this->get('session');
+        foreach (['success', 'error', 'warning', 'info'] as $type) {
+            $flashKey = sprintf('everblock_%s', $type);
+            if ($session->getFlashBag()->has($flashKey)) {
+                $notifications[$type] = array_merge(
+                    $notifications[$type],
+                    $session->getFlashBag()->get($flashKey)
+                );
+            }
+        }
+
+        return $notifications;
+    }
+
+    private function buildModuleViewModel(Module $module): array
+    {
+        $context = $this->get('prestashop.adapter.legacy.context')->getContext();
+
+        return [
+            'name' => $module->displayName,
+            'version' => $module->version,
+            'donationLink' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            'blockAdminLink' => $context->link->getAdminLink('AdminEverBlock', true, [], [
+                'configure' => $module->name,
+                'module_name' => $module->name,
+            ]),
+            'faqAdminLink' => $context->link->getAdminLink('AdminEverBlockFaq', true, [], [
+                'configure' => $module->name,
+                'module_name' => $module->name,
+            ]),
+            'hookAdminLink' => $context->link->getAdminLink('AdminEverBlockHook', true, [], [
+                'configure' => $module->name,
+                'module_name' => $module->name,
+            ]),
+            'shortcodeAdminLink' => $context->link->getAdminLink('AdminEverBlockShortcode', true, [], [
+                'configure' => $module->name,
+                'module_name' => $module->name,
+            ]),
+            'modulesListLink' => $context->link->getAdminLink('AdminModules'),
+        ];
+    }
+
+    private function getExampleTabsUrl(Module $module): string
+    {
+        $baseUrl = Tools::getHttpHost(true) . __PS_BASE_URI__;
+
+        return $baseUrl . 'modules/' . $module->name . '/input/sample/tabs.xlsx';
+    }
+
+    private function getConfigurationLink(Module $module): string
+    {
+        /** @var AdminUrlGenerator $adminUrlGenerator */
+        $adminUrlGenerator = $this->get('prestashop.bundle.admin.url_generator');
+
+        return $adminUrlGenerator
+            ->setController('AdminModules')
+            ->setQueryParams([
+                'configure' => $module->name,
+                'module_name' => $module->name,
+            ])
+            ->generateUrl();
+    }
+
+    private function presentToolbarButtons(ButtonCollection $collection): array
+    {
+        return $this->get('prestashop.core.toolbar.presenter')->present($collection);
+    }
+}

--- a/src/PrestaShopBundle/Grid/Data/Factory/EverBlockGridDataFactory.php
+++ b/src/PrestaShopBundle/Grid/Data/Factory/EverBlockGridDataFactory.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\PrestaShopBundle\Grid\Data\Factory;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Grid\Data\Factory\GridDataFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+class EverBlockGridDataFactory implements GridDataFactoryInterface
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    public function __construct(Connection $connection, LegacyContext $legacyContext, string $dbPrefix)
+    {
+        $this->connection = $connection;
+        $this->legacyContext = $legacyContext;
+        $this->dbPrefix = $dbPrefix;
+    }
+
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $baseQueryBuilder = $this->getBaseQueryBuilder();
+        $this->applyFilters($baseQueryBuilder, $searchCriteria->getFilters());
+
+        $orderedQueryBuilder = clone $baseQueryBuilder;
+
+        $orderBy = $searchCriteria->getOrderBy();
+        if ('hname' === $orderBy) {
+            $orderBy = 'sort_key';
+        }
+
+        if (!$orderBy) {
+            $orderBy = 'sort_key';
+        }
+
+        $orderWay = $searchCriteria->getOrderWay() ?: 'asc';
+        $orderedQueryBuilder->orderBy($orderBy, $orderWay);
+
+        $offset = $searchCriteria->getOffset();
+        if (null !== $offset) {
+            $orderedQueryBuilder->setFirstResult((int) $offset);
+        }
+
+        $limit = $searchCriteria->getLimit();
+        if (null !== $limit) {
+            $orderedQueryBuilder->setMaxResults((int) $limit);
+        }
+
+        $records = $this->fetchAll($orderedQueryBuilder);
+
+        $countQueryBuilder = clone $baseQueryBuilder;
+        $countQueryBuilder->select('COUNT(eb.id_everblock)');
+        $filteredRecordsCount = (int) $this->fetchSingleColumn($countQueryBuilder);
+
+        $totalQueryBuilder = $this->getBaseQueryBuilder();
+        $totalRecords = (int) $this->fetchSingleColumn($totalQueryBuilder->select('COUNT(eb.id_everblock)'));
+
+        return new GridData($records, $totalRecords, $filteredRecordsCount);
+    }
+
+    private function getBaseQueryBuilder(): QueryBuilder
+    {
+        $context = $this->legacyContext->getContext();
+
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
+            ->from($this->dbPrefix . 'everblock', 'eb')
+            ->select('eb.*')
+            ->addSelect('h.title AS hname')
+            ->addSelect("CONCAT(IFNULL(h.title, ''), LPAD(eb.position, 10, '0')) AS sort_key")
+            ->leftJoin('eb', $this->dbPrefix . 'hook', 'h', 'h.id_hook = eb.id_hook')
+            ->andWhere('eb.id_shop = :id_shop')
+            ->setParameter('id_shop', (int) $context->shop->id);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param array<string, mixed> $filters
+     */
+    private function applyFilters(QueryBuilder $queryBuilder, array $filters): void
+    {
+        foreach ($filters as $filterName => $value) {
+            if ('' === $value || null === $value) {
+                continue;
+            }
+
+            switch ($filterName) {
+                case 'id_everblock':
+                case 'position':
+                    $queryBuilder->andWhere(sprintf('eb.%s = :%s', $filterName, $filterName));
+                    $queryBuilder->setParameter($filterName, (int) $value);
+                    break;
+                case 'hname':
+                    $queryBuilder->andWhere('h.title LIKE :hname');
+                    $queryBuilder->setParameter('hname', '%' . $value . '%');
+                    break;
+                case 'name':
+                    $queryBuilder->andWhere('eb.name LIKE :name');
+                    $queryBuilder->setParameter('name', '%' . $value . '%');
+                    break;
+                case 'date_start':
+                case 'date_end':
+                    $queryBuilder->andWhere(sprintf('eb.%s LIKE :%s', $filterName, $filterName));
+                    $queryBuilder->setParameter($filterName, '%' . $value . '%');
+                    break;
+                case 'only_home':
+                case 'only_category':
+                case 'only_manufacturer':
+                case 'only_supplier':
+                case 'only_cms_category':
+                case 'modal':
+                case 'active':
+                    $queryBuilder->andWhere(sprintf('eb.%s = :%s', $filterName, $filterName));
+                    $queryBuilder->setParameter($filterName, (int) $value);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchAll(QueryBuilder $queryBuilder): array
+    {
+        if (method_exists($queryBuilder, 'executeQuery')) {
+            $result = $queryBuilder->executeQuery();
+
+            return method_exists($result, 'fetchAllAssociative')
+                ? $result->fetchAllAssociative()
+                : $result->fetchAll();
+        }
+
+        $statement = $queryBuilder->execute();
+
+        if (method_exists($statement, 'fetchAllAssociative')) {
+            return $statement->fetchAllAssociative();
+        }
+
+        return $statement->fetchAll();
+    }
+
+    private function fetchSingleColumn(QueryBuilder $queryBuilder): int
+    {
+        if (method_exists($queryBuilder, 'executeQuery')) {
+            $result = $queryBuilder->executeQuery();
+
+            if (method_exists($result, 'fetchOne')) {
+                return (int) $result->fetchOne();
+            }
+
+            return (int) $result->fetchColumn();
+        }
+
+        $statement = $queryBuilder->execute();
+
+        if (method_exists($statement, 'fetchOne')) {
+            return (int) $statement->fetchOne();
+        }
+
+        return (int) $statement->fetchColumn();
+    }
+}

--- a/src/PrestaShopBundle/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
+++ b/src/PrestaShopBundle/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\PrestaShopBundle\Grid\Definition\Factory;
+
+use Everblock\PrestaShopBundle\Grid\Search\Filters\EverBlockFilters;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class EverBlockGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    protected function getId(): string
+    {
+        return EverBlockFilters::FILTER_ID;
+    }
+
+    protected function getName(): string
+    {
+        return $this->trans('HTML blocks', 'Modules.Everblock.Admin');
+    }
+
+    protected function getColumns(): ColumnCollection
+    {
+        $columns = new ColumnCollection();
+
+        $columns->add((new DataColumn('id_everblock'))
+            ->setName($this->trans('ID', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'id_everblock',
+            ])
+        );
+
+        $columns->add((new DataColumn('name'))
+            ->setName($this->trans('Name', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'name',
+            ])
+        );
+
+        $columns->add((new DataColumn('hname'))
+            ->setName($this->trans('Hook', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'hname',
+            ])
+        );
+
+        $columns->add((new DataColumn('position'))
+            ->setName($this->trans('Position', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'position',
+            ])
+        );
+
+        foreach ([
+            'only_home' => $this->trans('Home only', 'Modules.Everblock.Admin'),
+            'only_category' => $this->trans('Category only', 'Modules.Everblock.Admin'),
+            'only_manufacturer' => $this->trans('Manufacturer only', 'Modules.Everblock.Admin'),
+            'only_supplier' => $this->trans('Supplier only', 'Modules.Everblock.Admin'),
+            'only_cms_category' => $this->trans('CMS category only', 'Modules.Everblock.Admin'),
+            'modal' => $this->trans('Is modal', 'Modules.Everblock.Admin'),
+            'active' => $this->trans('Status', 'Modules.Everblock.Admin'),
+        ] as $field => $label) {
+            $columns->add((new DataColumn($field))
+                ->setName($label)
+                ->setOptions([
+                    'field' => $field,
+                ])
+            );
+        }
+
+        $columns->add((new DataColumn('date_start'))
+            ->setName($this->trans('Date start', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'date_start',
+            ])
+        );
+
+        $columns->add((new DataColumn('date_end'))
+            ->setName($this->trans('Date end', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'date_end',
+            ])
+        );
+
+        return $columns;
+    }
+
+    protected function getFilters(): FilterCollection
+    {
+        $filters = new FilterCollection();
+
+        foreach ([
+            'id_everblock' => $this->trans('Search ID', 'Modules.Everblock.Admin'),
+            'name' => $this->trans('Search name', 'Modules.Everblock.Admin'),
+            'hname' => $this->trans('Search hook', 'Modules.Everblock.Admin'),
+            'position' => $this->trans('Search position', 'Modules.Everblock.Admin'),
+            'date_start' => $this->trans('Search start date', 'Modules.Everblock.Admin'),
+            'date_end' => $this->trans('Search end date', 'Modules.Everblock.Admin'),
+        ] as $filterName => $placeholder) {
+            $filters->add((new Filter($filterName, TextType::class))
+                ->setTypeOptions([
+                    'attr' => [
+                        'placeholder' => $placeholder,
+                    ],
+                ])
+            );
+        }
+
+        foreach ([
+            'only_home',
+            'only_category',
+            'only_manufacturer',
+            'only_supplier',
+            'only_cms_category',
+            'modal',
+            'active',
+        ] as $booleanFilter) {
+            $filters->add((new Filter($booleanFilter, YesAndNoChoiceType::class))
+                ->setAssociatedColumn($booleanFilter)
+            );
+        }
+
+        return $filters;
+    }
+}

--- a/src/PrestaShopBundle/Grid/Search/Filters/EverBlockFilters.php
+++ b/src/PrestaShopBundle/Grid/Search/Filters/EverBlockFilters.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\PrestaShopBundle\Grid\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Search\Filters;
+
+class EverBlockFilters extends Filters
+{
+    public const FILTER_ID = 'ever_block';
+
+    protected $filterId = self::FILTER_ID;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected $defaults = [
+        'limit' => 20,
+        'offset' => 0,
+        'orderBy' => 'sort_key',
+        'orderWay' => 'asc',
+    ];
+
+    /**
+     * @param array<string, mixed> $filters
+     * @param array<string, mixed> $defaults
+     */
+    public function __construct(array $filters = [], array $defaults = [])
+    {
+        parent::__construct($filters, array_merge($this->defaults, $defaults));
+    }
+}

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -7,4 +7,5 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Everblock\\Tools\\' => array($baseDir . '/src'),
+    'Everblock\\PrestaShopBundle\\' => array($baseDir . '/src/PrestaShopBundle'),
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -10,6 +10,7 @@ class ComposerStaticInitc44e5ac729cb9f81a689ee15bff0603d
         'E' => 
         array (
             'Everblock\\Tools\\' => 16,
+            'Everblock\\PrestaShopBundle\\' => 27,
         ),
     );
 
@@ -17,6 +18,10 @@ class ComposerStaticInitc44e5ac729cb9f81a689ee15bff0603d
         'Everblock\\Tools\\' => 
         array (
             0 => __DIR__ . '/../..' . '/src',
+        ),
+        'Everblock\\PrestaShopBundle\\' => 
+        array (
+            0 => __DIR__ . '/../..' . '/src/PrestaShopBundle',
         ),
     );
 

--- a/views/templates/admin/everblock/index.html.twig
+++ b/views/templates/admin/everblock/index.html.twig
@@ -1,0 +1,401 @@
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="everblock-header panel row">
+    <div class="col-md-8">
+      <h3 class="mb-3">
+        <i class="material-icons">sentiment_satisfied</i>
+        {{ 'Ever Block'|trans({}, 'Modules.Everblock.Admin') }} {{ module.version }}
+      </h3>
+      <a href="#everblock-footer-logo">
+        <img id="everblock-header-logo" class="img-fluid" src="{{ modulePublicPath ~ 'logo.png' }}" alt="{{ 'Ever Block logo'|trans({}, 'Modules.Everblock.Admin') }}" style="max-width: 120px;" />
+      </a>
+      <p class="mt-2">{{ 'Thanks for using Team Ever\'s modules'|trans({}, 'Modules.Everblock.Admin') }}<br /></p>
+    </div>
+    <div class="col-md-4 text-right mt-3">
+      {% if shortcodeDocumentation is not empty %}
+        <button type="button" class="btn btn-info" data-toggle="modal" data-target="#everblockShortcodeModal">
+          <i class="material-icons">book</i> {{ 'Shortcode documentation'|trans({}, 'Modules.Everblock.Admin') }}
+        </button>
+      {% endif %}
+      <a href="{{ module.modulesListLink }}" class="btn btn-outline-secondary">
+        <i class="material-icons">arrow_back</i> {{ 'Back to modules'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.blockAdminLink }}" class="btn btn-success">
+        {{ 'Manage blocks'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.faqAdminLink }}" class="btn btn-success">
+        {{ 'Manage FAQ'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.hookAdminLink }}" class="btn btn-success">
+        {{ 'Manage all hooks'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.shortcodeAdminLink }}" class="btn btn-success">
+        {{ 'Manage shortcodes'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.donationLink }}" class="btn btn-warning" target="_blank">
+        <i class="material-icons">payments</i> {{ 'Make a donation'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+    </div>
+  </div>
+
+  <div class="everblock-config-wrapper">
+    {% set hasNotifications = notifications.error is not empty or notifications.success is not empty or notifications.warning is not empty or notifications.info is not empty %}
+    {% if hasNotifications %}
+      <div class="everblock-config__notifications">
+        {% for message in notifications.error %}
+          <div class="alert alert-danger" role="alert">{{ message|raw }}</div>
+        {% endfor %}
+        {% for message in notifications.warning %}
+          <div class="alert alert-warning" role="alert">{{ message|raw }}</div>
+        {% endfor %}
+        {% for message in notifications.success %}
+          <div class="alert alert-success" role="alert">{{ message|raw }}</div>
+        {% endfor %}
+        {% for message in notifications.info %}
+          <div class="alert alert-info" role="alert">{{ message|raw }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <section class="everblock-config__hero">
+      <div class="everblock-config__hero-main">
+        <span class="everblock-config__badge">{{ 'Module'|trans({}, 'Modules.Everblock.Admin') }}</span>
+        <h2 class="everblock-config__hero-title">{{ module.name }}</h2>
+        <p class="everblock-config__hero-description">
+          {{ 'Fine-tune the behaviour, integrations and automation rules of Ever Block from a single, curated control centre.'|trans({}, 'Modules.Everblock.Admin') }}
+        </p>
+        <div class="everblock-config__hero-meta">
+          <span class="everblock-chip">
+            <i class="material-icons">sell</i>
+            {{ 'Version'|trans({}, 'Modules.Everblock.Admin') }} {{ module.version }}
+          </span>
+          <span class="everblock-chip">
+            <i class="material-icons">check_circle</i>
+            {{ 'Content managed (total)'|trans({}, 'Modules.Everblock.Admin') }}: {{ stats.blocks_total|default(0) }}
+          </span>
+        </div>
+      </div>
+      <div class="everblock-config__hero-stats">
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.blocks_active|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Active blocks'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.shortcodes|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Shortcodes'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.flags|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Flags'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+        <div class="everblock-config__stat">
+          <div class="everblock-config__stat-value">{{ stats.tabs|default(0) }}</div>
+          <div class="everblock-config__stat-label">{{ 'Product tabs'|trans({}, 'Modules.Everblock.Admin') }}</div>
+        </div>
+      </div>
+    </section>
+
+    <div class="everblock-config__layout">
+      <div class="everblock-config__main">
+        {% if displayUpgrade %}
+          <div class="everblock-config__card">
+            {{ include('@Modules/everblock/views/templates/admin/upgrade.tpl') }}
+          </div>
+        {% endif %}
+
+        <div class="everblock-config__card everblock-config__card--grid">
+          {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': grid}) }}
+        </div>
+      </div>
+
+      <aside class="everblock-config__aside">
+        <div class="everblock-sidecard">
+          <h3 class="everblock-sidecard__title">
+            <i class="material-icons">view_module</i>
+            {{ 'Quick actions'|trans({}, 'Modules.Everblock.Admin') }}
+          </h3>
+          <p class="everblock-sidecard__subtitle">
+            {{ 'Jump straight into your daily tasks with shortcuts curated for content managers.'|trans({}, 'Modules.Everblock.Admin') }}
+          </p>
+          <ul class="everblock-sidecard__actions">
+            <li>
+              <a class="everblock-sidecard__link" href="{{ module.blockAdminLink }}">
+                <span class="everblock-sidecard__icon"><i class="material-icons">extension</i></span>
+                <span>
+                  <strong>{{ 'Manage blocks'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Create, schedule and personalise content blocks.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ module.shortcodeAdminLink }}">
+                <span class="everblock-sidecard__icon"><i class="material-icons">code</i></span>
+                <span>
+                  <strong>{{ 'Manage shortcodes'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Build reusable snippets for your CMS and product pages.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ module.faqAdminLink }}">
+                <span class="everblock-sidecard__icon"><i class="material-icons">help_outline</i></span>
+                <span>
+                  <strong>{{ 'Manage FAQ'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Update customer-facing answers in a few clicks.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+            <li>
+              <a class="everblock-sidecard__link" href="{{ module.hookAdminLink }}">
+                <span class="everblock-sidecard__icon"><i class="material-icons">share</i></span>
+                <span>
+                  <strong>{{ 'Manage hooks'|trans({}, 'Modules.Everblock.Admin') }}</strong>
+                  <small>{{ 'Control where content appears across your store.'|trans({}, 'Modules.Everblock.Admin') }}</small>
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="everblock-sidecard">
+          <h3 class="everblock-sidecard__title">
+            <i class="material-icons">campaign</i>
+            {{ 'Support & resources'|trans({}, 'Modules.Everblock.Admin') }}
+          </h3>
+          <p class="everblock-sidecard__subtitle">
+            {{ 'Need inspiration? Explore documentation, automations and best practices shipped with Ever Block.'|trans({}, 'Modules.Everblock.Admin') }}
+          </p>
+          <ul class="everblock-sidecard__badges">
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="material-icons">insights</i>
+                {{ 'Total blocks: %count%'|trans({'%count%': stats.blocks_total|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="material-icons">question_answer</i>
+                {{ 'FAQ entries: %count%'|trans({'%count%': stats.faqs|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+            <li>
+              <span class="everblock-sidecard__badge">
+                <i class="material-icons">sports_esports</i>
+                {{ 'Gamification sessions: %count%'|trans({'%count%': stats.game_sessions|default(0)}, 'Modules.Everblock.Admin') }}
+              </span>
+            </li>
+          </ul>
+          <a class="everblock-sidecard__cta" href="{{ module.donationLink }}" target="_blank">
+            <i class="material-icons">favorite</i>
+            {{ 'Support ongoing development'|trans({}, 'Modules.Everblock.Admin') }}
+          </a>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <div class="panel everblock-footer text-center">
+    <h3><i class="material-icons">sentiment_satisfied</i> {{ 'Ever Block'|trans({}, 'Modules.Everblock.Admin') }}</h3>
+    <a href="#everblock-header-logo" class="d-block mb-2">
+      <img id="everblock-footer-logo" class="img-fluid" src="{{ modulePublicPath ~ 'logo.png' }}" alt="{{ 'Ever Block logo'|trans({}, 'Modules.Everblock.Admin') }}" style="max-width: 120px;" />
+    </a>
+    <p>
+      <strong>{{ 'Thank you for your confidence :-)'|trans({}, 'Modules.Everblock.Admin') }}</strong><br />
+      {{ 'Feel free to contact us for more support or help'|trans({}, 'Modules.Everblock.Admin') }}
+    </p>
+    <p class="mt-2">
+      <a href="#everblock-header-logo" class="btn btn-outline-secondary">
+        <i class="material-icons" aria-hidden="true">arrow_upward</i> {{ 'Back to top'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+      <a href="{{ module.donationLink }}" class="btn btn-warning" target="_blank">
+        <i class="material-icons">payments</i> {{ 'Make a donation'|trans({}, 'Modules.Everblock.Admin') }}
+      </a>
+    </p>
+  </div>
+
+  {% if shortcodeDocumentation is not empty %}
+    <div class="modal fade everblock-shortcode-modal" id="everblockShortcodeModal" tabindex="-1" role="dialog" aria-labelledby="everblockShortcodeModalLabel" aria-modal="true">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="everblock-shortcode-modal__header">
+            <div class="everblock-shortcode-modal__icon" aria-hidden="true">
+              <i class="material-icons">code</i>
+            </div>
+            <div class="everblock-shortcode-modal__intro">
+              <h3 class="everblock-shortcode-modal__title" id="everblockShortcodeModalLabel">
+                {{ 'Available shortcodes'|trans({}, 'Modules.Everblock.Admin') }}
+              </h3>
+              <p class="everblock-shortcode-modal__subtitle">
+                {{ 'Use these shortcodes inside your blocks, CMS pages or PrettyBlocks zones.'|trans({}, 'Modules.Everblock.Admin') }}
+              </p>
+            </div>
+            <button type="button" class="everblock-shortcode-modal__close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Modules.Everblock.Admin') }}">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="everblock-shortcode-modal__tools">
+            <label for="everblockShortcodeSearch" class="sr-only visually-hidden">
+              {{ 'Search shortcodes'|trans({}, 'Modules.Everblock.Admin') }}
+            </label>
+            <div class="everblock-shortcode-search input-group">
+              <span class="input-group-addon input-group-text"><i class="material-icons">search</i></span>
+              <input type="search" class="form-control" id="everblockShortcodeSearch" placeholder="{{ 'Search shortcodes…'|trans({}, 'Modules.Everblock.Admin') }}" autocomplete="off">
+              <div class="input-group-btn input-group-append">
+                <button class="btn btn-outline-secondary everblock-shortcode-clear" type="button">
+                  {{ 'Clear'|trans({}, 'Modules.Everblock.Admin') }}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="everblock-shortcode-modal__body">
+            <div class="everblock-shortcode-modal__empty">
+              <i class="material-icons" aria-hidden="true">warning</i>
+              <p>{{ 'No shortcode matches your search. Try different keywords or reset the filters.'|trans({}, 'Modules.Everblock.Admin') }}</p>
+              <button type="button" class="btn btn-link everblock-shortcode-reset">
+                {{ 'Show all shortcodes'|trans({}, 'Modules.Everblock.Admin') }}
+              </button>
+            </div>
+            <div class="everblock-shortcode-categories">
+              {% for category in shortcodeDocumentation %}
+                {% set entries = category.entries|default([]) %}
+                <article class="everblock-shortcode-category-card">
+                  <header class="everblock-shortcode-category-card__header">
+                    <div class="everblock-shortcode-category-card__heading">
+                      <h4 class="everblock-shortcode-category-card__title">{{ category.title }}</h4>
+                      {% if entries|length > 0 %}
+                        <span class="everblock-shortcode-category-card__count" aria-hidden="true">{{ entries|length }}</span>
+                        <span class="sr-only visually-hidden">
+                          {% if entries|length == 1 %}
+                            {{ '1 shortcode in this category'|trans({}, 'Modules.Everblock.Admin') }}
+                          {% else %}
+                            {{ '%count% shortcodes in this category'|trans({'%count%': entries|length}, 'Modules.Everblock.Admin') }}
+                          {% endif %}
+                        </span>
+                      {% endif %}
+                    </div>
+                  </header>
+                  {% if entries is not empty %}
+                    <div class="everblock-shortcode-category-card__entries">
+                      {% for entry in entries %}
+                        <section class="everblock-shortcode-entry" data-everblock-shortcode-entry data-filter-text="{{ entry.code }} {{ entry.description }}{% if entry.parameters is defined %}{% for param in entry.parameters %} {{ param.name }} {{ param.description|default('') }}{% endfor %}{% endif %}">
+                          <div class="everblock-shortcode-entry__header">
+                            <code class="everblock-shortcode-entry__code">{{ entry.code }}</code>
+                            <button type="button" class="btn btn-link everblock-shortcode-entry__copy" data-everblock-copy="{{ entry.code }}" title="{{ 'Copy shortcode'|trans({}, 'Modules.Everblock.Admin') }}">
+                              <i class="material-icons" aria-hidden="true">content_copy</i>
+                              <span class="sr-only visually-hidden">{{ 'Copy shortcode'|trans({}, 'Modules.Everblock.Admin') }}</span>
+                            </button>
+                          </div>
+                          <p class="everblock-shortcode-entry__description">
+                            {{ entry.description }}
+                          </p>
+                          {% if entry.parameters is defined and entry.parameters is not empty %}
+                            <ul class="everblock-shortcode-entry__params">
+                              {% for param in entry.parameters %}
+                                <li class="everblock-shortcode-entry__param">
+                                  <span class="everblock-shortcode-entry__badge {{ param.required ? 'is-required' : 'is-optional' }}">
+                                    {% if param.required %}
+                                      {{ 'Required'|trans({}, 'Modules.Everblock.Admin') }}
+                                    {% else %}
+                                      {{ 'Optional'|trans({}, 'Modules.Everblock.Admin') }}
+                                    {% endif %}
+                                  </span>
+                                  <span class="everblock-shortcode-entry__param-name">{{ param.name }}</span>
+                                  {% if param.description is defined %}
+                                    <span class="everblock-shortcode-entry__param-description">{{ param.description }}</span>
+                                  {% endif %}
+                                </li>
+                              {% endfor %}
+                            </ul>
+                          {% endif %}
+                        </section>
+                      {% endfor %}
+                    </div>
+                  {% else %}
+                    <p class="everblock-shortcode-category-card__empty">
+                      {{ 'No shortcodes are currently registered in this category.'|trans({}, 'Modules.Everblock.Admin') }}
+                    </p>
+                  {% endif %}
+                </article>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="everblock-shortcode-modal__footer">
+            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+              {{ 'Close'|trans({}, 'Modules.Everblock.Admin') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="text/javascript">
+      (function ($) {
+        $(function () {
+          var $modal = $('#everblockShortcodeModal');
+          var $search = $('#everblockShortcodeSearch');
+          var $clearBtn = $modal.find('.everblock-shortcode-clear');
+          var $resetBtn = $modal.find('.everblock-shortcode-reset');
+          var $entries = $modal.find('[data-everblock-shortcode-entry]');
+          var $categories = $modal.find('.everblock-shortcode-category-card');
+          var $emptyState = $modal.find('.everblock-shortcode-modal__empty');
+
+          function updateClearButtonState() {
+            var hasValue = $.trim($search.val()).length > 0;
+            $clearBtn.prop('disabled', !hasValue).toggleClass('is-disabled', !hasValue);
+          }
+
+          function toggleEmptyState() {
+            var visibleEntries = $entries.filter(':visible').length;
+            $emptyState.toggleClass('is-visible', visibleEntries === 0);
+          }
+
+          function filterEntries() {
+            var filterValue = $.trim($search.val()).toLowerCase();
+
+            $entries.each(function () {
+              var $entry = $(this);
+              var haystack = ($entry.data('filter-text') || '').toString().toLowerCase();
+              var isVisible = filterValue === '' || haystack.indexOf(filterValue) !== -1;
+              $entry.toggle(isVisible);
+            });
+
+            $categories.each(function () {
+              var $category = $(this);
+              var visibleEntries = $category.find('[data-everblock-shortcode-entry]:visible').length;
+              $category.toggle(visibleEntries > 0);
+            });
+
+            toggleEmptyState();
+          }
+
+          $search.on('input', function () {
+            updateClearButtonState();
+            filterEntries();
+          });
+
+          $clearBtn.on('click', function () {
+            $search.val('');
+            updateClearButtonState();
+            filterEntries();
+          });
+
+          $resetBtn.on('click', function () {
+            $search.val('');
+            updateClearButtonState();
+            filterEntries();
+          });
+
+          $modal.on('click', '[data-everblock-copy]', function (event) {
+            event.preventDefault();
+            var text = $(this).data('everblock-copy');
+            navigator.clipboard && navigator.clipboard.writeText(text);
+          });
+
+          updateClearButtonState();
+          toggleEmptyState();
+        });
+      })(window.jQuery);
+    </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Symfony back-office route for Ever Block and map legacy access to it
- build grid definition/data factories to expose the legacy listing inside the new controller
- replace the legacy Smarty layout with a single Twig template that renders notifications, hero cards, quick actions and the grid

## Testing
- php -l src/PrestaShopBundle/Controller/Admin/EverBlockController.php
- php -l src/PrestaShopBundle/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
- php -l src/PrestaShopBundle/Grid/Data/Factory/EverBlockGridDataFactory.php
- php -l src/PrestaShopBundle/Grid/Search/Filters/EverBlockFilters.php

------
https://chatgpt.com/codex/tasks/task_e_68f8db44a5548322a376fd219f67feec