### PR TITLE
Fix missing Manufacturer import in EverblockTools

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -44,6 +44,7 @@ use ImageManager;
 use ImageType;
 use Language;
 use Link;
+use Manufacturer;
 use Media;
 use Module;
 use NewsletterProSubscription;


### PR DESCRIPTION
## Summary
- add the missing Manufacturer import so the brand data helper can instantiate the PrestaShop model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9db1c561483229c0a567b8011276b