### PR TITLE
Migrate Everblock grid actions to Symfony controllers

### DIFF
--- a/config/routes/admin/ever_block.yml
+++ b/config/routes/admin/ever_block.yml
@@ -5,3 +5,83 @@ admin_everblock_index:
     _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::indexAction'
     _legacy_controller: 'AdminEverBlock'
     _legacy_link: 'AdminEverBlock'
+
+admin_everblock_duplicate:
+  path: /everblock/{everBlockId}/duplicate
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::duplicateAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+  requirements:
+    everBlockId: '\\d+'
+
+admin_everblock_toggle_status:
+  path: /everblock/{everBlockId}/toggle-status
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::toggleStatusAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+  requirements:
+    everBlockId: '\\d+'
+
+admin_everblock_export_sql:
+  path: /everblock/{everBlockId}/export
+  methods: [GET]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::exportSqlAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+  requirements:
+    everBlockId: '\\d+'
+
+admin_everblock_delete:
+  path: /everblock/{everBlockId}/delete
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::deleteAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+  requirements:
+    everBlockId: '\\d+'
+
+admin_everblock_bulk_delete:
+  path: /everblock/bulk/delete
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::bulkDeleteAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+
+admin_everblock_bulk_enable:
+  path: /everblock/bulk/enable
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::bulkEnableAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+
+admin_everblock_bulk_disable:
+  path: /everblock/bulk/disable
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::bulkDisableAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+
+admin_everblock_bulk_duplicate:
+  path: /everblock/bulk/duplicate
+  methods: [POST]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::bulkDuplicateAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'
+
+admin_everblock_clear_cache:
+  path: /everblock/clear-cache
+  methods: [GET]
+  defaults:
+    _controller: 'Everblock\\PrestaShopBundle\\Controller\\Admin\\EverBlockController::clearCacheAction'
+    _legacy_controller: 'AdminEverBlock'
+    _legacy_link: 'AdminEverBlock'

--- a/config/services.yml
+++ b/config/services.yml
@@ -69,3 +69,30 @@ services:
             - '@prestashop.core.grid.filter.form_factory'
             - '@prestashop.core.hook.dispatcher'
 
+    Everblock\PrestaShopBundle\Service\EverBlockDatabaseMaintainer: ~
+
+    Everblock\PrestaShopBundle\Service\EverBlockSqlExporter: ~
+
+    Everblock\PrestaShopBundle\Service\EverBlockContentConverter: ~
+
+    Everblock\PrestaShopBundle\Service\EverBlockCacheRefresher: ~
+
+    Everblock\PrestaShopBundle\Service\EverBlockBulkActionIdsExtractor: ~
+
+    Everblock\PrestaShopBundle\Domain\EverBlock\Repository\LegacyEverBlockRepository: ~
+
+    Everblock\PrestaShopBundle\Domain\EverBlock\Repository\EverBlockRepositoryInterface:
+        alias: Everblock\PrestaShopBundle\Domain\EverBlock\Repository\LegacyEverBlockRepository
+
+    Everblock\PrestaShopBundle\Controller\Admin\EverBlockController:
+        arguments:
+            $duplicateHandler: '@Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler\DuplicateEverBlockHandler'
+            $toggleStatusHandler: '@Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler\ToggleEverBlockStatusHandler'
+            $exportSqlHandler: '@Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler\ExportEverBlockSqlHandler'
+            $everBlockRepository: '@Everblock\PrestaShopBundle\Domain\EverBlock\Repository\EverBlockRepositoryInterface'
+            $cacheRefresher: '@Everblock\PrestaShopBundle\Service\EverBlockCacheRefresher'
+            $databaseMaintainer: '@Everblock\PrestaShopBundle\Service\EverBlockDatabaseMaintainer'
+            $bulkActionIdsExtractor: '@Everblock\PrestaShopBundle\Service\EverBlockBulkActionIdsExtractor'
+        tags:
+            - { name: controller.service_arguments }
+

--- a/src/PrestaShopBundle/Domain/EverBlock/Command/DuplicateEverBlockCommand.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Command/DuplicateEverBlockCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Command;
+
+/**
+ * Command used to duplicate an existing block from the grid.
+ */
+class DuplicateEverBlockCommand
+{
+    /**
+     * @var int
+     */
+    private $everBlockId;
+
+    public function __construct(int $everBlockId)
+    {
+        $this->everBlockId = $everBlockId;
+    }
+
+    public function getEverBlockId(): int
+    {
+        return $this->everBlockId;
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Command/ExportEverBlockSqlCommand.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Command/ExportEverBlockSqlCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Command;
+
+/**
+ * Command used to export the SQL representation of a block.
+ */
+class ExportEverBlockSqlCommand
+{
+    /**
+     * @var int
+     */
+    private $everBlockId;
+
+    public function __construct(int $everBlockId)
+    {
+        $this->everBlockId = $everBlockId;
+    }
+
+    public function getEverBlockId(): int
+    {
+        return $this->everBlockId;
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Command/ToggleEverBlockStatusCommand.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Command/ToggleEverBlockStatusCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Command;
+
+/**
+ * Command responsible for toggling a block status from the grid.
+ */
+class ToggleEverBlockStatusCommand
+{
+    /**
+     * @var int
+     */
+    private $everBlockId;
+
+    public function __construct(int $everBlockId)
+    {
+        $this->everBlockId = $everBlockId;
+    }
+
+    public function getEverBlockId(): int
+    {
+        return $this->everBlockId;
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/DuplicateEverBlockHandler.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/DuplicateEverBlockHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler;
+
+use Everblock\PrestaShopBundle\Domain\EverBlock\Command\DuplicateEverBlockCommand;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Repository\EverBlockRepositoryInterface;
+
+class DuplicateEverBlockHandler
+{
+    /**
+     * @var EverBlockRepositoryInterface
+     */
+    private $repository;
+
+    public function __construct(EverBlockRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function handle(DuplicateEverBlockCommand $command): int
+    {
+        return $this->repository->duplicate($command->getEverBlockId());
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/ExportEverBlockSqlHandler.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/ExportEverBlockSqlHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler;
+
+use Everblock\PrestaShopBundle\Domain\EverBlock\Command\ExportEverBlockSqlCommand;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotExportEverBlockSqlException;
+use Everblock\PrestaShopBundle\Service\EverBlockSqlExporter;
+
+class ExportEverBlockSqlHandler
+{
+    /**
+     * @var EverBlockSqlExporter
+     */
+    private $exporter;
+
+    public function __construct(EverBlockSqlExporter $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
+    public function handle(ExportEverBlockSqlCommand $command): string
+    {
+        $sql = $this->exporter->export($command->getEverBlockId());
+
+        if ('' === trim($sql)) {
+            throw new CannotExportEverBlockSqlException('Unable to export SQL for this block.');
+        }
+
+        return $sql;
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/ToggleEverBlockStatusHandler.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/CommandHandler/ToggleEverBlockStatusHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler;
+
+use Everblock\PrestaShopBundle\Domain\EverBlock\Command\ToggleEverBlockStatusCommand;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Repository\EverBlockRepositoryInterface;
+
+class ToggleEverBlockStatusHandler
+{
+    /**
+     * @var EverBlockRepositoryInterface
+     */
+    private $repository;
+
+    public function __construct(EverBlockRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function handle(ToggleEverBlockStatusCommand $command): bool
+    {
+        return $this->repository->toggleStatus($command->getEverBlockId());
+    }
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotDeleteEverBlockException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotDeleteEverBlockException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class CannotDeleteEverBlockException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotDuplicateEverBlockException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotDuplicateEverBlockException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class CannotDuplicateEverBlockException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotExportEverBlockSqlException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotExportEverBlockSqlException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class CannotExportEverBlockSqlException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotToggleEverBlockStatusException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotToggleEverBlockStatusException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class CannotToggleEverBlockStatusException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotUpdateEverBlockStatusException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/CannotUpdateEverBlockStatusException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class CannotUpdateEverBlockStatusException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/EverBlockException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/EverBlockException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+use Exception;
+
+class EverBlockException extends Exception
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Exception/EverBlockNotFoundException.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Exception/EverBlockNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Exception;
+
+class EverBlockNotFoundException extends EverBlockException
+{
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Repository/EverBlockRepositoryInterface.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Repository/EverBlockRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Repository;
+
+interface EverBlockRepositoryInterface
+{
+    /**
+     * Duplicate the given block and return the newly created identifier.
+     */
+    public function duplicate(int $everBlockId): int;
+
+    /**
+     * Toggle the status of the given block and returns the new status.
+     */
+    public function toggleStatus(int $everBlockId): bool;
+
+    /**
+     * Force block status to the given state.
+     */
+    public function updateStatus(int $everBlockId, bool $enabled): void;
+
+    /**
+     * Remove the block permanently.
+     */
+    public function delete(int $everBlockId): void;
+}

--- a/src/PrestaShopBundle/Domain/EverBlock/Repository/LegacyEverBlockRepository.php
+++ b/src/PrestaShopBundle/Domain/EverBlock/Repository/LegacyEverBlockRepository.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Domain\EverBlock\Repository;
+
+use EverBlockClass;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotDeleteEverBlockException;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotDuplicateEverBlockException;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotToggleEverBlockStatusException;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotUpdateEverBlockStatusException;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\EverBlockNotFoundException;
+use Everblock\PrestaShopBundle\Service\EverBlockContentConverter;
+
+class LegacyEverBlockRepository implements EverBlockRepositoryInterface
+{
+    /**
+     * @var EverBlockContentConverter
+     */
+    private $contentConverter;
+
+    public function __construct(EverBlockContentConverter $contentConverter)
+    {
+        $this->contentConverter = $contentConverter;
+    }
+
+    public function duplicate(int $everBlockId): int
+    {
+        $original = $this->getEverBlock($everBlockId);
+
+        $duplicate = new EverBlockClass();
+        $duplicate->name = $original->name;
+        $duplicate->content = $this->contentConverter->convert($this->normalizeLocalizedData($original->content));
+        $duplicate->custom_code = $this->normalizeLocalizedData($original->custom_code);
+        $duplicate->only_home = (int) $original->only_home;
+        $duplicate->only_category = (int) $original->only_category;
+        $duplicate->only_category_product = (int) $original->only_category_product;
+        $duplicate->only_manufacturer = (int) $original->only_manufacturer;
+        $duplicate->only_supplier = (int) $original->only_supplier;
+        $duplicate->only_cms_category = (int) $original->only_cms_category;
+        $duplicate->obfuscate_link = (int) $original->obfuscate_link;
+        $duplicate->add_container = (int) $original->add_container;
+        $duplicate->lazyload = (int) $original->lazyload;
+        $duplicate->id_hook = (int) $original->id_hook;
+        $duplicate->device = (int) $original->device;
+        $duplicate->groups = $original->groups;
+        $duplicate->background = $original->background;
+        $duplicate->css_class = $original->css_class;
+        $duplicate->data_attribute = $original->data_attribute;
+        $duplicate->bootstrap_class = $original->bootstrap_class;
+        $duplicate->position = (int) $original->position;
+        $duplicate->id_shop = (int) $original->id_shop;
+        $duplicate->categories = $original->categories;
+        $duplicate->manufacturers = $original->manufacturers;
+        $duplicate->suppliers = $original->suppliers;
+        $duplicate->cms_categories = $original->cms_categories;
+        $duplicate->modal = (int) $original->modal;
+        $duplicate->delay = (int) $original->delay;
+        $duplicate->timeout = (int) $original->timeout;
+        $duplicate->date_start = $original->date_start;
+        $duplicate->date_end = $original->date_end;
+        $duplicate->active = 0;
+
+        if (!$duplicate->save()) {
+            throw new CannotDuplicateEverBlockException('Unable to duplicate Ever Block "' . $original->name . '".');
+        }
+
+        return (int) $duplicate->id;
+    }
+
+    public function toggleStatus(int $everBlockId): bool
+    {
+        $block = $this->getEverBlock($everBlockId);
+        $newStatus = !(bool) $block->active;
+        $block->active = (int) $newStatus;
+
+        if (!$block->save()) {
+            throw new CannotToggleEverBlockStatusException('Unable to toggle block status.');
+        }
+
+        return $newStatus;
+    }
+
+    public function updateStatus(int $everBlockId, bool $enabled): void
+    {
+        $block = $this->getEverBlock($everBlockId);
+        $block->active = (int) $enabled;
+
+        if (!$block->save()) {
+            throw new CannotUpdateEverBlockStatusException('Unable to update block status.');
+        }
+    }
+
+    public function delete(int $everBlockId): void
+    {
+        $block = $this->getEverBlock($everBlockId);
+
+        if (!$block->delete()) {
+            throw new CannotDeleteEverBlockException('Unable to delete Ever Block.');
+        }
+    }
+
+    /**
+     * @param mixed $localizedData
+     *
+     * @return array<int, string>
+     */
+    private function normalizeLocalizedData($localizedData): array
+    {
+        if (!is_array($localizedData)) {
+            return [];
+        }
+
+        return $localizedData;
+    }
+
+    private function getEverBlock(int $everBlockId): EverBlockClass
+    {
+        $everBlock = new EverBlockClass($everBlockId);
+        if (!isset($everBlock->id) || !$everBlock->id) {
+            throw new EverBlockNotFoundException('Ever Block #' . $everBlockId . ' was not found.');
+        }
+
+        return $everBlock;
+    }
+}

--- a/src/PrestaShopBundle/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
+++ b/src/PrestaShopBundle/Grid/Definition/Factory/EverBlockGridDefinitionFactory.php
@@ -20,7 +20,13 @@
 namespace Everblock\PrestaShopBundle\Grid\Definition\Factory;
 
 use Everblock\PrestaShopBundle\Grid\Search\Filters\EverBlockFilters;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
@@ -79,7 +85,6 @@ class EverBlockGridDefinitionFactory extends AbstractGridDefinitionFactory
             'only_supplier' => $this->trans('Supplier only', 'Modules.Everblock.Admin'),
             'only_cms_category' => $this->trans('CMS category only', 'Modules.Everblock.Admin'),
             'modal' => $this->trans('Is modal', 'Modules.Everblock.Admin'),
-            'active' => $this->trans('Status', 'Modules.Everblock.Admin'),
         ] as $field => $label) {
             $columns->add((new DataColumn($field))
                 ->setName($label)
@@ -88,6 +93,17 @@ class EverBlockGridDefinitionFactory extends AbstractGridDefinitionFactory
                 ])
             );
         }
+
+        $columns->add((new ToggleColumn('active'))
+            ->setName($this->trans('Status', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'field' => 'active',
+                'primary_field' => 'id_everblock',
+                'route' => 'admin_everblock_toggle_status',
+                'route_param_name' => 'everBlockId',
+                'route_param_field' => 'id_everblock',
+            ])
+        );
 
         $columns->add((new DataColumn('date_start'))
             ->setName($this->trans('Date start', 'Modules.Everblock.Admin'))
@@ -142,5 +158,80 @@ class EverBlockGridDefinitionFactory extends AbstractGridDefinitionFactory
         }
 
         return $filters;
+    }
+
+    protected function getRowActions(): RowActionCollection
+    {
+        $rowActions = new RowActionCollection();
+
+        $rowActions->add((new SubmitRowAction('duplicate'))
+            ->setName($this->trans('Duplicate', 'Modules.Everblock.Admin'))
+            ->setIcon('content_copy')
+            ->setOptions([
+                'route' => 'admin_everblock_duplicate',
+                'route_param_name' => 'everBlockId',
+                'route_param_field' => 'id_everblock',
+                'confirm_message' => $this->trans('Duplicate this block?', 'Modules.Everblock.Admin'),
+            ])
+        );
+
+        $rowActions->add((new LinkRowAction('export'))
+            ->setName($this->trans('Export SQL', 'Modules.Everblock.Admin'))
+            ->setIcon('cloud_download')
+            ->setOptions([
+                'route' => 'admin_everblock_export_sql',
+                'route_param_name' => 'everBlockId',
+                'route_param_field' => 'id_everblock',
+            ])
+        );
+
+        $rowActions->add((new SubmitRowAction('delete'))
+            ->setName($this->trans('Delete', 'Modules.Everblock.Admin'))
+            ->setIcon('delete')
+            ->setOptions([
+                'route' => 'admin_everblock_delete',
+                'route_param_name' => 'everBlockId',
+                'route_param_field' => 'id_everblock',
+                'confirm_message' => $this->trans('Delete this block?', 'Modules.Everblock.Admin'),
+            ])
+        );
+
+        return $rowActions;
+    }
+
+    protected function getBulkActions(): BulkActionCollection
+    {
+        $bulkActions = new BulkActionCollection();
+
+        $bulkActions->add((new SubmitBulkAction('delete'))
+            ->setName($this->trans('Delete selected', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'submit_route' => 'admin_everblock_bulk_delete',
+                'confirm_message' => $this->trans('Delete selected blocks?', 'Modules.Everblock.Admin'),
+            ])
+        );
+
+        $bulkActions->add((new SubmitBulkAction('disable'))
+            ->setName($this->trans('Disable selected', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'submit_route' => 'admin_everblock_bulk_disable',
+            ])
+        );
+
+        $bulkActions->add((new SubmitBulkAction('enable'))
+            ->setName($this->trans('Enable selected', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'submit_route' => 'admin_everblock_bulk_enable',
+            ])
+        );
+
+        $bulkActions->add((new SubmitBulkAction('duplicate'))
+            ->setName($this->trans('Duplicate selected', 'Modules.Everblock.Admin'))
+            ->setOptions([
+                'submit_route' => 'admin_everblock_bulk_duplicate',
+            ])
+        );
+
+        return $bulkActions;
     }
 }

--- a/src/PrestaShopBundle/Service/EverBlockBulkActionIdsExtractor.php
+++ b/src/PrestaShopBundle/Service/EverBlockBulkActionIdsExtractor.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Service;
+
+use Everblock\PrestaShopBundle\Grid\Search\Filters\EverBlockFilters;
+use Symfony\Component\HttpFoundation\Request;
+
+class EverBlockBulkActionIdsExtractor
+{
+    /**
+     * @var string
+     */
+    private $gridId;
+
+    public function __construct(string $gridId = EverBlockFilters::FILTER_ID)
+    {
+        $this->gridId = $gridId;
+    }
+
+    public function extractFromRequest(Request $request): array
+    {
+        return $this->extractFromArray($request->request->all(), $request->query->all());
+    }
+
+    public function extractFromArray(array ...$sources): array
+    {
+        foreach ($sources as $source) {
+            if (!is_array($source)) {
+                continue;
+            }
+
+            $ids = $this->resolveIdsFromSource($source);
+            if (!empty($ids)) {
+                return $ids;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     *
+     * @return array<int, int>
+     */
+    private function resolveIdsFromSource(array $source): array
+    {
+        if (isset($source['grid']) && is_array($source['grid'])) {
+            $gridData = $source['grid'];
+            if (isset($gridData[$this->gridId]['bulk_action']['ids'])) {
+                return $this->sanitizeIds($gridData[$this->gridId]['bulk_action']['ids']);
+            }
+        }
+
+        if (isset($source[$this->gridId]['bulk_action']['ids'])) {
+            return $this->sanitizeIds($source[$this->gridId]['bulk_action']['ids']);
+        }
+
+        if (isset($source[$this->gridId . '_bulk']['ids'])) {
+            return $this->sanitizeIds($source[$this->gridId . '_bulk']['ids']);
+        }
+
+        if (isset($source['ids'])) {
+            return $this->sanitizeIds($source['ids']);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param mixed $ids
+     *
+     * @return array<int, int>
+     */
+    private function sanitizeIds($ids): array
+    {
+        if (!is_array($ids)) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ($ids as $id) {
+            if (is_numeric($id)) {
+                $sanitized[] = (int) $id;
+            }
+        }
+
+        return array_values(array_unique($sanitized));
+    }
+}

--- a/src/PrestaShopBundle/Service/EverBlockCacheRefresher.php
+++ b/src/PrestaShopBundle/Service/EverBlockCacheRefresher.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Service;
+
+use Tools;
+
+class EverBlockCacheRefresher
+{
+    /**
+     * @var callable
+     */
+    private $clearer;
+
+    public function __construct(?callable $clearer = null)
+    {
+        $this->clearer = $clearer ?: [Tools::class, 'clearAllCache'];
+    }
+
+    public function clear(): void
+    {
+        \call_user_func($this->clearer);
+    }
+}

--- a/src/PrestaShopBundle/Service/EverBlockContentConverter.php
+++ b/src/PrestaShopBundle/Service/EverBlockContentConverter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Service;
+
+use Everblock\Tools\Service\EverblockTools;
+
+class EverBlockContentConverter
+{
+    /**
+     * @var callable
+     */
+    private $webpConverter;
+
+    public function __construct(?callable $webpConverter = null)
+    {
+        $this->webpConverter = $webpConverter ?: [EverblockTools::class, 'convertImagesToWebP'];
+    }
+
+    /**
+     * @param array<int, mixed> $localizedContent
+     *
+     * @return array<int, mixed>
+     */
+    public function convert(array $localizedContent): array
+    {
+        foreach ($localizedContent as $idLang => $content) {
+            if (!is_string($content)) {
+                continue;
+            }
+
+            $localizedContent[$idLang] = (string) \call_user_func($this->webpConverter, $content);
+        }
+
+        return $localizedContent;
+    }
+}

--- a/src/PrestaShopBundle/Service/EverBlockDatabaseMaintainer.php
+++ b/src/PrestaShopBundle/Service/EverBlockDatabaseMaintainer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Service;
+
+use Everblock\Tools\Service\EverblockTools;
+
+class EverBlockDatabaseMaintainer
+{
+    /**
+     * @var callable
+     */
+    private $checker;
+
+    public function __construct(?callable $checker = null)
+    {
+        $this->checker = $checker ?: [EverblockTools::class, 'checkAndFixDatabase'];
+    }
+
+    public function ensureSchema(): void
+    {
+        \call_user_func($this->checker);
+    }
+}

--- a/src/PrestaShopBundle/Service/EverBlockSqlExporter.php
+++ b/src/PrestaShopBundle/Service/EverBlockSqlExporter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Everblock\PrestaShopBundle\Service;
+
+use Everblock\Tools\Service\EverblockTools;
+
+class EverBlockSqlExporter
+{
+    /**
+     * @var callable
+     */
+    private $exporter;
+
+    public function __construct(?callable $exporter = null)
+    {
+        $this->exporter = $exporter ?: [EverblockTools::class, 'exportBlockSQL'];
+    }
+
+    public function export(int $everBlockId): string
+    {
+        return (string) \call_user_func($this->exporter, $everBlockId);
+    }
+}

--- a/tests/Functional/BulkActionIdsExtractorTest.php
+++ b/tests/Functional/BulkActionIdsExtractorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Everblock\PrestaShopBundle\Service\EverBlockBulkActionIdsExtractor;
+
+function expectTrue(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$extractor = new EverBlockBulkActionIdsExtractor('ever_block');
+
+$ids = $extractor->extractFromArray([
+    'grid' => [
+        'ever_block' => [
+            'bulk_action' => [
+                'ids' => ['1', '2', 'foo', 3],
+            ],
+        ],
+    ],
+]);
+
+expectTrue($ids === [1, 2, 3], 'Failed to extract ids from grid payload');
+
+$ids = $extractor->extractFromArray([
+    'ever_block' => [
+        'bulk_action' => [
+            'ids' => [10, '11'],
+        ],
+    ],
+]);
+
+expectTrue($ids === [10, 11], 'Failed to extract ids from direct bulk payload');
+
+$ids = $extractor->extractFromArray([
+    'ids' => ['not', 'numeric'],
+]);
+
+expectTrue($ids === [], 'Non numeric identifiers should be ignored');
+
+echo "BulkActionIdsExtractorTest passed\n";

--- a/tests/Functional/DuplicateEverBlockHandlerTest.php
+++ b/tests/Functional/DuplicateEverBlockHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Everblock\PrestaShopBundle\Domain\EverBlock\Command\DuplicateEverBlockCommand;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Command\ToggleEverBlockStatusCommand;
+use Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler\DuplicateEverBlockHandler;
+use Everblock\PrestaShopBundle\Domain\EverBlock\CommandHandler\ToggleEverBlockStatusHandler;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Repository\EverBlockRepositoryInterface;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotDuplicateEverBlockException;
+use Everblock\PrestaShopBundle\Domain\EverBlock\Exception\CannotToggleEverBlockStatusException;
+
+function expect(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+class InMemoryEverBlockRepository implements EverBlockRepositoryInterface
+{
+    public $duplicatedIds = [];
+    public $toggledIds = [];
+    public $statusMap = [];
+    public $deletedIds = [];
+
+    public function duplicate(int $everBlockId): int
+    {
+        if ($everBlockId === 99) {
+            throw new CannotDuplicateEverBlockException('boom');
+        }
+        $this->duplicatedIds[] = $everBlockId;
+
+        return $everBlockId + 1000;
+    }
+
+    public function toggleStatus(int $everBlockId): bool
+    {
+        if ($everBlockId === 77) {
+            throw new CannotToggleEverBlockStatusException('boom');
+        }
+        $this->toggledIds[] = $everBlockId;
+        $this->statusMap[$everBlockId] = !($this->statusMap[$everBlockId] ?? false);
+
+        return $this->statusMap[$everBlockId];
+    }
+
+    public function updateStatus(int $everBlockId, bool $enabled): void
+    {
+        $this->statusMap[$everBlockId] = $enabled;
+    }
+
+    public function delete(int $everBlockId): void
+    {
+        $this->deletedIds[] = $everBlockId;
+    }
+}
+
+$repository = new InMemoryEverBlockRepository();
+$duplicateHandler = new DuplicateEverBlockHandler($repository);
+$toggleHandler = new ToggleEverBlockStatusHandler($repository);
+
+$resultId = $duplicateHandler->handle(new DuplicateEverBlockCommand(5));
+expect($resultId === 1005, 'Unexpected duplicated block id');
+expect($repository->duplicatedIds === [5], 'Duplicate operation not recorded');
+
+$status = $toggleHandler->handle(new ToggleEverBlockStatusCommand(5));
+expect($status === true, 'Status should have been toggled to true');
+$status = $toggleHandler->handle(new ToggleEverBlockStatusCommand(5));
+expect($status === false, 'Status should have been toggled to false');
+
+$exceptionThrown = false;
+try {
+    $duplicateHandler->handle(new DuplicateEverBlockCommand(99));
+} catch (CannotDuplicateEverBlockException $exception) {
+    $exceptionThrown = true;
+}
+expect($exceptionThrown, 'Duplicate handler should propagate repository exceptions');
+
+echo "DuplicateEverBlockHandlerTest passed\n";

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,14 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$tests = [
+    __DIR__ . '/Functional/BulkActionIdsExtractorTest.php',
+    __DIR__ . '/Functional/DuplicateEverBlockHandlerTest.php',
+];
+
+foreach ($tests as $testFile) {
+    require $testFile;
+}
+
+echo "All functional tests executed successfully\n";


### PR DESCRIPTION
## Summary
- add Symfony routes, services, and DI wiring to expose the Everblock grid actions through the new controller
- implement command handlers, repository, and utility services to duplicate blocks, toggle status, export SQL, and manage cache/DB checks
- extend the grid with toggle/row/bulk actions and cover the new behaviour with lightweight functional tests

## Testing
- `php tests/run.php`


------
https://chatgpt.com/codex/tasks/task_e_68f8e95da9848322bfb794d16aaae4bc