### PR TITLE
Fix checkout step compatibility with newer PrestaShop namespaces

### DIFF
--- a/src/Checkout/EverblockCheckoutStep.php
+++ b/src/Checkout/EverblockCheckoutStep.php
@@ -20,6 +20,20 @@
 
 namespace Everblock\Tools\Checkout;
 
+if (!class_exists(\PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class)) {
+    if (class_exists(\PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class)) {
+        class_alias(
+            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class,
+            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class
+        );
+    } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class)) {
+        class_alias(
+            \PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class,
+            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class
+        );
+    }
+}
+
 use Context;
 use Configuration;
 use Everblock;


### PR DESCRIPTION
## Summary
- add runtime aliases to resolve AbstractCheckoutStep across renamed PrestaShop namespaces

## Testing
- php -l src/Checkout/EverblockCheckoutStep.php

------
https://chatgpt.com/codex/tasks/task_e_6900a2e3332083229ba72f9c05bffde9