### PR TITLE
Fix admin configuration tab redirect

### DIFF
--- a/controllers/admin/AdminEverBlockConfigurationController.php
+++ b/controllers/admin/AdminEverBlockConfigurationController.php
@@ -38,13 +38,20 @@ class AdminEverBlockConfigurationController extends ModuleAdminController
     protected function redirectToConfiguration()
     {
         $moduleName = $this->module instanceof Module ? $this->module->name : 'everblock';
+        $params = [
+            'configure' => $moduleName,
+            'module_name' => $moduleName,
+        ];
+
+        if ($this->module instanceof Module && property_exists($this->module, 'tab') && $this->module->tab) {
+            $params['tab_module'] = $this->module->tab;
+        }
+
         $url = $this->context->link->getAdminLink(
             'AdminModules',
             true,
             [],
-            [
-                'configure' => $moduleName,
-            ]
+            $params
         );
 
         Tools::redirectAdmin($url);


### PR DESCRIPTION
## Summary
- ensure the admin configuration tab redirects to the module configuration page
- include the module name (and tab when available) when building the redirect URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900be6b67608322bcdedcfdacdc7684