### PR TITLE
Adjust log directory path for open_basedir compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The module uses its own cache system in addition to the PrestaShop one.
 
 The cache directory is located in /var/cache/dev?prod/everblock/
 
-The logs directory is located in /var/logs/everblock
+The logs directory is located in var/logs/everblock inside your PrestaShop root directory.
 Log files are created only when there is content to log.
 
 Clearing the native PrestaShop cache will also clear the module cache, but the module will clear its own cache on a block expiry automatically.
@@ -604,7 +604,7 @@ Le module utilise son propre système de cache en plus de celui de PrestaShop.
 
 Le dossier du cache se situe dans /var/cache/dev?prod/everblock/
 
-Le dossier des logs se situe dans /var/logs/everblock
+Le dossier des logs se situe dans var/logs/everblock à la racine de votre installation PrestaShop.
 Les fichiers de log ne sont créés que s'il y a un message à enregistrer.
 
 Vider le cache natif de PrestaShop videra également le cache du module, mais ce dernier vide automatiquement son cache lorsqu'un bloc expire.
@@ -830,7 +830,7 @@ El módulo utiliza su propio sistema de caché además del de PrestaShop.
 
 El directorio de caché está en /var/cache/dev?prod/everblock/
 
-El directorio de logs está en /var/logs/everblock
+El directorio de logs está en var/logs/everblock dentro de la raíz de tu instalación de PrestaShop.
 Los archivos de registro solo se crean si contienen información.
 
 Borrar la caché nativa de PrestaShop también limpiará la del módulo, pero este limpia automáticamente su caché cuando expira un bloque.
@@ -1056,7 +1056,7 @@ Il modulo utilizza un proprio sistema di cache oltre a quello di PrestaShop.
 
 La cartella cache si trova in /var/cache/dev?prod/everblock/
 
-La cartella log si trova in /var/logs/everblock
+La cartella dei log si trova in var/logs/everblock all'interno della directory principale di PrestaShop.
 I file di log vengono creati solo se contengono dei messaggi.
 
 Cancellare la cache nativa di PrestaShop cancellerà anche quella del modulo, ma quest'ultimo la pulisce automaticamente alla scadenza di un blocco.


### PR DESCRIPTION
## Summary
- update the log service to resolve the log directory inside the PrestaShop root so it respects open_basedir restrictions
- allow overriding the log directory and keep compatibility with existing usages
- refresh documentation to describe the new log directory location

## Testing
- php -l src/Service/LogService.php

------
https://chatgpt.com/codex/tasks/task_e_690361f180608322a84bdd374eb53373