### PR TITLE
Fix inconsistent product sizing in category tab block

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -3163,7 +3163,37 @@ $(document).ready(function(){
         requestStatus();
     });
 
+    initPrettyblockCategoryTabs();
     initPrettyblockToc();
+
+    function initPrettyblockCategoryTabs() {
+        var $blocks = $('.prettyblock-category-tabs');
+        if (!$blocks.length) {
+            return;
+        }
+
+        function refreshProducts($context) {
+            if (typeof prestashop !== 'undefined' && typeof prestashop.emit === 'function') {
+                prestashop.emit('updateProductList', {
+                    html: $context.find('.tab-pane.active')
+                });
+            }
+
+            setTimeout(function () {
+                $(window).trigger('resize');
+            }, 0);
+        }
+
+        $blocks.each(function () {
+            var $block = $(this);
+
+            $block.find('[data-bs-toggle="tab"], [data-toggle="tab"]').on('shown.bs.tab', function () {
+                refreshProducts($block);
+            });
+
+            refreshProducts($block);
+        });
+    }
 
     function initPrettyblockToc() {
         $('.pb-toc-summary').each(function(index){

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -18,7 +18,7 @@
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
+<div id="block-{$block.id_prettyblocks}" class="prettyblock-category-tabs{if $block.settings.default.force_full_width} container-fluid px-0 mx-0{elseif $block.settings.default.container} container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -33,8 +33,9 @@
         <div class="tab-container">
             <ul class="nav nav-tabs justify-content-center" role="tablist">
                 {foreach from=$block.states item=state key=key name=categorytabs}
+                    {assign var='tabId' value="tab-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key}
                     <li class="nav-item">
-                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" data-toggle="tab" data-bs-toggle="tab" href="#tab-{$block.id_prettyblocks}-{$key}" role="tab" aria-controls="tab-{$block.id_prettyblocks}-{$key}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}">
+                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" id="{$tabId}-tab" data-toggle="tab" data-bs-toggle="tab" data-bs-target="#{$tabId}" href="#{$tabId}" role="tab" aria-controls="{$tabId}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}">
                             {$state.name}
                         </a>
                     </li>
@@ -42,7 +43,9 @@
             </ul>
             <div class="tab-content">
                 {foreach from=$block.states item=state key=key name=categorytabs}
-                    <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}" id="tab-{$block.id_prettyblocks}-{$key}" role="tabpanel" aria-labelledby="tab-{$block.id_prettyblocks}-{$key}-tab">
+                    {assign var='tabId' value="tab-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key}
+                    {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+                    <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" id="{$tabId}" role="tabpanel" aria-labelledby="{$tabId}-tab" style="{$prettyblock_state_spacing_style}{if isset($state.background_color) && $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if isset($state.text_color) && $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
                         {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                         <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
                             <div class="products row">


### PR DESCRIPTION
## Summary
- ensure each category tab pane exposes consistent IDs, spacing and styling helpers
- add front-office script that refreshes product list rendering whenever a tab is shown so thumbnails keep a consistent size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902268b0258832299c62ba2d5e317e3