### PR TITLE
Ensure admin tab routes are validated during DB checks

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4462,6 +4462,7 @@ class EverblockTools extends ObjectModel
     public static function checkAndFixDatabase()
     {
         $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+        static::checkAdminTabsUrls();
         $tableNames = [
             _DB_PREFIX_ . 'everblock',
             _DB_PREFIX_ . 'everblock_lang',
@@ -4979,6 +4980,59 @@ class EverblockTools extends ObjectModel
         $db = Db::getInstance();
         $result = $db->executeS('SHOW TABLES LIKE "' . $tableName . '"');
         return !empty($result);
+    }
+
+    protected static function ifColumnExists(string $tableName, string $columnName): bool
+    {
+        $db = Db::getInstance();
+
+        $result = $db->executeS(
+            'SHOW COLUMNS FROM `' . pSQL($tableName) . '` LIKE \'' . pSQL($columnName) . '\''
+        );
+
+        return !empty($result);
+    }
+
+    protected static function checkAdminTabsUrls(): void
+    {
+        if (!static::ifTableExists(_DB_PREFIX_ . 'tab')) {
+            return;
+        }
+
+        if (!static::ifColumnExists(_DB_PREFIX_ . 'tab', 'route_name')) {
+            return;
+        }
+
+        $tabClassName = 'AdminEverBlock';
+        $tabId = (int) Tab::getIdFromClassName($tabClassName);
+
+        if ($tabId <= 0) {
+            return;
+        }
+
+        $db = Db::getInstance();
+        $currentValues = $db->getRow(
+            'SELECT `route_name`, `module` FROM `' . _DB_PREFIX_ . 'tab` WHERE `id_tab` = ' . (int) $tabId
+        );
+
+        if (!$currentValues) {
+            return;
+        }
+
+        $updates = [];
+        $expectedRoute = 'everblock_admin_index';
+
+        if ($currentValues['route_name'] !== $expectedRoute) {
+            $updates['route_name'] = pSQL($expectedRoute);
+        }
+
+        if ($currentValues['module'] !== 'everblock') {
+            $updates['module'] = 'everblock';
+        }
+
+        if (!empty($updates)) {
+            $db->update('tab', $updates, 'id_tab = ' . (int) $tabId);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- call the admin tab URL verification when running the database maintenance helper
- add helpers that ensure the AdminEverBlock tab keeps the expected Symfony route and module binding

## Testing
- php -l models/EverblockTools.php
- php -l src/Service/EverblockTools.php

------
https://chatgpt.com/codex/tasks/task_e_69036a5753fc832292e649d4e9a1b70f