### PR TITLE
Improve checkout step class aliasing

### DIFF
--- a/src/Checkout/EverblockCheckoutStep.php
+++ b/src/Checkout/EverblockCheckoutStep.php
@@ -20,6 +20,20 @@
 
 namespace Everblock\Tools\Checkout;
 
+if (!class_exists(\PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class)) {
+    if (class_exists(\PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class)) {
+        class_alias(
+            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class,
+            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class
+        );
+    } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class)) {
+        class_alias(
+            \PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class,
+            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class
+        );
+    }
+}
+
 if (!class_exists(\PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class)) {
     if (class_exists(\PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class)) {
         class_alias(


### PR DESCRIPTION
## Summary
- add compatibility shims to expose `AbstractCheckoutStep` under both legacy and PS9 namespaces
- keep support for adapter-based checkout step fallback

## Testing
- php -l src/Checkout/EverblockCheckoutStep.php

------
https://chatgpt.com/codex/tasks/task_e_6900a451fab4832287e0bf1657f42637