### PR TITLE
Fix AdminEverBlock tab route

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -462,6 +462,10 @@ class Everblock extends Module
         $tab->id_parent = (int) Tab::getIdFromClassName($parent);
         $tab->position = Tab::getNewLastPosition($tab->id_parent);
         $tab->module = $this->name;
+
+        if ($tabClass === 'AdminEverBlock' && property_exists($tab, 'route_name')) {
+            $tab->route_name = 'everblock_admin_index';
+        }
         if ($tabClass == 'AdminEverBlockParent') {
             $tab->icon = 'icon-team-ever';
         }


### PR DESCRIPTION
## Summary
- ensure the AdminEverBlock back-office tab records its Symfony route during installation so it no longer redirects to the module configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903731426f48322bf30057196ed08e8