### PR TITLE
Ensure Doctrine entities use configured table prefix

### DIFF
--- a/src/Doctrine/TablePrefixMetadataSubscriber.php
+++ b/src/Doctrine/TablePrefixMetadataSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Everblock\Tools\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+
+class TablePrefixMetadataSubscriber implements EventSubscriber
+{
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSubscribedEvents(): array
+    {
+        return [Events::loadClassMetadata];
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs): void
+    {
+        if ('' === $this->prefix) {
+            return;
+        }
+
+        $classMetadata = $eventArgs->getClassMetadata();
+        $tableName = $classMetadata->getTableName();
+
+        if (!$this->startsWithPrefix($tableName)) {
+            $classMetadata->setPrimaryTable([
+                'name' => $this->prefix . $tableName,
+            ]);
+        }
+
+        foreach ($classMetadata->associationMappings as $name => $mapping) {
+            if (!isset($mapping['joinTable']['name'])) {
+                continue;
+            }
+
+            $joinTableName = $mapping['joinTable']['name'];
+
+            if ($this->startsWithPrefix($joinTableName)) {
+                continue;
+            }
+
+            $mapping['joinTable']['name'] = $this->prefix . $joinTableName;
+            $classMetadata->associationMappings[$name] = $mapping;
+        }
+    }
+
+    private function startsWithPrefix(string $value): bool
+    {
+        return 0 === strpos($value, $this->prefix);
+    }
+}

--- a/src/Service/DoctrineEntityManagerFactory.php
+++ b/src/Service/DoctrineEntityManagerFactory.php
@@ -2,9 +2,11 @@
 
 namespace Everblock\Tools\Service;
 
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
+use Everblock\Tools\Doctrine\TablePrefixMetadataSubscriber;
 
 class DoctrineEntityManagerFactory
 {
@@ -29,6 +31,14 @@ class DoctrineEntityManagerFactory
             static fn ($value): bool => null !== $value && $value !== ''
         );
 
-        return EntityManager::create($connectionParams, $config);
+        $eventManager = new EventManager();
+
+        $tablePrefix = defined('_DB_PREFIX_') ? (string) _DB_PREFIX_ : '';
+
+        if ('' !== $tablePrefix) {
+            $eventManager->addEventSubscriber(new TablePrefixMetadataSubscriber($tablePrefix));
+        }
+
+        return EntityManager::create($connectionParams, $config, $eventManager);
     }
 }


### PR DESCRIPTION
## Summary
- add a Doctrine metadata subscriber that prefixes table and join table names with the PrestaShop database prefix
- register the subscriber in the Doctrine entity manager factory when bootstrapping the legacy context connection

## Testing
- php -l src/Doctrine/TablePrefixMetadataSubscriber.php

------
https://chatgpt.com/codex/tasks/task_e_69038673f0188322acb8306597b55c20