### PR TITLE
Fix admin controllers missing stats assignment

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -70,6 +70,7 @@ class AdminEverBlockController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -71,6 +71,7 @@ class AdminEverBlockFaqController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -70,6 +70,7 @@ class AdminEverBlockHookController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
         $this->fields_list = [

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -71,6 +71,7 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
+            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 

--- a/everblock.php
+++ b/everblock.php
@@ -2199,6 +2199,11 @@ class Everblock extends Module
         return $stats;
     }
 
+    public function getAdminModuleStatistics(): array
+    {
+        return $this->getModuleStatistics();
+    }
+
     protected function countTableRecords(string $table, string $whereClause = ''): int
     {
         if (!$this->moduleTableExists($table)) {


### PR DESCRIPTION
## Summary
- expose module statistics through a new public accessor on the module
- assign module statistics to Smarty in each admin controller to avoid undefined key notices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb7d3f869083229c73978f3fc0fc68