### PR TITLE
Configure Doctrine entity manager service

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -3,6 +3,18 @@ services:
         autowire: true
         autoconfigure: true
 
+    Doctrine\ORM\EntityManagerInterface:
+        factory: ['Everblock\\Tools\\Service\\DoctrineEntityManagerFactory', 'createForLegacyContext']
+
+    Everblock\Tools\Service\EverblockManager:
+        arguments:
+            - '@Doctrine\\ORM\\EntityManagerInterface'
+
+    Everblock\Tools\Controller\Admin\EverblockController:
+        public: true
+        tags:
+            - { name: 'controller.service_arguments' }
+
     everblock.tools.import:
         class: Everblock\Tools\Command\ImportFileCommand
         public: true


### PR DESCRIPTION
## Summary
- register Doctrine ORM entity manager service using the legacy factory
- inject the entity manager into the EverblockManager definition
- expose the Everblock admin controller as a public, container-managed service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69037e67806083228c9ed5a0190d0a5e