### PR TITLE
Update WordPress post fetching and simplify configuration

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -107,8 +107,6 @@ class Everblock extends Module
         Configuration::updateValue('EVERPS_TAB_NB', 5);
         Configuration::updateValue('EVERPS_FLAG_NB', 5);
         Configuration::updateValue('EVERWP_API_URL', '');
-        Configuration::updateValue('EVERWP_API_USER', '');
-        Configuration::updateValue('EVERWP_API_PWD', '');
         Configuration::updateValue('EVERWP_POST_NBR', 3);
         Configuration::updateValue('EVER_SOLDOUT_COLOR', '#ff0000');
         Configuration::updateValue('EVER_SOLDOUT_TEXTCOLOR', '#ffffff');
@@ -232,8 +230,6 @@ class Everblock extends Module
         Configuration::deleteByName('EVERPSCSS_S_LLOREM_NUMBER');
         Configuration::deleteByName('EVERBLOCK_TINYMCE');
         Configuration::deleteByName('EVERWP_API_URL');
-        Configuration::deleteByName('EVERWP_API_USER');
-        Configuration::deleteByName('EVERWP_API_PWD');
         Configuration::deleteByName('EVERWP_POST_NBR');
         Configuration::deleteByName('EVER_SOLDOUT_COLOR');
         Configuration::deleteByName('EVER_SOLDOUT_TEXTCOLOR');
@@ -1586,16 +1582,6 @@ class Everblock extends Module
             ],
             [
                 'type' => 'text',
-                'label' => $this->l('WordPress API user'),
-                'name' => 'EVERWP_API_USER',
-            ],
-            [
-                'type' => 'text',
-                'label' => $this->l('WordPress API password'),
-                'name' => 'EVERWP_API_PWD',
-            ],
-            [
-                'type' => 'text',
                 'label' => $this->l('Number of blog posts to display'),
                 'name' => 'EVERWP_POST_NBR',
             ],
@@ -2346,8 +2332,6 @@ class Everblock extends Module
             'EVERINSTA_LINK' => Configuration::get('EVERINSTA_LINK'),
             'EVERINSTA_SHOW_CAPTION' => Configuration::get('EVERINSTA_SHOW_CAPTION'),
             'EVERWP_API_URL' => Configuration::get('EVERWP_API_URL'),
-            'EVERWP_API_USER' => Configuration::get('EVERWP_API_USER'),
-            'EVERWP_API_PWD' => Configuration::get('EVERWP_API_PWD'),
             'EVERWP_POST_NBR' => Configuration::get('EVERWP_POST_NBR'),
             'EVERBLOCK_GOOGLE_API_KEY' => Configuration::get('EVERBLOCK_GOOGLE_API_KEY'),
             'EVERBLOCK_GOOGLE_PLACE_ID' => Configuration::get('EVERBLOCK_GOOGLE_PLACE_ID'),
@@ -2704,14 +2688,6 @@ class Everblock extends Module
         Configuration::updateValue(
             'EVERWP_API_URL',
             Tools::getValue('EVERWP_API_URL')
-        );
-        Configuration::updateValue(
-            'EVERWP_API_USER',
-            Tools::getValue('EVERWP_API_USER')
-        );
-        Configuration::updateValue(
-            'EVERWP_API_PWD',
-            Tools::getValue('EVERWP_API_PWD')
         );
         Configuration::updateValue(
             'EVERWP_POST_NBR',

--- a/models/EverblockTools.php
+++ b/models/EverblockTools.php
@@ -5296,16 +5296,14 @@ class EverblockTools extends ObjectModel
         if ($limit < 1) {
             $limit = 3;
         }
-        $requestUrl = rtrim($apiUrl, '/') . '?per_page=' . $limit . '&_embed';
-        $user = Configuration::get('EVERWP_API_USER');
-        $pwd = Configuration::get('EVERWP_API_PWD');
-        $contextOptions = [];
-        if ($user && $pwd) {
-            $contextOptions['http'] = [
-                'header' => 'Authorization: Basic ' . base64_encode($user . ':' . $pwd),
-            ];
-        }
-        $response = Tools::file_get_contents($requestUrl, false, empty($contextOptions) ? null : stream_context_create($contextOptions));
+        $requestUrl = rtrim($apiUrl, '/');
+        $queryParams = [
+            'per_page' => $limit,
+            '_embed' => 1,
+        ];
+        $separator = (strpos($requestUrl, '?') === false) ? '?' : '&';
+        $requestUrl .= $separator . http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $response = Tools::file_get_contents($requestUrl);
         $posts = json_decode($response, true);
         if (!$posts || !is_array($posts)) {
             return false;
@@ -5319,6 +5317,8 @@ class EverblockTools extends ObjectModel
             $imgUrl = '';
             if (isset($post['_embedded']['wp:featuredmedia'][0]['source_url'])) {
                 $imgUrl = $post['_embedded']['wp:featuredmedia'][0]['source_url'];
+            } elseif (isset($post['yoast_head_json']['og_image'][0]['url'])) {
+                $imgUrl = $post['yoast_head_json']['og_image'][0]['url'];
             }
             $imgTag = '';
             if ($imgUrl) {

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -5370,16 +5370,14 @@ class EverblockTools extends ObjectModel
         if ($limit < 1) {
             $limit = 3;
         }
-        $requestUrl = rtrim($apiUrl, '/') . '?per_page=' . $limit . '&_embed';
-        $user = Configuration::get('EVERWP_API_USER');
-        $pwd = Configuration::get('EVERWP_API_PWD');
-        $contextOptions = [];
-        if ($user && $pwd) {
-            $contextOptions['http'] = [
-                'header' => 'Authorization: Basic ' . base64_encode($user . ':' . $pwd),
-            ];
-        }
-        $response = Tools::file_get_contents($requestUrl, false, empty($contextOptions) ? null : stream_context_create($contextOptions));
+        $requestUrl = rtrim($apiUrl, '/');
+        $queryParams = [
+            'per_page' => $limit,
+            '_embed' => 1,
+        ];
+        $separator = (strpos($requestUrl, '?') === false) ? '?' : '&';
+        $requestUrl .= $separator . http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+        $response = Tools::file_get_contents($requestUrl);
         $posts = json_decode($response, true);
         if (!$posts || !is_array($posts)) {
             return false;
@@ -5393,6 +5391,8 @@ class EverblockTools extends ObjectModel
             $imgUrl = '';
             if (isset($post['_embedded']['wp:featuredmedia'][0]['source_url'])) {
                 $imgUrl = $post['_embedded']['wp:featuredmedia'][0]['source_url'];
+            } elseif (isset($post['yoast_head_json']['og_image'][0]['url'])) {
+                $imgUrl = $post['yoast_head_json']['og_image'][0]['url'];
             }
             $imgTag = '';
             if ($imgUrl) {


### PR DESCRIPTION
## Summary
- update the WordPress post fetcher to query the public REST endpoint and fall back to Yoast image metadata when featured media is absent
- remove the obsolete WordPress API user/password configuration options from the module forms and persistence

## Testing
- php -l src/Service/EverblockTools.php
- php -l models/EverblockTools.php
- php -l everblock.php

------
https://chatgpt.com/codex/tasks/task_e_6908b47fe4908322b292b92356c2f01a