### PR TITLE
Guard testimonial fields against missing data

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial.tpl
@@ -35,7 +35,7 @@
         <div class="container">
             <div class="text-center row">
                 <div class="col-md-12">
-                    <span class="mb-2 h2">{$block.settings.name}</span>
+                    <span class="mb-2 h2">{$block.settings.name|default:''}</span>
                 </div>
             </div>
             <div class="row">
@@ -43,11 +43,11 @@
                 <div class="col-md-4">
                     <div class="testimonial">
                         <div class="testimonial-author text-center">
-                            <p class="author-name">{$state.name}</p>
+                            <p class="author-name">{$state.name|default:''}</p>
                             <picture>
-                              <source srcset="{$state.image.url}" type="image/webp">
-                              <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                              <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="rounded-circle img img-fluid lazyload" loading="lazy" width="60">
+                              <source srcset="{$state.image.url|default:''}" type="image/webp">
+                              <source srcset="{$state.image.url|default:''|replace:'.webp':'.jpg'}" type="image/jpeg">
+                              <img src="{$state.image.url|default:''|replace:'.webp':'.jpg'}" alt="{$state.name|default:''}" title="{$state.name|default:''}" class="rounded-circle img img-fluid lazyload" loading="lazy" width="60">
                             </picture>
                         </div>
                         <div class="testimonial-content text-center">


### PR DESCRIPTION
## Summary
- default testimonial heading to an empty string when the name setting is absent
- guard testimonial state fields when author metadata or image URLs are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901de70322883229c8b87094802f053