### PR TITLE
Enable infinite looping for selected products slider

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -237,6 +237,48 @@ $(document).ready(function(){
             $carousel.addClass('prettyblocks-carousel-initialised');
         });
     }
+    $('[data-ever-infinite-carousel="1"]').each(function(){
+        var $carousel = $(this);
+        var $inner = $carousel.find('.carousel-inner');
+        if (!$inner.length || $inner.children('.carousel-item').length <= 1) {
+            return;
+        }
+        var refreshInstanceItems = function() {
+            if (typeof bootstrap !== 'undefined' && typeof bootstrap.Carousel !== 'undefined') {
+                var instance = bootstrap.Carousel.getInstance($carousel[0]);
+                if (instance) {
+                    instance._items = [].slice.call($inner.children('.carousel-item'));
+                    instance._activeElement = $inner.children('.carousel-item.active')[0] || null;
+                }
+            } else if (typeof $carousel.data === 'function') {
+                var legacyInstance = $carousel.data('bs.carousel') || $carousel.data('carousel');
+                if (legacyInstance) {
+                    legacyInstance._items = [].slice.call($inner.children('.carousel-item'));
+                    legacyInstance._activeElement = $inner.children('.carousel-item.active')[0] || null;
+                }
+            }
+        };
+        $carousel.on('slide.bs.carousel', function(event){
+            $carousel.data('everInfiniteDirection', event.direction);
+        });
+        $carousel.on('slid.bs.carousel', function(){
+            var direction = $carousel.data('everInfiniteDirection');
+            if (!direction) {
+                return;
+            }
+            var $items = $inner.children('.carousel-item');
+            if (direction === 'left') {
+                $inner.append($items.first());
+            } else if (direction === 'right') {
+                $inner.prepend($items.last());
+            }
+            $items = $inner.children('.carousel-item');
+            $items.removeClass('active');
+            $items.first().addClass('active');
+            refreshInstanceItems();
+            $carousel.removeData('everInfiniteDirection');
+        });
+    });
     $('.ever_instagram img').on('click', function() {
         // Mettre à jour le src de l'image dans la modal
         var imageSrc = $(this).attr('src');

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -25,9 +25,9 @@
   <section class="ever-featured-products featured-products clearfix mx-5 d-none d-md-block{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
     {if isset($carousel) && $carousel}
       {assign var="carouselId" value="ever-presented-carousel-"|cat:mt_rand(1000,999999)}
-      <div id="{$carouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+      {assign var="numProductsPerSlide" value=4}
+      <div id="{$carouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-infinite-carousel="1">
         <div class="carousel-inner products">
-          {assign var="numProductsPerSlide" value=4}
           {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
           {foreach from=$everPresentProducts item=product name=products}
             {if $product@index % $numProductsPerSlide == 0}


### PR DESCRIPTION
## Summary
- flag the selected products carousel markup when the slider is enabled so it can opt into infinite scrolling
- rotate carousel items after each transition and refresh the Bootstrap instance to create a seamless infinite loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69020e82e4e08322b1b95ece7590d04f