### PR TITLE
Handle product modal file upload via AJAX

### DIFF
--- a/views/templates/admin/productModal.tpl
+++ b/views/templates/admin/productModal.tpl
@@ -15,7 +15,7 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
 *}
-<div class="panel">
+<div class="panel everblock-modal-panel" data-everblock-modal="1" data-ever-ajax-url="{$ever_ajax_url|escape:'htmlall':'UTF-8'}" data-ever-product-id="{$ever_product_id|intval}" data-ever-no-file-text="{l s='No file uploaded yet.' mod='everblock'|escape:'htmlall':'UTF-8'}" data-ever-error-text="{l s='An error occurred while updating the modal file.' mod='everblock'|escape:'htmlall':'UTF-8'}">
     <div class="panel-heading">
         {l s='Everblock modal content' mod='everblock'}
     </div>
@@ -30,20 +30,27 @@
         </div>
         <div class="form-group">
             <label for="everblock_modal_file">{l s='Modal file' mod='everblock'}</label>
-            {if $modal_file_url}
-                <p>
-                    <a href="{$modal_file_url|escape:'htmlall':'UTF-8'}" target="_blank">{$modal_file_name|escape:'htmlall':'UTF-8'}</a>
-                </p>
+            <div class="everblock-modal-file-wrapper">
+                {if $modal_file_url}
+                    <p class="everblock-modal-current-file">
+                        <a href="{$modal_file_url|escape:'htmlall':'UTF-8'}" target="_blank" class="everblock-modal-file-link">{$modal_file_name|escape:'htmlall':'UTF-8'}</a>
+                    </p>
+                {else}
+                    <p class="everblock-modal-current-file text-muted">{l s='No file uploaded yet.' mod='everblock'}</p>
+                {/if}
+            </div>
+            <div class="everblock-modal-delete-wrapper"{if !$modal_file_url} style="display:none;"{/if}>
                 <div class="checkbox">
                     <label>
                         <input type="checkbox" name="everblock_modal_file_delete" value="1" />
                         {l s='Delete file' mod='everblock'}
                     </label>
                 </div>
-            {/if}
+            </div>
             <input type="file" name="everblock_modal_file" id="everblock_modal_file" class="form-control" />
             <input type="hidden" name="everblock_modal_file_payload" id="everblock_modal_file_payload" value="" />
             <input type="hidden" name="everblock_modal_file_name" id="everblock_modal_file_name" value="" />
+            <div class="everblock-modal-feedback alert d-none" role="alert"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add an AJAX handler in `getContent` to process product modal file uploads and deletions immediately
- expose the module ajax endpoint to the product modal template and enhance its markup for live feedback
- replace the legacy base64 JavaScript uploader with an XMLHttpRequest-based implementation that updates the UI in real time

## Testing
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68ff44e014148322a964819722a4bc50