### PR TITLE
Use Bootstrap classes for Prettyblock product highlight button

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -58,8 +58,7 @@
           {$block.settings.custom_text nofilter}
         </p>
 
-        <a href="{$product.url}" class="btn fw-bold rounded-pill px-4 py-2"
-           style="background-color: #C6F219; color: #000; border: none;">
+        <a href="{$product.url}" class="btn btn-warning text-dark border-0 fw-bold rounded-pill px-4 py-2">
           {l s='See the product' mod='everblock'}
         </a>
       </div>


### PR DESCRIPTION
## Summary
- replace the inline styles on the Prettyblock product highlight button with standard Bootstrap utility classes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901dab899cc83229ebddaef3affb957