### PR TITLE
Configure admin routes for Everblock controllers

### DIFF
--- a/modules/everblock/config/routes.yml
+++ b/modules/everblock/config/routes.yml
@@ -1,0 +1,4 @@
+everblock_admin:
+    resource: "../src/Controller/Admin/"
+    type: attribute
+    prefix: "/admin/everblocks"

--- a/src/Controller/Admin/EverblockController.php
+++ b/src/Controller/Admin/EverblockController.php
@@ -11,14 +11,17 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-#[Route(path: '/admin/everblocks', name: 'everblock_admin_')]
+#[Route(path: '', name: 'everblock_admin_')]
 class EverblockController extends AbstractController
 {
     public function __construct(private EverblockManager $manager)
     {
     }
 
-    #[Route(path: '', name: 'index', methods: ['GET'])]
+    #[Route(path: '', name: 'index', methods: ['GET'], defaults: [
+        '_legacy_controller' => 'AdminEverblock',
+        '_legacy_link' => 'AdminEverblock',
+    ])]
     public function index(Request $request): JsonResponse
     {
         $shopId = (int) $request->query->get('shop', 1);


### PR DESCRIPTION
## Summary
- register the admin Symfony controllers through `modules/everblock/config/routes.yml` using attribute routing
- adjust the controller route prefix to rely on the shared configuration and add PrestaShop legacy metadata for the index endpoint

## Testing
- not run (PrestaShop console not available in the module repository)


------
https://chatgpt.com/codex/tasks/task_e_690378104d5483229df183db5e6fef18