### PR TITLE
Add configurable columns to reassurance block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -537,6 +537,18 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Display reassurances side by side'),
                             'default' => false,
                         ],
+                        'columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Number of columns per row'),
+                            'choices' => [
+                                '1' => $module->l('1 column'),
+                                '2' => $module->l('2 columns'),
+                                '3' => $module->l('3 columns'),
+                                '4' => $module->l('4 columns'),
+                                '6' => $module->l('6 columns'),
+                            ],
+                            'default' => '3',
+                        ],
                     ],
                 ],
                 'repeater' => [

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -24,8 +24,17 @@
     <div class="row">
   {/if}
 
-  {if isset($block.states) && $block.states}
-    {foreach from=$block.states item=state key=key}
+{assign var='reassuranceColumns' value=$block.settings.default.columns|default:0|intval}
+{assign var='reassuranceColumnClass' value=''}
+{if $reassuranceColumns > 0}
+  {math assign="reassuranceColumnWidth" equation="12 / x" x=$reassuranceColumns format="%.0f"}
+  {assign var='reassuranceColumnClass' value="col-12 col-md-"|cat:$reassuranceColumnWidth|cat:' '}
+{elseif $block.settings.default.display_inline}
+  {assign var='reassuranceColumnClass' value='col '}
+{/if}
+
+{if isset($block.states) && $block.states}
+  {foreach from=$block.states item=state key=key}
       {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
       {* Génère l'URL de l'icône depuis le nom brut *}
       {assign var="icon_url" value=false}
@@ -41,7 +50,7 @@
         {/if}
       {/if}
 
-      <div id="block-{$block.id_prettyblocks}-{$key}" class="{if $block.settings.default.display_inline}col {/if}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}
+      <div id="block-{$block.id_prettyblocks}-{$key}" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}
         {if $state.background_color}background-color:{$state.background_color};{/if}
         {if $state.text_color}color:{$state.text_color};{/if}
       ">


### PR DESCRIPTION
## Summary
- add a column count selector to the Prettyblock Reassurance block settings
- apply responsive column classes in the reassurance template using the selected value or the legacy inline option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901efc580b48322bdd1a5558ef76002