### PR TITLE
Limit product modal script to admin product page

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -2783,6 +2783,35 @@ class Everblock extends Module
     public function hookActionAdminControllerSetMedia()
     {
         $this->context->controller->addCss($this->_path . 'views/css/ever.css');
+
+        $isAdminProductPage = false;
+
+        if (isset($this->context->controller)) {
+            if (property_exists($this->context->controller, 'controller_name')
+                && $this->context->controller->controller_name === 'AdminProducts'
+            ) {
+                $isAdminProductPage = true;
+            }
+
+            if (!$isAdminProductPage
+                && method_exists($this->context->controller, 'getControllerName')
+                && $this->context->controller->getControllerName() === 'AdminProducts'
+            ) {
+                $isAdminProductPage = true;
+            }
+        }
+
+        if (!$isAdminProductPage) {
+            $controllerParam = Tools::getValue('controller');
+            if (!empty($controllerParam) && $controllerParam === 'AdminProducts') {
+                $isAdminProductPage = true;
+            }
+        }
+
+        if ($isAdminProductPage && method_exists($this->context->controller, 'addJs')) {
+            $this->context->controller->addJs($this->_path . 'views/js/product-modal.js');
+        }
+
         if (Tools::getValue('id_' . $this->name)
             || Tools::getIsset('add' . $this->name)
             || Tools::getValue('configure') == $this->name
@@ -3330,9 +3359,6 @@ class Everblock extends Module
     {
         if (empty($params['id_product'])) {
             return;
-        }
-        if (isset($this->context->controller) && method_exists($this->context->controller, 'addJs')) {
-            $this->context->controller->addJs($this->_path . 'views/js/product-modal.js');
         }
         $modal = EverblockModal::getByProductId(
             (int) $params['id_product'],


### PR DESCRIPTION
## Summary
- add guards around the product modal script to only enqueue it from admin product pages
- remove the redundant enqueue from the product modal hook itself to avoid double loading

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff3b47f9d08322b8e96f9a0c19e17d