### PR TITLE
Add central log service and expose logs in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The module uses its own cache system in addition to the PrestaShop one.
 
 The cache directory is located in /var/cache/dev?prod/everblock/
 
-The logs directory is located in /var/logs/
+The logs directory is located in /var/logs/everblock
 Log files are created only when there is content to log.
 
 Clearing the native PrestaShop cache will also clear the module cache, but the module will clear its own cache on a block expiry automatically.
@@ -604,7 +604,7 @@ Le module utilise son propre système de cache en plus de celui de PrestaShop.
 
 Le dossier du cache se situe dans /var/cache/dev?prod/everblock/
 
-Le dossier des logs se situe dans /var/logs/
+Le dossier des logs se situe dans /var/logs/everblock
 Les fichiers de log ne sont créés que s'il y a un message à enregistrer.
 
 Vider le cache natif de PrestaShop videra également le cache du module, mais ce dernier vide automatiquement son cache lorsqu'un bloc expire.
@@ -830,7 +830,7 @@ El módulo utiliza su propio sistema de caché además del de PrestaShop.
 
 El directorio de caché está en /var/cache/dev?prod/everblock/
 
-El directorio de logs está en /var/logs/
+El directorio de logs está en /var/logs/everblock
 Los archivos de registro solo se crean si contienen información.
 
 Borrar la caché nativa de PrestaShop también limpiará la del módulo, pero este limpia automáticamente su caché cuando expira un bloque.
@@ -1056,7 +1056,7 @@ Il modulo utilizza un proprio sistema di cache oltre a quello di PrestaShop.
 
 La cartella cache si trova in /var/cache/dev?prod/everblock/
 
-La cartella log si trova in /var/logs/
+La cartella log si trova in /var/logs/everblock
 I file di log vengono creati solo se contengono dei messaggi.
 
 Cancellare la cache nativa di PrestaShop cancellerà anche quella del modulo, ma quest'ultimo la pulisce automaticamente alla scadenza di un blocco.

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -18,6 +18,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 use Everblock\Tools\Service\EverblockCache;
+use Everblock\Tools\Service\LogService;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -5071,32 +5072,28 @@ class EverblockTools extends ObjectModel
 
     public static function setLog(string $logKey, string $logValue)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
+        $logService = new LogService();
         $logValue = trim($logValue);
+
         if ($logValue === '') {
-            if (file_exists($logFilePath)) {
-                unlink($logFilePath);
-            }
+            $logService->deleteLog($logKey . '.log');
             return;
         }
-        file_put_contents($logFilePath, $logValue);
+
+        $logService->writeLog($logKey . '.log', $logValue);
     }
 
     public static function getLog(string $logKey)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
-        if (file_exists($logFilePath)) {
-            return Tools::file_get_contents($logFilePath);
-        }
-        return '';
+        $logService = new LogService();
+
+        return $logService->readLog($logKey . '.log');
     }
 
     public static function dropLog(string $logKey)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
-        if (file_exists($logFilePath)) {
-            unlink($logFilePath);
-        }
+        $logService = new LogService();
+        $logService->deleteLog($logKey . '.log');
     }
 
     public static function purgeNativePrestashopLogsTable()

--- a/src/Command/ImportFileCommand.php
+++ b/src/Command/ImportFileCommand.php
@@ -25,6 +25,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Everblock\Tools\Service\ImportFile;
+use Everblock\Tools\Service\LogService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,11 +41,16 @@ class ImportFileCommand extends Command
     public const FAILURE = 1;
     public const INVALID = 2;
     public const ABORTED = 3;
-    
+
     protected $filename;
+    /** @var LogService */
+    private $logService;
+
+    private const LOG_PREFIX = 'log-everblock-import';
 
     public function __construct(KernelInterface $kernel)
     {
+        $this->logService = new LogService();
         parent::__construct();
     }
 
@@ -53,7 +59,7 @@ class ImportFileCommand extends Command
         $this->setName('everblock:tools:import');
         $this->setDescription('Import HTML blocks from xlsx file');
         $this->filename = _PS_MODULE_DIR_ . 'everblock/input/everblock.xlsx';
-        $this->logFile = _PS_ROOT_DIR_ . '/var/logs/log-everblock-import-' . date('Y-m-d') . '.log';
+        $this->logFile = $this->logService->getDailyLogPath(self::LOG_PREFIX);
         $help = sprintf(
             'File must be set on ' . _PS_MODULE_DIR_ . 'everblock/input/everblock.xlsx'
         );
@@ -439,11 +445,6 @@ class ImportFileCommand extends Command
         . '-------------------------'
         . PHP_EOL;
 
-        //Save string to log, use FILE_APPEND to append.
-        file_put_contents(
-            $this->logFile,
-            $log,
-            FILE_APPEND
-        );
+        $this->logService->appendToDailyLog(self::LOG_PREFIX, $log);
     }
 }

--- a/src/Command/ImportTabCommand.php
+++ b/src/Command/ImportTabCommand.php
@@ -25,6 +25,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use Everblock\Tools\Service\ImportFile;
+use Everblock\Tools\Service\LogService;
 use Language;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -39,11 +40,17 @@ class ImportTabCommand extends Command
     public const FAILURE = 1;
     public const INVALID = 2;
     public const ABORTED = 3;
-    
+
     protected $filename;
+
+    /** @var LogService */
+    private $logService;
+
+    private const LOG_PREFIX = 'log-everblock_tabs-import';
 
     public function __construct(KernelInterface $kernel)
     {
+        $this->logService = new LogService();
         parent::__construct();
     }
 
@@ -52,7 +59,7 @@ class ImportTabCommand extends Command
         $this->setName('everblock:tools:import_tab');
         $this->setDescription('Update product tabs usinx xlsx');
         $this->filename = _PS_MODULE_DIR_ . 'everblock/input/everblock_tabs.xlsx';
-        $this->logFile = _PS_ROOT_DIR_ . '/var/logs/log-everblock_tabs-import-' . date('Y-m-d') . '.log';
+        $this->logFile = $this->logService->getDailyLogPath(self::LOG_PREFIX);
         $help = sprintf(
             'File must be set on ' . _PS_MODULE_DIR_ . 'everblock/input/everblock_tabs.xlsx'
         );
@@ -160,11 +167,6 @@ class ImportTabCommand extends Command
                 date('j.n.Y') . PHP_EOL .
                 '-------------------------' . PHP_EOL;
 
-        //Save string to log, use FILE_APPEND to append.
-        file_put_contents(
-            $this->logFile,
-            $log,
-            FILE_APPEND
-        );
+        $this->logService->appendToDailyLog(self::LOG_PREFIX, $log);
     }
 }

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -5145,32 +5145,28 @@ class EverblockTools extends ObjectModel
 
     public static function setLog(string $logKey, string $logValue)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
+        $logService = new LogService();
         $logValue = trim($logValue);
+
         if ($logValue === '') {
-            if (file_exists($logFilePath)) {
-                unlink($logFilePath);
-            }
+            $logService->deleteLog($logKey . '.log');
             return;
         }
-        file_put_contents($logFilePath, $logValue);
+
+        $logService->writeLog($logKey . '.log', $logValue);
     }
 
     public static function getLog(string $logKey)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
-        if (file_exists($logFilePath)) {
-            return Tools::file_get_contents($logFilePath);
-        }
-        return '';
+        $logService = new LogService();
+
+        return $logService->readLog($logKey . '.log');
     }
 
     public static function dropLog(string $logKey)
     {
-        $logFilePath = _PS_ROOT_DIR_ . '/var/logs/' . $logKey . '.log';
-        if (file_exists($logFilePath)) {
-            unlink($logFilePath);
-        }
+        $logService = new LogService();
+        $logService->deleteLog($logKey . '.log');
     }
 
     public static function purgeNativePrestashopLogsTable()

--- a/src/Service/LogService.php
+++ b/src/Service/LogService.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use DateTimeImmutable;
+use FilesystemIterator;
+use RuntimeException;
+use Tools;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class LogService
+{
+    private const LOG_DIRECTORY = '/var/logs/everblock';
+    private const MAX_LOG_AGE_DAYS = 7;
+
+    public function getLogDirectory(): string
+    {
+        $this->ensureDirectory();
+
+        return self::LOG_DIRECTORY;
+    }
+
+    public function getDailyLogPath(string $prefix): string
+    {
+        $normalized = trim($prefix);
+        if ($normalized === '') {
+            throw new RuntimeException('Log prefix cannot be empty.');
+        }
+
+        $filename = sprintf('%s-%s.log', $normalized, date('Y-m-d'));
+
+        return $this->getLogPath($filename);
+    }
+
+    public function appendToDailyLog(string $prefix, string $content): void
+    {
+        $path = $this->getDailyLogPath($prefix);
+        file_put_contents($path, $content, FILE_APPEND);
+    }
+
+    public function writeLog(string $filename, string $content): void
+    {
+        $path = $this->getLogPath($filename);
+        file_put_contents($path, $content);
+    }
+
+    public function readLog(string $filename): string
+    {
+        $path = $this->getLogPath($filename);
+        if (!is_file($path)) {
+            return '';
+        }
+
+        $contents = @file_get_contents($path);
+
+        return $contents !== false ? (string) $contents : '';
+    }
+
+    public function deleteLog(string $filename): void
+    {
+        $path = $this->getLogPath($filename);
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+
+    public function listLogs(): array
+    {
+        $this->purgeOldLogs();
+
+        if (!is_dir(self::LOG_DIRECTORY)) {
+            return [];
+        }
+
+        $logs = [];
+
+        try {
+            $iterator = new FilesystemIterator(self::LOG_DIRECTORY, FilesystemIterator::SKIP_DOTS);
+        } catch (RuntimeException $e) {
+            return [];
+        }
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $extension = Tools::strtolower((string) $file->getExtension());
+            if ($extension !== 'log') {
+                continue;
+            }
+
+            $content = @file_get_contents($file->getPathname());
+
+            $logs[] = [
+                'filename' => $file->getFilename(),
+                'path' => $file->getPathname(),
+                'modified_at' => $file->getMTime(),
+                'size' => $file->getSize(),
+                'content' => $content !== false ? (string) $content : '',
+            ];
+        }
+
+        usort($logs, static function (array $a, array $b) {
+            return $b['modified_at'] <=> $a['modified_at'];
+        });
+
+        return $logs;
+    }
+
+    public function purgeOldLogs(): void
+    {
+        $this->ensureDirectory();
+
+        if (!is_dir(self::LOG_DIRECTORY)) {
+            return;
+        }
+
+        $threshold = (new DateTimeImmutable('-' . self::MAX_LOG_AGE_DAYS . ' days'))->getTimestamp();
+
+        try {
+            $iterator = new FilesystemIterator(self::LOG_DIRECTORY, FilesystemIterator::SKIP_DOTS);
+        } catch (RuntimeException $e) {
+            return;
+        }
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $extension = Tools::strtolower((string) $file->getExtension());
+            if ($extension !== 'log') {
+                continue;
+            }
+
+            if ($file->getMTime() < $threshold) {
+                @unlink($file->getPathname());
+            }
+        }
+    }
+
+    public function getLogPath(string $filename): string
+    {
+        $this->ensureDirectory();
+        $this->purgeOldLogs();
+
+        $sanitized = trim($filename);
+        if ($sanitized === '') {
+            throw new RuntimeException('Log filename cannot be empty.');
+        }
+
+        $sanitized = basename($sanitized);
+
+        return rtrim(self::LOG_DIRECTORY, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $sanitized;
+    }
+
+    private function ensureDirectory(): void
+    {
+        if (is_dir(self::LOG_DIRECTORY)) {
+            return;
+        }
+
+        @mkdir(self::LOG_DIRECTORY, 0775, true);
+    }
+}

--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -292,6 +292,46 @@
     margin-bottom: 0;
 }
 
+.everblock-config__card--logs details {
+    margin-bottom: 1rem;
+}
+
+.everblock-log-list details:last-child {
+    margin-bottom: 0;
+}
+
+.everblock-log__summary {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-weight: 600;
+    cursor: pointer;
+    gap: 0.75rem;
+}
+
+.everblock-log__meta {
+    color: #6c757d;
+    font-weight: 400;
+    font-size: 0.875rem;
+}
+
+.everblock-log__content {
+    margin-top: 0.75rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    max-height: 320px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.everblock-config__empty-state {
+    margin: 0;
+    color: #6c757d;
+}
+
 #module_form .nav-tabs {
     background: #f3f4ff;
     border-radius: 18px;

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -77,6 +77,34 @@
                     {$everblock_form nofilter}
                 </div>
             {/if}
+
+            {if isset($everblock_logs)}
+                <div class="everblock-config__card everblock-config__card--logs">
+                    <h3 class="everblock-config__card-title">{l s='Module logs' mod='everblock'}</h3>
+                    {if $everblock_log_directory}
+                        <p class="everblock-config__card-description">
+                            {l s='Logs are stored in %s.' mod='everblock' sprintf=[$everblock_log_directory]}
+                        </p>
+                    {/if}
+                    {if $everblock_logs|@count}
+                        <div class="everblock-log-list">
+                            {foreach $everblock_logs as $log}
+                                <details class="everblock-log">
+                                    <summary class="everblock-log__summary">
+                                        <span class="everblock-log__name">{$log.filename|escape:'htmlall':'UTF-8'}</span>
+                                        <span class="everblock-log__meta">
+                                            {$log.modified_at_formatted|escape:'htmlall':'UTF-8'} · {$log.size|escape:'htmlall':'UTF-8'}
+                                        </span>
+                                    </summary>
+                                    <pre class="everblock-log__content">{$log.content|escape:'htmlall':'UTF-8'}</pre>
+                                </details>
+                            {/foreach}
+                        </div>
+                    {else}
+                        <p class="everblock-config__empty-state">{l s='No log files are available yet.' mod='everblock'}</p>
+                    {/if}
+                </div>
+            {/if}
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add a dedicated LogService that writes module output under /var/logs/everblock and purges files older than seven days
- update console commands and helper utilities to rely on the centralised log service
- surface log files from the new location inside the module configuration UI with supporting styles and documentation updates

## Testing
- php -l src/Service/LogService.php
- php -l everblock.php
- php -l src/Command/ImportFileCommand.php
- php -l src/Command/ExportFileCommand.php
- php -l src/Command/ImportTabCommand.php
- php -l models/EverblockTools.php
- php -l src/Service/EverblockTools.php


------
https://chatgpt.com/codex/tasks/task_e_69034e89f76c8322b804c32ba54b86a5