### PR TITLE
Add EverblockFaqProduct to allowed files list

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -73,6 +73,7 @@ return [
     'src/Checkout/EverblockCheckoutStep.php',
     'models/EverblockClass.php',
     'models/EverblockFaq.php',
+    'models/EverblockFaqProduct.php',
     'models/EverblockFlagsClass.php',
     'models/EverblockModal.php',
     'src/Service/EverblockPrettyBlocks.php',


### PR DESCRIPTION
## Summary
- add the EverblockFaqProduct model to the allow-listed files configuration

## Testing
- php -l config/allowed_files.php

------
https://chatgpt.com/codex/tasks/task_e_68f9d628c4908322970f170f18c18a37