### PR TITLE
Remove overflow constraint from form card styling

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -286,7 +286,6 @@
 
 .everblock-config__card--form {
     padding: 0;
-    overflow: hidden;
 }
 
 .everblock-config__card--form #module_form {


### PR DESCRIPTION
## Summary
- remove the `overflow: hidden` rule from the `.everblock-config__card--form` style to allow overflow content to display normally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb7ff2ccb083229717306dada6d92c