### PR TITLE
Fix Doctrine EntityManager service reference

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -3,12 +3,12 @@ services:
         autowire: true
         autoconfigure: true
 
-    Doctrine\ORM\EntityManagerInterface:
-        factory: ['Everblock\\Tools\\Service\\DoctrineEntityManagerFactory', 'createForLegacyContext']
+    'Doctrine\ORM\EntityManagerInterface':
+        factory: ['Everblock\Tools\Service\DoctrineEntityManagerFactory', 'createForLegacyContext']
 
     Everblock\Tools\Service\EverblockManager:
         arguments:
-            - '@Doctrine\\ORM\\EntityManagerInterface'
+            - '@Doctrine\ORM\EntityManagerInterface'
 
     Everblock\Tools\Controller\Admin\EverblockController:
         public: true


### PR DESCRIPTION
## Summary
- register the Doctrine entity manager interface service using the correct FQCN
- update the EverblockManager service to reference the corrected Doctrine manager service id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69038133c52c8322b8479f6fb23c02e6