### PR TITLE
Remove admin configuration sidebar panels

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -408,15 +408,9 @@
 }
 
 .everblock-config__layout {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 2.25rem;
-}
-
-@media (min-width: 992px) {
-    .everblock-config__layout {
-        grid-template-columns: minmax(0, 2.25fr) minmax(260px, 1fr);
-        align-items: start;
-    }
 }
 
 .everblock-config__card {
@@ -540,129 +534,6 @@
     margin-top: 0.5rem;
 }
 
-.everblock-sidecard {
-    background: #ffffff;
-    border-radius: 22px;
-    box-shadow: 0 22px 55px rgba(15, 23, 42, 0.16);
-    padding: 1.9rem 1.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-}
-
-.everblock-sidecard__title {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 1.15rem;
-    font-weight: 700;
-    margin: 0;
-    color: #1f2552;
-}
-
-.everblock-sidecard__subtitle {
-    margin: 0;
-    font-size: 0.95rem;
-    color: #4b5563;
-}
-
-.everblock-sidecard__actions {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.everblock-sidecard__link {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    text-decoration: none;
-    background: #f5f6ff;
-    border-radius: 16px;
-    padding: 1rem 1.1rem;
-    color: #111827;
-    border: 1px solid transparent;
-    transition: all 0.2s ease;
-}
-
-.everblock-sidecard__link strong {
-    font-size: 1rem;
-    font-weight: 700;
-    display: block;
-}
-
-.everblock-sidecard__link small {
-    display: block;
-    margin-top: 0.35rem;
-    font-size: 0.85rem;
-    color: #5b6075;
-    font-weight: 500;
-}
-
-.everblock-sidecard__link:hover {
-    border-color: #4337ff;
-    box-shadow: 0 18px 34px rgba(67, 55, 255, 0.22);
-    transform: translateY(-2px);
-    color: #111827;
-}
-
-.everblock-sidecard__icon {
-    width: 46px;
-    height: 46px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #4337ff 0%, #8f5bff 100%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #fff;
-    font-size: 1.15rem;
-    flex-shrink: 0;
-    box-shadow: 0 12px 20px rgba(67, 55, 255, 0.35);
-}
-
-.everblock-sidecard__badges {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-}
-
-.everblock-sidecard__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.65rem;
-    padding: 0.65rem 1.1rem;
-    border-radius: 999px;
-    background: #eef0ff;
-    color: #3a3a68;
-    font-weight: 600;
-}
-
-.everblock-sidecard__cta {
-    margin-top: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.65rem;
-    padding: 0.9rem 1.5rem;
-    border-radius: 14px;
-    background: linear-gradient(135deg, #ff7a59 0%, #ff4f8b 100%);
-    color: #fff;
-    font-weight: 700;
-    text-decoration: none;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.everblock-sidecard__cta:hover {
-    color: #fff;
-    transform: translateY(-2px);
-    box-shadow: 0 18px 38px rgba(255, 79, 139, 0.35);
-}
 
 details.everblock-doc-accordion {
     background: #ffffff;

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -65,112 +65,16 @@
     </section>
 
     <div class="everblock-config__layout">
-        <div class="everblock-config__main">
-            {if isset($display_upgrade) && $display_upgrade}
-                <div class="everblock-config__card">
-                    {include file='module:everblock/views/templates/admin/upgrade.tpl'}
-                </div>
-            {/if}
-
-            {if isset($everblock_form)}
-                <div class="everblock-config__card everblock-config__card--form">
-                    {$everblock_form nofilter}
-                </div>
-            {/if}
-        </div>
-
-        <aside class="everblock-config__aside">
-            <div class="everblock-sidecard">
-                <h3 class="everblock-sidecard__title">
-                    <i class="icon-th-large"></i>
-                    {l s='Quick actions' mod='everblock'}
-                </h3>
-                <p class="everblock-sidecard__subtitle">
-                    {l s='Jump straight into your daily tasks with shortcuts curated for content managers.' mod='everblock'}
-                </p>
-                <ul class="everblock-sidecard__actions">
-                    {if isset($block_admin_link) && $block_admin_link}
-                        <li>
-                            <a class="everblock-sidecard__link" href="{$block_admin_link|escape:'htmlall':'UTF-8'}">
-                                <span class="everblock-sidecard__icon"><i class="icon-puzzle-piece"></i></span>
-                                <span>
-                                    <strong>{l s='Manage blocks' mod='everblock'}</strong>
-                                    <small>{l s='Create, schedule and personalise content blocks.' mod='everblock'}</small>
-                                </span>
-                            </a>
-                        </li>
-                    {/if}
-                    {if isset($shortcode_admin_link) && $shortcode_admin_link}
-                        <li>
-                            <a class="everblock-sidecard__link" href="{$shortcode_admin_link|escape:'htmlall':'UTF-8'}">
-                                <span class="everblock-sidecard__icon"><i class="icon-code"></i></span>
-                                <span>
-                                    <strong>{l s='Manage shortcodes' mod='everblock'}</strong>
-                                    <small>{l s='Build reusable snippets for your CMS and product pages.' mod='everblock'}</small>
-                                </span>
-                            </a>
-                        </li>
-                    {/if}
-                    {if isset($faq_admin_link) && $faq_admin_link}
-                        <li>
-                            <a class="everblock-sidecard__link" href="{$faq_admin_link|escape:'htmlall':'UTF-8'}">
-                                <span class="everblock-sidecard__icon"><i class="icon-question-sign"></i></span>
-                                <span>
-                                    <strong>{l s='Manage FAQ' mod='everblock'}</strong>
-                                    <small>{l s='Update customer-facing answers in a few clicks.' mod='everblock'}</small>
-                                </span>
-                            </a>
-                        </li>
-                    {/if}
-                    {if isset($hook_admin_link) && $hook_admin_link}
-                        <li>
-                            <a class="everblock-sidecard__link" href="{$hook_admin_link|escape:'htmlall':'UTF-8'}">
-                                <span class="everblock-sidecard__icon"><i class="icon-sitemap"></i></span>
-                                <span>
-                                    <strong>{l s='Manage hooks' mod='everblock'}</strong>
-                                    <small>{l s='Control where content appears across your store.' mod='everblock'}</small>
-                                </span>
-                            </a>
-                        </li>
-                    {/if}
-                </ul>
+        {if isset($display_upgrade) && $display_upgrade}
+            <div class="everblock-config__card">
+                {include file='module:everblock/views/templates/admin/upgrade.tpl'}
             </div>
+        {/if}
 
-            <div class="everblock-sidecard">
-                <h3 class="everblock-sidecard__title">
-                    <i class="icon-bullhorn"></i>
-                    {l s='Support & resources' mod='everblock'}
-                </h3>
-                <p class="everblock-sidecard__subtitle">
-                    {l s='Need inspiration? Explore documentation, automations and best practices shipped with Ever Block.' mod='everblock'}
-                </p>
-                <ul class="everblock-sidecard__badges">
-                    <li>
-                        <span class="everblock-sidecard__badge">
-                            <i class="icon-bar-chart"></i>
-                            {l s='Total blocks: %s' sprintf=[$everblock_stats.blocks_total|intval] mod='everblock'}
-                        </span>
-                    </li>
-                    <li>
-                        <span class="everblock-sidecard__badge">
-                            <i class="icon-comments"></i>
-                            {l s='FAQ entries: %s' sprintf=[$everblock_stats.faqs|intval] mod='everblock'}
-                        </span>
-                    </li>
-                    <li>
-                        <span class="everblock-sidecard__badge">
-                            <i class="icon-gamepad"></i>
-                            {l s='Gamification sessions: %s' sprintf=[$everblock_stats.game_sessions|intval] mod='everblock'}
-                        </span>
-                    </li>
-                </ul>
-                {if isset($donation_link)}
-                    <a class="everblock-sidecard__cta" href="{$donation_link|escape:'htmlall':'UTF-8'}" target="_blank">
-                        <i class="icon-heart"></i>
-                        {l s='Support ongoing development' mod='everblock'}
-                    </a>
-                {/if}
+        {if isset($everblock_form)}
+            <div class="everblock-config__card everblock-config__card--form">
+                {$everblock_form nofilter}
             </div>
-        </aside>
+        {/if}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove the Quick actions and Support & resources panels from the module configuration view
- simplify the admin configuration layout styling to a single column
- drop the unused sidebar-related CSS rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9daeaa82483229b2330f70ae4a81e