### PR TITLE
Improve admin product modal media handling

### DIFF
--- a/views/js/product-modal.js
+++ b/views/js/product-modal.js
@@ -41,6 +41,13 @@
     var feedback = container.querySelector('.everblock-modal-feedback');
     var fileWrapper = container.querySelector('.everblock-modal-file-wrapper');
     var deleteWrapper = container.querySelector('.everblock-modal-delete-wrapper');
+    var previewContainer = container.querySelector('.everblock-modal-preview-container');
+    var previewWrapper = container.querySelector('.everblock-modal-preview-wrapper');
+    var previewImage = container.querySelector('.everblock-modal-preview-image');
+    var previewEmpty = container.querySelector('.everblock-modal-preview-empty');
+    var previewEmptyText = container.getAttribute('data-ever-preview-empty-text')
+      || (previewContainer && previewContainer.getAttribute('data-ever-preview-empty-text'))
+      || '';
     var isProcessing = false;
 
     if (!fileInput) {
@@ -88,7 +95,19 @@
       }
     }
 
-    function updateFileDisplay(url, name) {
+    function buildPreviewUrl(url, timestamp) {
+      if (!url) {
+        return '';
+      }
+
+      var separator = url.indexOf('?') === -1 ? '?' : '&';
+      var safeTimestamp = typeof timestamp === 'number' && !isNaN(timestamp) ? timestamp : Date.now();
+
+      return url + separator + 't=' + safeTimestamp;
+    }
+
+    function updateFileDisplay(url, name, options) {
+      options = options || {};
       if (!fileWrapper) {
         return;
       }
@@ -108,11 +127,53 @@
         link.href = url;
         link.target = '_blank';
         link.className = 'everblock-modal-file-link';
-        link.textContent = name || url;
+        var linkLabel = name || url;
+        link.textContent = linkLabel;
         current.appendChild(link);
       } else {
         current.classList.add('text-muted');
         current.textContent = noFileText;
+      }
+
+      if (previewContainer) {
+        if (url) {
+          previewContainer.classList.remove('d-none');
+        } else {
+          previewContainer.classList.add('d-none');
+        }
+      }
+
+      var hasPreview = !!(url && options.isImage);
+      var previewUrl = options.previewUrl || buildPreviewUrl(url, options.timestamp);
+
+      if (previewWrapper) {
+        if (hasPreview) {
+          previewWrapper.classList.remove('d-none');
+          if (previewImage) {
+            previewImage.style.display = '';
+            previewImage.src = previewUrl || url;
+            previewImage.alt = name || '';
+          }
+        } else {
+          previewWrapper.classList.add('d-none');
+          if (previewImage) {
+            previewImage.removeAttribute('src');
+            previewImage.alt = '';
+          }
+        }
+      }
+
+      if (previewEmpty) {
+        if (!url) {
+          previewEmpty.classList.add('d-none');
+        } else if (hasPreview) {
+          previewEmpty.classList.add('d-none');
+        } else {
+          previewEmpty.classList.remove('d-none');
+          if (previewEmptyText) {
+            previewEmpty.textContent = previewEmptyText;
+          }
+        }
       }
     }
 
@@ -146,8 +207,17 @@
       showFeedback(success ? 'success' : 'error', message);
 
       if (success) {
-        var hasFile = data.file_url ? data.file_url.length > 0 : false;
-        updateFileDisplay(hasFile ? data.file_url : '', data.file_name || '');
+        var hasFile = data && data.file_url ? data.file_url.length > 0 : false;
+        var displayName = data && (data.file_display_name || data.file_name) ? (data.file_display_name || data.file_name) : '';
+        updateFileDisplay(
+          hasFile ? data.file_url : '',
+          displayName,
+          {
+            isImage: !!(data && data.is_image),
+            previewUrl: data && data.file_preview_url ? data.file_preview_url : '',
+            timestamp: data && typeof data.file_timestamp !== 'undefined' ? data.file_timestamp : null,
+          }
+        );
         toggleDeleteWrapper(hasFile);
         resetPayload();
       } else if (context === 'delete' && deleteCheckbox) {

--- a/views/templates/admin/productModal.tpl
+++ b/views/templates/admin/productModal.tpl
@@ -15,7 +15,7 @@
  *  @copyright 2019-2025 Team Ever
  *  @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
 *}
-<div class="panel everblock-modal-panel" data-everblock-modal="1" data-ever-ajax-url="{$ever_ajax_url|escape:'htmlall':'UTF-8'}" data-ever-product-id="{$ever_product_id|intval}" data-ever-no-file-text="{l s='No file uploaded yet.' mod='everblock'|escape:'htmlall':'UTF-8'}" data-ever-error-text="{l s='An error occurred while updating the modal file.' mod='everblock'|escape:'htmlall':'UTF-8'}">
+<div class="panel everblock-modal-panel" data-everblock-modal="1" data-ever-ajax-url="{$ever_ajax_url|escape:'htmlall':'UTF-8'}" data-ever-product-id="{$ever_product_id|intval}" data-ever-no-file-text="{l s='No file uploaded yet.' mod='everblock'|escape:'htmlall':'UTF-8'}" data-ever-error-text="{l s='An error occurred while updating the modal file.' mod='everblock'|escape:'htmlall':'UTF-8'}" data-ever-preview-empty-text="{l s='Preview not available for this file.' mod='everblock'|escape:'htmlall':'UTF-8'}">
     <div class="panel-heading">
         {l s='Everblock modal content' mod='everblock'}
     </div>
@@ -46,6 +46,15 @@
                         {l s='Delete file' mod='everblock'}
                     </label>
                 </div>
+            </div>
+            <div class="everblock-modal-preview-container mt-3{if !$modal_file_url} d-none{/if}" data-ever-preview-empty-text="{l s='Preview not available for this file.' mod='everblock'|escape:'htmlall':'UTF-8'}">
+                <label class="form-label d-block">{l s='Preview' mod='everblock'}</label>
+                <div class="everblock-modal-preview-wrapper{if !$modal_file_url || !$modal_file_is_image} d-none{/if}">
+                    <img class="everblock-modal-preview-image img-thumbnail" alt="{$modal_file_name|escape:'htmlall':'UTF-8'}"{if $modal_file_url && $modal_file_is_image} src="{$modal_file_preview_url|escape:'htmlall':'UTF-8'}" loading="lazy"{/if} />
+                </div>
+                <p class="everblock-modal-preview-empty text-muted{if $modal_file_url && $modal_file_is_image} d-none{/if}">
+                    {l s='Preview not available for this file.' mod='everblock'}
+                </p>
             </div>
             <input type="file" name="everblock_modal_file" id="everblock_modal_file" class="form-control" />
             <input type="hidden" name="everblock_modal_file_payload" id="everblock_modal_file_payload" value="" />


### PR DESCRIPTION
## Summary
- preserve uploaded modal filenames by saving them in product-specific directories and returning preview metadata
- expose preview data in the admin product modal tab with timestamped URLs for cache busting
- update the product modal uploader JavaScript to refresh links and previews after uploads or deletions

## Testing
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_68ff623cdd648322b2c3feb462bd1b8a