### PR TITLE
Handle array-based features in Prettyblock pricing table

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
@@ -30,9 +30,18 @@
           {if $state.price}<div class="pricing-price">{$state.price|escape:'htmlall'}</div>{/if}
           {if $state.features}
             <ul class="pricing-features">
-              {foreach from=$state.features|preg_split:"/\\r\\n|\\r|\\n/" item=feature}
-                {if $feature}<li>{$feature|escape:'htmlall'}</li>{/if}
-              {/foreach}
+              {if $state.features|is_array}
+                {foreach from=$state.features item=feature}
+                  {if $feature|is_array}
+                    {assign var='feature_text' value=$feature.text|default:$feature.value|default:''}
+                    {if $feature_text}<li>{$feature_text|escape:'htmlall'}</li>{/if}
+                  {elseif $feature}<li>{$feature|escape:'htmlall'}</li>{/if}
+                {/foreach}
+              {else}
+                {foreach from=$state.features|preg_split:"/\\r\\n|\\r|\\n/" item=feature}
+                  {if $feature}<li>{$feature|escape:'htmlall'}</li>{/if}
+                {/foreach}
+              {/if}
             </ul>
           {/if}
           {if $state.cta_url && $state.cta_label}


### PR DESCRIPTION
## Summary
- update the Prettyblock pricing table template so features entered through the repeater render whether stored as strings or arrays

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901ef5d64a483229c23c0c589006162