### PR TITLE
Add product FAQ associations and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ views/css/custom1.css
 views/js/custom-compressed1.js
 views/js/custom1.js
 upgrade/*.php
+!upgrade/upgrade-*.php
 views/js/store-locator-1.js
 *.sql
 views/backup/css/custom-compressed1.css

--- a/models/EverblockFaqProduct.php
+++ b/models/EverblockFaqProduct.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+use Everblock\Tools\Service\EverblockCache;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverblockFaqProduct extends ObjectModel
+{
+    /** @var int */
+    public $id_everblock_faq_product;
+
+    /** @var int */
+    public $id_product;
+
+    /** @var int */
+    public $id_shop;
+
+    /** @var int */
+    public $id_everblock_faq;
+
+    /** @var string */
+    public $date_add;
+
+    /** @var string */
+    public $date_upd;
+
+    public static $definition = [
+        'table' => 'everblock_faq_product',
+        'primary' => 'id_everblock_faq_product',
+        'fields' => [
+            'id_product' => [
+                'type' => self::TYPE_INT,
+                'validate' => 'isUnsignedId',
+                'required' => true,
+            ],
+            'id_shop' => [
+                'type' => self::TYPE_INT,
+                'validate' => 'isUnsignedId',
+                'required' => true,
+            ],
+            'id_everblock_faq' => [
+                'type' => self::TYPE_INT,
+                'validate' => 'isUnsignedId',
+                'required' => true,
+            ],
+            'date_add' => [
+                'type' => self::TYPE_DATE,
+                'validate' => 'isDate',
+                'required' => false,
+            ],
+            'date_upd' => [
+                'type' => self::TYPE_DATE,
+                'validate' => 'isDate',
+                'required' => false,
+            ],
+        ],
+    ];
+
+    public function add($autoDate = true, $nullValues = false)
+    {
+        $result = parent::add($autoDate, $nullValues);
+
+        if ($result) {
+            static::clearCacheForProduct((int) $this->id_product, (int) $this->id_shop);
+        }
+
+        return $result;
+    }
+
+    public function delete()
+    {
+        $productId = (int) $this->id_product;
+        $shopId = (int) $this->id_shop;
+
+        $result = parent::delete();
+
+        if ($result) {
+            static::clearCacheForProduct($productId, $shopId);
+        }
+
+        return $result;
+    }
+
+    public static function addAssociation(int $productId, int $shopId, int $faqId): bool
+    {
+        if ($productId <= 0 || $shopId <= 0 || $faqId <= 0) {
+            return false;
+        }
+
+        $sql = new DbQuery();
+        $sql->select(self::$definition['primary']);
+        $sql->from(self::$definition['table']);
+        $sql->where('id_product = ' . (int) $productId);
+        $sql->where('id_shop = ' . (int) $shopId);
+        $sql->where('id_everblock_faq = ' . (int) $faqId);
+
+        $exists = (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+
+        if ($exists > 0) {
+            return true;
+        }
+
+        $association = new self();
+        $association->id_product = (int) $productId;
+        $association->id_shop = (int) $shopId;
+        $association->id_everblock_faq = (int) $faqId;
+
+        $saved = $association->save();
+
+        if ($saved) {
+            static::clearCacheForProduct($productId, $shopId);
+        }
+
+        return $saved;
+    }
+
+    public static function removeAssociation(int $productId, int $shopId, int $faqId): bool
+    {
+        if ($productId <= 0 || $shopId <= 0 || $faqId <= 0) {
+            return false;
+        }
+
+        $deleted = Db::getInstance()->delete(
+            self::$definition['table'],
+            'id_product = ' . (int) $productId
+            . ' AND id_shop = ' . (int) $shopId
+            . ' AND id_everblock_faq = ' . (int) $faqId
+        );
+
+        if ($deleted) {
+            static::clearCacheForProduct($productId, $shopId);
+        }
+
+        return (bool) $deleted;
+    }
+
+    public static function deleteByFaq(int $faqId): bool
+    {
+        if ($faqId <= 0) {
+            return true;
+        }
+
+        $associations = static::getProductAssociationsByFaq($faqId);
+
+        if (empty($associations)) {
+            return true;
+        }
+
+        $deleted = Db::getInstance()->delete(
+            self::$definition['table'],
+            'id_everblock_faq = ' . (int) $faqId
+        );
+
+        if ($deleted) {
+            static::clearCacheForAssociations($associations);
+        }
+
+        return (bool) $deleted;
+    }
+
+    public static function getFaqIdsByProduct(int $productId, int $shopId): array
+    {
+        if ($productId <= 0 || $shopId <= 0) {
+            return [];
+        }
+
+        $sql = new DbQuery();
+        $sql->select('id_everblock_faq');
+        $sql->from(self::$definition['table']);
+        $sql->where('id_product = ' . (int) $productId);
+        $sql->where('id_shop = ' . (int) $shopId);
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+
+        if (empty($rows)) {
+            return [];
+        }
+
+        return array_map(static function ($row) {
+            return (int) $row['id_everblock_faq'];
+        }, $rows);
+    }
+
+    public static function getProductAssociationsByFaq(int $faqId): array
+    {
+        if ($faqId <= 0) {
+            return [];
+        }
+
+        $sql = new DbQuery();
+        $sql->select('id_product, id_shop');
+        $sql->from(self::$definition['table']);
+        $sql->where('id_everblock_faq = ' . (int) $faqId);
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+    }
+
+    public static function clearCacheForProduct(int $productId, int $shopId): void
+    {
+        if ($productId <= 0 || $shopId <= 0) {
+            return;
+        }
+
+        EverblockCache::clearFaqProductCache((int) $shopId, (int) $productId);
+    }
+
+    public static function clearCacheForFaq(int $faqId): void
+    {
+        $associations = static::getProductAssociationsByFaq($faqId);
+
+        if (empty($associations)) {
+            return;
+        }
+
+        static::clearCacheForAssociations($associations);
+    }
+
+    public static function clearCacheForShop(int $shopId): void
+    {
+        if ($shopId <= 0) {
+            return;
+        }
+
+        $sql = new DbQuery();
+        $sql->select('DISTINCT id_product');
+        $sql->from(self::$definition['table']);
+        $sql->where('id_shop = ' . (int) $shopId);
+
+        $products = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+
+        if (empty($products)) {
+            return;
+        }
+
+        foreach ($products as $product) {
+            static::clearCacheForProduct((int) $product['id_product'], (int) $shopId);
+        }
+    }
+
+    protected static function clearCacheForAssociations(array $associations): void
+    {
+        if (empty($associations)) {
+            return;
+        }
+
+        $handled = [];
+
+        foreach ($associations as $association) {
+            $productId = (int) $association['id_product'];
+            $shopId = (int) $association['id_shop'];
+
+            if ($productId <= 0 || $shopId <= 0) {
+                continue;
+            }
+
+            $key = $shopId . '-' . $productId;
+
+            if (isset($handled[$key])) {
+                continue;
+            }
+
+            $handled[$key] = true;
+            static::clearCacheForProduct($productId, $shopId);
+        }
+    }
+}

--- a/sql/install.php
+++ b/sql/install.php
@@ -102,6 +102,20 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_lang` (
         PRIMARY KEY (`id_everblock_faq`, `id_lang`)
     ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
 
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product` (
+        `id_everblock_faq_product` int(10) unsigned NOT NULL auto_increment,
+        `id_product` int(10) unsigned NOT NULL,
+        `id_shop` int(10) unsigned NOT NULL,
+        `id_everblock_faq` int(10) unsigned NOT NULL,
+        `date_add` DATETIME DEFAULT NULL,
+        `date_upd` DATETIME DEFAULT NULL,
+        PRIMARY KEY (`id_everblock_faq_product`),
+        UNIQUE KEY `idx_everblock_faq_product_unique` (`id_product`, `id_shop`, `id_everblock_faq`),
+        KEY `idx_everblock_faq_product_product` (`id_product`),
+        KEY `idx_everblock_faq_product_faq` (`id_everblock_faq`),
+        KEY `idx_everblock_faq_product_shop` (`id_shop`)
+    ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+
 /* Tabs */
 $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_tabs` (
          `id_everblock_tabs` int(10) unsigned NOT NULL auto_increment,

--- a/sql/uninstall.php
+++ b/sql/uninstall.php
@@ -29,6 +29,7 @@ $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_shortcode`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_shortcode_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq_lang`;';
+$sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_tabs`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_tabs_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_flags`;';

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -1002,7 +1002,19 @@ class EverblockTools extends ObjectModel
 
             $faqs = EverblockFaq::getFaqByTagName($context->shop->id, $context->language->id, $tagName);
 
-            $context->smarty->assign('everFaqs', $faqs);
+            $slug = Tools::str2url($tagName);
+            if ($slug === '') {
+                $slug = substr(md5($tagName), 0, 8);
+            }
+
+            $unique = uniqid($slug . '-', false);
+            $containerId = 'everblockFaq-' . $unique;
+
+            $context->smarty->assign([
+                'everFaqs' => $faqs,
+                'faqContainerId' => $containerId,
+                'faqAccordionId' => $containerId . '-accordion',
+            ]);
 
             return $context->smarty->fetch($templatePath);
 

--- a/upgrade/upgrade-8.0.5.php
+++ b/upgrade/upgrade-8.0.5.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_8_0_5($module)
+{
+    $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product` (
+            `id_everblock_faq_product` int(10) unsigned NOT NULL auto_increment,
+            `id_product` int(10) unsigned NOT NULL,
+            `id_shop` int(10) unsigned NOT NULL,
+            `id_everblock_faq` int(10) unsigned NOT NULL,
+            `date_add` DATETIME DEFAULT NULL,
+            `date_upd` DATETIME DEFAULT NULL,
+            PRIMARY KEY (`id_everblock_faq_product`),
+            UNIQUE KEY `idx_everblock_faq_product_unique` (`id_product`, `id_shop`, `id_everblock_faq`),
+            KEY `idx_everblock_faq_product_product` (`id_product`),
+            KEY `idx_everblock_faq_product_faq` (`id_everblock_faq`),
+            KEY `idx_everblock_faq_product_shop` (`id_shop`)
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+
+    return Db::getInstance()->execute($sql);
+}

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -17,10 +17,12 @@
 *}
 
 {if isset($everFaqs) && $everFaqs}
-  <div class="container" id="everblockFaq">
+  {assign var=containerId value=$faqContainerId|default:'everblockFaq'}
+  {assign var=accordionId value=$faqAccordionId|default:($containerId|cat:'-accordion')}
+  <div class="container" id="{$containerId|escape:'htmlall':'UTF-8'}">
     <div class="row">
       <div class="col-12">
-        <div class="accordion faq-accordion" id="faqAccordion">
+        <div class="accordion faq-accordion" id="{$accordionId|escape:'htmlall':'UTF-8'}">
           {foreach from=$everFaqs item=faq name=faqloop}
             <div class="accordion-item card faq-item">
               <h2 class="accordion-header card-header p-0" id="headingEverFaq{$faq->id_everblock_faq}">
@@ -34,7 +36,7 @@
                 </button>
               </h2>
               <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
-                   aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
+                   aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#{$accordionId|escape:'htmlall':'UTF-8'}" data-bs-parent="#{$accordionId|escape:'htmlall':'UTF-8'}">
                 <div class="accordion-body card-body faq-answer">
                   <div class="faq-answer__content">{$faq->content nofilter}</div>
                 </div>


### PR DESCRIPTION
## Summary
- add the everblock_faq_product association table during install and drop it on uninstall, plus ship an upgrade script for existing shops
- introduce the EverblockFaqProduct model and extend FAQ/cache logic to manage product associations and grouped retrieval
- render product-linked FAQs in hookDisplayProductExtraContent with tag-based panels and unique accordion/template identifiers

## Testing
- php -l everblock/everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68f9b8ebfaa0832281b06eb49612031e