### PR TITLE
Fix undefined donation link notice in settings documentation

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1088,6 +1088,12 @@ class Everblock extends Module
             $docTemplates['prettyblock'] = 'prettyblock.tpl';
         }
 
+        if (null === $this->context->smarty->getTemplateVars('donation_link')) {
+            $this->context->smarty->assign([
+                'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            ]);
+        }
+
         foreach ($docTemplates as $tab => $template) {
             $docPath = $this->local_path . 'views/templates/admin/config/docs/' . $template;
 

--- a/views/templates/admin/config/docs/settings.tpl
+++ b/views/templates/admin/config/docs/settings.tpl
@@ -45,9 +45,11 @@
         <p>{l s='Ever Block is and will remain free. You can support ongoing development by using the donation button available below the form.' mod='everblock'}</p>
 
         <p class="mt-3">
-            <a href="{$donation_link|escape:'htmlall':'UTF-8'}" class="btn btn-warning" target="_blank">
-                <i class="icon-money"></i> {l s='Make a donation' mod='everblock'}
-            </a>
+            {if isset($donation_link) && $donation_link}
+                <a href="{$donation_link|escape:'htmlall':'UTF-8'}" class="btn btn-warning" target="_blank">
+                    <i class="icon-money"></i> {l s='Make a donation' mod='everblock'}
+                </a>
+            {/if}
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- ensure the donation link smarty variable is defined before rendering configuration documentation cards
- guard the donation button markup so it only renders when a link is available

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_68fb6ba3d6a08322bfdac35116b24eba