### PR TITLE
Allow configuring lookbook marker colors

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3163,6 +3163,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Enable zoom animation'),
                             'default' => 0,
                         ],
+                        'marker_color' => [
+                            'type' => 'color',
+                            'label' => $module->l('Marker color'),
+                            'default' => '#f25b76',
+                        ],
                     ], $module),
                 ],
             ];

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -24,7 +24,10 @@
     cursor: pointer;
 }
 /* Lookbook product markers */
+
 .lookbook-marker {
+    --lookbook-marker-color: #f25b76;
+    --lookbook-marker-color-rgb: 242, 91, 118;
     position: relative;
     width: 2.75rem;
     height: 2.75rem;
@@ -34,10 +37,10 @@
     align-items: center;
     justify-content: center;
     background-color: #fff;
-    border: 3px solid #f25b76;
-    box-shadow: 0 12px 24px rgba(242, 91, 118, 0.25);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-    color: #f25b76;
+    border: 3px solid var(--lookbook-marker-color);
+    box-shadow: 0 12px 24px rgba(var(--lookbook-marker-color-rgb), 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    color: var(--lookbook-marker-color);
     overflow: visible;
     z-index: 1;
 }
@@ -46,14 +49,14 @@
 .lookbook-marker:hover,
 .lookbook-marker:active {
     transform: scale(1.05);
-    box-shadow: 0 16px 32px rgba(242, 91, 118, 0.35);
-    background-color: #f25b76;
-    border-color: #f25b76;
+    box-shadow: 0 16px 32px rgba(var(--lookbook-marker-color-rgb), 0.35);
+    background-color: var(--lookbook-marker-color);
+    border-color: var(--lookbook-marker-color);
     color: #fff;
 }
 
 .lookbook-marker:focus-visible {
-    outline: 3px solid rgba(242, 91, 118, 0.35);
+    outline: 3px solid rgba(var(--lookbook-marker-color-rgb), 0.35);
     outline-offset: 2px;
 }
 
@@ -72,7 +75,7 @@
     border-radius: 50%;
     transform: translate(-50%, -50%) scale(1);
     opacity: 0.55;
-    background: rgba(242, 91, 118, 0.22);
+    background: rgba(var(--lookbook-marker-color-rgb), 0.22);
     pointer-events: none;
     z-index: -1;
 }
@@ -90,12 +93,12 @@
     0%,
     100% {
         transform: scale(1);
-        box-shadow: 0 12px 24px rgba(242, 91, 118, 0.25);
+        box-shadow: 0 12px 24px rgba(var(--lookbook-marker-color-rgb), 0.25);
     }
 
     45% {
         transform: scale(1.16);
-        box-shadow: 0 22px 44px rgba(242, 91, 118, 0.45);
+        box-shadow: 0 22px 44px rgba(var(--lookbook-marker-color-rgb), 0.45);
     }
 }
 

--- a/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_lookbook.tpl
@@ -52,7 +52,28 @@
           {if isset($block.states) && $block.states}
             {foreach from=$block.states item=state}
               {if isset($state.product.id) && $state.product.id}
-                <button type="button" class="lookbook-marker position-absolute{if $state.animation_enabled|default:false} lookbook-marker--animated{/if}" style="top:{$state.top|default:'0%'|escape:'htmlall'};left:{$state.left|default:'0%'|escape:'htmlall'};transform:translate(-50%,-50%);" data-product-id="{$state.product.id}">
+                {assign var='marker_color' value=$state.marker_color|default:''}
+                {assign var='marker_color_clean' value=$marker_color|replace:'#':''}
+                {assign var='marker_color_rgb' value=''}
+                {if $marker_color_clean && $marker_color_clean|strlen == 6}
+                  {assign var='marker_color_r' value=$marker_color_clean|substr:0:2|@hexdec}
+                  {assign var='marker_color_g' value=$marker_color_clean|substr:2:2|@hexdec}
+                  {assign var='marker_color_b' value=$marker_color_clean|substr:4:2|@hexdec}
+                  {assign var='marker_color_rgb' value="`$marker_color_r`, `$marker_color_g`, `$marker_color_b`"}
+                {/if}
+                {capture name='lookbook_marker_style'}
+                  top:{$state.top|default:'0%'|escape:'htmlall'};
+                  left:{$state.left|default:'0%'|escape:'htmlall'};
+                  transform:translate(-50%,-50%);
+                  {if $marker_color}
+                    --lookbook-marker-color:{$marker_color|escape:'htmlall':'UTF-8'};
+                  {/if}
+                  {if $marker_color_rgb}
+                    --lookbook-marker-color-rgb:{$marker_color_rgb|escape:'htmlall':'UTF-8'};
+                  {/if}
+                {/capture}
+                {assign var='lookbook_marker_style' value=$smarty.capture.lookbook_marker_style|replace:"\n":''|replace:"  ":' '|trim}
+                <button type="button" class="lookbook-marker position-absolute{if $state.animation_enabled|default:false} lookbook-marker--animated{/if}" style="{$lookbook_marker_style}" data-product-id="{$state.product.id}">
                   <span class="visually-hidden">{l s='View product' mod='everblock'}</span>
                 </button>
               {/if}


### PR DESCRIPTION
## Summary
- add a color picker to each Lookbook repeater item so markers can use custom accents
- pass the selected marker color to the front template and expose it through CSS variables
- update Lookbook marker styling to rely on the customizable variables while keeping sensible fallbacks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901e082f84083228bf81bf5ad412436