### PR TITLE
Fix flash deals hook data key

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5223,7 +5223,11 @@ class Everblock extends Module
             return false;
         }
 
-        return ['products' => $presentedProducts];
+        if (count($presentedProducts) > $limit) {
+            $presentedProducts = array_slice($presentedProducts, 0, $limit);
+        }
+
+        return ['deals' => $presentedProducts];
     }
 
     public function hookBeforeRenderingEverblockGuidedSelector($params)


### PR DESCRIPTION
## Summary
- align the flash deals hook output with the template by returning a `deals` key
- trim the presented products to the configured limit before rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690232a430f083228fb0a1a6b1d4953b