### PR TITLE
Add tag-aware FAQ reordering in admin

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -173,6 +173,8 @@ return [
     'views/templates/admin/header.tpl',
     'views/templates/admin/index.php',
     'views/templates/admin/list_action_export.tpl',
+    'views/templates/admin/faq/tag_filter.tpl',
+    'views/templates/admin/faq/index.php',
     'views/templates/admin/productTab.tpl',
     'views/templates/admin/productModal.tpl',
     'views/templates/admin/upgrade.tpl',

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -142,6 +142,7 @@ class AdminEverBlockFaqController extends ModuleAdminController
         parent::setMedia($isNewTheme);
 
         $this->addCSS(_PS_MODULE_DIR_ . 'everblock/views/css/ever.css');
+        $this->addJS(_PS_MODULE_DIR_ . 'everblock/views/js/admin.js');
     }
 
     public function l($string, $class = null, $addslashes = false, $htmlentities = true)
@@ -194,6 +195,7 @@ class AdminEverBlockFaqController extends ModuleAdminController
             $this->confirmations[] = $this->l('Cache has been cleared');
         }
         $lists = parent::renderList();
+        $lists = $this->prepareFaqListMarkup($lists);
 
         $moduleInstance = Module::getInstanceByName('everblock');
         $displayUpgrade = $moduleInstance->checkLatestEverModuleVersion();
@@ -229,6 +231,148 @@ class AdminEverBlockFaqController extends ModuleAdminController
         return $content;
     }
 
+    protected function prepareFaqListMarkup($listHtml)
+    {
+        if (!is_string($listHtml) || empty($this->_list) || !is_array($this->_list)) {
+            return $listHtml;
+        }
+
+        $rowMetadata = [];
+        $tags = [];
+
+        foreach ($this->_list as $row) {
+            if (!isset($row[$this->identifier])) {
+                continue;
+            }
+
+            $faqId = (int) $row[$this->identifier];
+
+            if ($faqId <= 0) {
+                continue;
+            }
+
+            $tagName = isset($row['tag_name']) ? (string) $row['tag_name'] : '';
+            $position = isset($row['position']) ? (int) $row['position'] : 0;
+
+            $rowMetadata[$faqId] = [
+                'tag' => $tagName,
+                'position' => $position,
+            ];
+
+            if ($tagName !== '' && !in_array($tagName, $tags, true)) {
+                $tags[] = $tagName;
+            }
+        }
+
+        if (!empty($rowMetadata)) {
+            $listHtml = $this->injectFaqRowAttributes($listHtml, $rowMetadata);
+            $listHtml = $this->markFaqTable($listHtml);
+        }
+
+        if (!empty($tags)) {
+            sort($tags, SORT_STRING | SORT_FLAG_CASE);
+            $filterHtml = $this->renderFaqTagFilter($tags);
+
+            if ($filterHtml !== '') {
+                $listHtml = $filterHtml . $listHtml;
+            }
+        }
+
+        return $listHtml;
+    }
+
+    protected function renderFaqTagFilter(array $tags): string
+    {
+        if (empty($tags)) {
+            return '';
+        }
+
+        $template = $this->context->smarty->createTemplate(
+            _PS_MODULE_DIR_ . 'everblock/views/templates/admin/faq/tag_filter.tpl'
+        );
+
+        $template->assign([
+            'faq_tags' => $tags,
+            'filter_all_label' => $this->l('All tags'),
+            'filter_label' => $this->l('Filter by tag'),
+        ]);
+
+        return (string) $template->fetch();
+    }
+
+    protected function markFaqTable(string $listHtml): string
+    {
+        $pattern = '#<table[^>]*id="table-' . preg_quote($this->table, '#') . '"[^>]*>#i';
+
+        return (string) preg_replace_callback($pattern, function ($matches) {
+            if (false !== strpos($matches[0], 'data-everblock-faq-table')) {
+                return $matches[0];
+            }
+
+            $closingPosition = strrpos($matches[0], '>');
+
+            if (false === $closingPosition) {
+                return $matches[0];
+            }
+
+            $before = substr($matches[0], 0, $closingPosition);
+            $after = substr($matches[0], $closingPosition);
+
+            return $before . ' data-everblock-faq-table="1"' . $after;
+        }, $listHtml, 1);
+    }
+
+    protected function injectFaqRowAttributes(string $listHtml, array $rowMetadata): string
+    {
+        if (empty($rowMetadata)) {
+            return $listHtml;
+        }
+
+        $pattern = '#<tr([^>]*)id="tr_' . preg_quote($this->table, '#') . '_(\d+)"([^>]*)>#i';
+
+        return (string) preg_replace_callback($pattern, function ($matches) use ($rowMetadata) {
+            $faqId = (int) $matches[2];
+
+            if (!isset($rowMetadata[$faqId])) {
+                return $matches[0];
+            }
+
+            $tagName = htmlspecialchars($rowMetadata[$faqId]['tag'], ENT_QUOTES, 'UTF-8');
+            $position = (int) $rowMetadata[$faqId]['position'];
+
+            $rowMarkup = $matches[0];
+            $closingPosition = strrpos($rowMarkup, '>');
+
+            if (false === $closingPosition) {
+                return $rowMarkup;
+            }
+
+            $before = substr($rowMarkup, 0, $closingPosition);
+            $after = substr($rowMarkup, $closingPosition);
+
+            if (false === strpos($before, 'class=')) {
+                $before = str_replace('<tr', '<tr class="js-everblock-faq-row"', $before);
+            } elseif (false === strpos($before, 'js-everblock-faq-row')) {
+                $before = preg_replace(
+                    '#class="([^"]*)"#',
+                    'class="$1 js-everblock-faq-row"',
+                    $before,
+                    1
+                );
+            }
+
+            if (false === strpos($before, 'data-tag=')) {
+                $before .= ' data-tag="' . $tagName . '"';
+            }
+
+            if (false === strpos($before, 'data-position=')) {
+                $before .= ' data-position="' . (int) $position . '"';
+            }
+
+            return $before . $after;
+        }, $listHtml);
+    }
+
     public function renderContentWithoutHtml($value, $row)
     {
         $cleanContent = trim(strip_tags($value));
@@ -257,6 +401,16 @@ class AdminEverBlockFaqController extends ModuleAdminController
             ]));
         }
 
+        $tagName = (string) Tools::getValue('tag_name', '');
+        $tagName = trim($tagName);
+
+        if ($tagName === '') {
+            $this->ajaxDie(Tools::jsonEncode([
+                'hasError' => true,
+                'errors' => [$this->l('Missing FAQ tag for reordering.')],
+            ]));
+        }
+
         $orderedIds = [];
         foreach ($positions as $identifier) {
             $parts = explode('_', (string) $identifier);
@@ -266,16 +420,19 @@ class AdminEverBlockFaqController extends ModuleAdminController
             }
         }
 
-        if (empty($orderedIds) || !EverblockFaq::updatePositions($orderedIds, (int) $this->context->shop->id)) {
+        if (empty($orderedIds)
+            || !EverblockFaq::updatePositions($orderedIds, (int) $this->context->shop->id, $tagName)
+        ) {
             $this->ajaxDie(Tools::jsonEncode([
                 'hasError' => true,
-                'errors' => [$this->l('Unable to update FAQ positions.')],
+                'errors' => [$this->l('Unable to update FAQ positions for the selected tag.')],
             ]));
         }
 
         $this->ajaxDie(Tools::jsonEncode([
             'success' => true,
-            'message' => $this->l('Positions updated successfully.'),
+            'tag' => $tagName,
+            'message' => $this->l('Positions updated successfully for the selected tag.'),
         ]));
     }
 

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -19,6 +19,7 @@
 $(document).ready(function() {
   const cssTextarea = document.getElementById('EVERPSCSS');
   const jsTextarea = document.getElementById('EVERPSJS');
+  let currentFaqTag = null;
 
   if (cssTextarea) {
     CodeMirror.fromTextArea(cssTextarea, {
@@ -105,5 +106,119 @@ $(document).ready(function() {
     setTimeout(function() {
       $pulse.remove();
     }, 600);
+  });
+
+  const $faqTable = $('[data-everblock-faq-table]');
+
+  function isFaqPositionRequest(settings) {
+    return (
+      settings &&
+      typeof settings.data === 'string' &&
+      settings.data.indexOf('controller=AdminEverBlockFaq') !== -1 &&
+      settings.data.indexOf('action=updatePositions') !== -1
+    );
+  }
+
+  function updateFaqRowPositions() {
+    if (!$faqTable.length) {
+      return;
+    }
+
+    const tagCounters = {};
+
+    $faqTable.find('tr.js-everblock-faq-row:visible').each(function() {
+      const $row = $(this);
+      const rowTag = ($row.data('tag') || '').toString();
+
+      if (!Object.prototype.hasOwnProperty.call(tagCounters, rowTag)) {
+        tagCounters[rowTag] = 0;
+      }
+
+      $row.attr('data-position', tagCounters[rowTag]);
+      tagCounters[rowTag] += 1;
+    });
+  }
+
+  function setCurrentFaqTagFromRow($row) {
+    if (!$row || !$row.length) {
+      return;
+    }
+
+    const tag = ($row.data('tag') || '').toString();
+
+    if (tag) {
+      currentFaqTag = tag;
+    }
+  }
+
+  if ($faqTable.length) {
+    const $faqFilter = $('.js-everblock-faq-filter');
+
+    if ($faqFilter.length) {
+      $faqFilter.on('change', function() {
+        const selectedTag = $(this).val();
+        const $rows = $faqTable.find('tr.js-everblock-faq-row');
+
+        if (!selectedTag) {
+          $rows.show();
+          updateFaqRowPositions();
+          return;
+        }
+
+        $rows.each(function() {
+          const $row = $(this);
+          const rowTag = ($row.data('tag') || '').toString();
+
+          if (rowTag === selectedTag) {
+            $row.show();
+          } else {
+            $row.hide();
+          }
+        });
+
+        updateFaqRowPositions();
+      });
+    }
+
+    $faqTable.on('mousedown touchstart', '.dragHandle', function() {
+      const $row = $(this).closest('tr');
+      setCurrentFaqTagFromRow($row);
+    });
+
+    updateFaqRowPositions();
+  }
+
+  $(document).ajaxSend(function(event, jqXHR, settings) {
+    if (!isFaqPositionRequest(settings)) {
+      return;
+    }
+
+    if (!currentFaqTag) {
+      const idMatch = settings.data.match(/everblock_faq%5B%5D=(\d+)/);
+
+      if (idMatch && idMatch[1]) {
+        const $row = $('#tr_everblock_faq_' + idMatch[1]);
+        setCurrentFaqTagFromRow($row);
+      }
+    }
+
+    if (currentFaqTag && settings.data.indexOf('tag_name=') === -1) {
+      settings.data += '&tag_name=' + encodeURIComponent(currentFaqTag);
+    }
+  });
+
+  $(document).ajaxSuccess(function(event, jqXHR, settings) {
+    if (!isFaqPositionRequest(settings)) {
+      return;
+    }
+
+    currentFaqTag = null;
+    updateFaqRowPositions();
+  });
+
+  $(document).ajaxError(function(event, jqXHR, settings) {
+    if (isFaqPositionRequest(settings)) {
+      currentFaqTag = null;
+    }
   });
 });

--- a/views/templates/admin/faq/index.php
+++ b/views/templates/admin/faq/index.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}

--- a/views/templates/admin/faq/tag_filter.tpl
+++ b/views/templates/admin/faq/tag_filter.tpl
@@ -1,0 +1,43 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+
+{if !empty($faq_tags)}
+<div class="panel everblock-faq-filter" data-everblock-faq-filter>
+    <div class="panel-heading">
+        <i class="icon-filter"></i>
+        {$filter_label|escape:'htmlall':'UTF-8'}
+    </div>
+    <div class="panel-body">
+        <div class="form-group">
+            <label class="control-label col-lg-2" for="everblock-faq-filter-select">
+                {l s='Tag' mod='everblock'}
+            </label>
+            <div class="col-lg-10">
+                <select id="everblock-faq-filter-select" class="form-control js-everblock-faq-filter">
+                    <option value="">{$filter_all_label|escape:'htmlall':'UTF-8'}</option>
+                    {foreach from=$faq_tags item=faq_tag}
+                        <option value="{$faq_tag|escape:'htmlall':'UTF-8'}">
+                            {$faq_tag|escape:'htmlall':'UTF-8'}
+                        </option>
+                    {/foreach}
+                </select>
+            </div>
+        </div>
+    </div>
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- segment the FAQ admin list by tag, exposing tag/position metadata and a filter widget
- update the drag-and-drop workflow to send the active tag and adjust backend position updates per tag with scoped cache clearing
- extend the admin JavaScript to handle tag-aware filtering and augment PrestaShop's reorder request payloads

## Testing
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l models/EverblockFaq.php
- php -l views/templates/admin/faq/index.php

------
https://chatgpt.com/codex/tasks/task_e_68f9bfd5e3588322a47998ccfd8d0edd