### PR TITLE
Enable drag-and-drop ordering in admin controllers

### DIFF
--- a/models/EverblockClass.php
+++ b/models/EverblockClass.php
@@ -380,4 +380,64 @@ class EverBlockClass extends ObjectModel
         }
         return EverblockCache::cacheRetrieve($cacheId);
     }
+
+    public static function updatePositionsByHook(array $positionsByHook, int $idShop): bool
+    {
+        if (empty($positionsByHook)) {
+            return true;
+        }
+
+        $db = Db::getInstance();
+
+        foreach ($positionsByHook as $idHook => $blockIds) {
+            if (!is_array($blockIds) || empty($blockIds)) {
+                continue;
+            }
+
+            $position = 0;
+            $seen = [];
+
+            foreach ($blockIds as $blockId) {
+                $blockId = (int) $blockId;
+                if ($blockId <= 0 || isset($seen[$blockId])) {
+                    continue;
+                }
+
+                $seen[$blockId] = true;
+
+                $updated = $db->update(
+                    'everblock',
+                    ['position' => (int) $position],
+                    'id_everblock = ' . (int) $blockId
+                    . ' AND id_hook = ' . (int) $idHook
+                    . ' AND id_shop = ' . (int) $idShop
+                );
+
+                if (!$updated) {
+                    return false;
+                }
+
+                ++$position;
+            }
+
+            static::clearPositionsCache((int) $idHook, (int) $idShop);
+        }
+
+        return true;
+    }
+
+    protected static function clearPositionsCache(int $idHook, int $idShop): void
+    {
+        $languages = Language::getLanguages(false);
+
+        foreach ($languages as $language) {
+            $idLang = (int) $language['id_lang'];
+            EverblockCache::cacheDrop('EverBlockClass_getBlocks_' . (int) $idHook . '_' . $idLang . '_' . (int) $idShop);
+            EverblockCache::cacheDrop('EverBlockClass_getAllBlocks_' . $idLang . '_' . (int) $idShop);
+        }
+
+        EverblockCache::cacheDropByPattern('EverBlockClass_getBlocks_' . (int) $idHook . '_');
+        EverblockCache::cacheDropByPattern('EverBlockClass_getAllBlocks_');
+        EverblockCache::cacheDropByPattern('everblock-id_hook-' . (int) $idHook);
+    }
 }


### PR DESCRIPTION
## Summary
- enable drag-and-drop handles on block and FAQ admin lists
- add AJAX handlers and model helpers to persist reordered positions and refresh caches

## Testing
- php -l controllers/admin/AdminEverBlockController.php
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l models/EverblockClass.php
- php -l models/EverblockFaq.php

------
https://chatgpt.com/codex/tasks/task_e_68f9034c8fdc832298bb9e8b452c75a2