### PR TITLE
Fix missing Manufacturer import

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -48,6 +48,7 @@ use Media;
 use Module;
 use NewsletterProSubscription;
 use ObjectModel;
+use Manufacturer;
 use PrestaShop\Module\PrestashopCheckout\Order\PaymentStepCheckoutOrderBuilder;
 use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
 use PrestaShop\PrestaShop\Core\Product\ProductPresenter;


### PR DESCRIPTION
## Summary
- import the PrestaShop Manufacturer class so EverblockTools can instantiate it when fetching brand data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa2a430974832292f0f3d595799eb3