### PR TITLE
Fix checkout step base class reference

### DIFF
--- a/src/Checkout/EverblockCheckoutStep.php
+++ b/src/Checkout/EverblockCheckoutStep.php
@@ -20,46 +20,17 @@
 
 namespace Everblock\Tools\Checkout;
 
-if (!class_exists(\PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class)) {
-    if (class_exists(\PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class)) {
-        class_alias(
-            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class,
-            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class
-        );
-    } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class)) {
-        class_alias(
-            \PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class,
-            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class
-        );
-    }
-}
-
-if (!class_exists(\PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class)) {
-    if (class_exists(\PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class)) {
-        class_alias(
-            \PrestaShop\PrestaShop\Core\Checkout\Step\AbstractCheckoutStep::class,
-            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class
-        );
-    } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class)) {
-        class_alias(
-            \PrestaShop\PrestaShop\Adapter\Checkout\CheckoutProcess\AbstractCheckoutStep::class,
-            \PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep::class
-        );
-    }
-}
-
 use Context;
 use Configuration;
 use Everblock;
 use Hook;
-use PrestaShop\PrestaShop\Core\Checkout\AbstractCheckoutStep;
 use Symfony\Component\Translation\TranslatorInterface;
 
 if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-class EverblockCheckoutStep extends AbstractCheckoutStep
+class EverblockCheckoutStep extends \AbstractCheckoutStep
 {
     protected $module;
     protected $everdata;
@@ -103,7 +74,7 @@ class EverblockCheckoutStep extends AbstractCheckoutStep
      * Restoration des données persistées
      *
      * @param array $data
-     * @return $this|AbstractCheckoutStep
+     * @return $this|\AbstractCheckoutStep
      */
     public function restorePersistedData(array $data)
     {


### PR DESCRIPTION
## Summary
- remove legacy class aliasing for checkout step compatibility
- extend the checkout step from the legacy global AbstractCheckoutStep class directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900a7655ff483228a95e2212048f8a7