### PR TITLE
Fix undefined module_name warnings in admin controllers

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -57,11 +57,16 @@ class AdminEverBlockController extends ModuleAdminController
         $this->name = 'AdminEverBlockController';
         $this->position_identifier = 'id_everblock';
         $this->allow_export = true;
+        if (!Tools::getIsset('module_name')) {
+            $_GET['module_name'] = 'everblock';
+            $_REQUEST['module_name'] = 'everblock';
+        }
         $module_link  = 'index.php?controller=AdminModules&configure=everblock&token=';
         $module_link .= Tools::getAdminTokenLite('AdminModules');
         $m = Module::getInstanceByName('everblock');
         $this->context->smarty->assign([
             $m->name . '_version' => $m->version,
+            'module_name' => $m->displayName,
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -58,11 +58,16 @@ class AdminEverBlockFaqController extends ModuleAdminController
         $this->context = Context::getContext();
         $this->identifier = 'id_everblock_faq';
         $this->name = 'AdminEverFaq';
+        if (!Tools::getIsset('module_name')) {
+            $_GET['module_name'] = 'everblock';
+            $_REQUEST['module_name'] = 'everblock';
+        }
         $module_link  = 'index.php?controller=AdminModules&configure=everblock&token=';
         $module_link .= Tools::getAdminTokenLite('AdminModules');
         $m = Module::getInstanceByName('everblock');
         $this->context->smarty->assign([
             $m->name . '_version' => $m->version,
+            'module_name' => $m->displayName,
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -56,12 +56,17 @@ class AdminEverBlockHookController extends ModuleAdminController
         $this->context = Context::getContext();
         $this->identifier = 'id_hook';
         $this->name = 'AdminEverBlockHook';
+        if (!Tools::getIsset('module_name')) {
+            $_GET['module_name'] = 'everblock';
+            $_REQUEST['module_name'] = 'everblock';
+        }
         EverblockTools::checkAndFixDatabase();
         $module_link  = 'index.php?controller=AdminModules&configure=everblock&token=';
         $module_link .= Tools::getAdminTokenLite('AdminModules');
         $m = Module::getInstanceByName('everblock');
         $this->context->smarty->assign([
             $m->name . '_version' => $m->version,
+            'module_name' => $m->displayName,
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -58,11 +58,16 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
         $this->context = Context::getContext();
         $this->identifier = 'id_everblock_shortcode';
         $this->name = 'AdminEverBlockShortcode';
+        if (!Tools::getIsset('module_name')) {
+            $_GET['module_name'] = 'everblock';
+            $_REQUEST['module_name'] = 'everblock';
+        }
         $module_link  = 'index.php?controller=AdminModules&configure=everblock&token=';
         $module_link .= Tools::getAdminTokenLite('AdminModules');
         $m = Module::getInstanceByName('everblock');
         $this->context->smarty->assign([
             $m->name . '_version' => $m->version,
+            'module_name' => $m->displayName,
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',


### PR DESCRIPTION
## Summary
- default the module_name request parameter in every admin controller
- expose the module display name to Smarty templates so configure.tpl can render without notices

## Testing
- php -l controllers/admin/AdminEverBlockController.php
- php -l controllers/admin/AdminEverBlockHookController.php
- php -l controllers/admin/AdminEverBlockFaqController.php
- php -l controllers/admin/AdminEverBlockShortcodeController.php

------
https://chatgpt.com/codex/tasks/task_e_68fb6b82929c83229d6e6f4638ecff5f