### PR TITLE
Add desktop and mobile image uploads to featured category prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -948,6 +948,20 @@ class EverblockPrettyBlocks
                                 'url' => '',
                             ],
                         ],
+                        'desktop_image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Desktop image (optional)'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'mobile_image' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Mobile image (optional)'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'image_width' => [
                             'type' => 'text',
                             'label' => 'Image width (e.g., 100px or 50%)',

--- a/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl
@@ -38,11 +38,29 @@
         {else}
           <a href="{$category_link}" title="{$state.name}" class="d-block h-100 w-100 text-decoration-none text-white"{if $state.target_blank} target="_blank"{/if}>
         {/if}
-          {if $state.image.url}
+          {assign var='desktop_image_url' value=$state.desktop_image.url|default:''}
+          {assign var='mobile_image_url' value=$state.mobile_image.url|default:''}
+          {assign var='fallback_image_url' value=$state.image.url|default:''}
+          {if not $desktop_image_url && $fallback_image_url}
+            {assign var='desktop_image_url' value=$fallback_image_url}
+          {/if}
+          {if not $mobile_image_url && $fallback_image_url}
+            {assign var='mobile_image_url' value=$fallback_image_url}
+          {/if}
+          {if not $fallback_image_url}
+            {assign var='fallback_image_url' value=$desktop_image_url|default:$mobile_image_url}
+          {/if}
+          {if $fallback_image_url}
             <picture>
-              <source srcset="{$state.image.url}" type="image/webp">
-              <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-              <img src="{$state.image.url|replace:'.webp':'.jpg'}"
+              {if $mobile_image_url}
+                <source srcset="{$mobile_image_url}" media="(max-width: 767px)" type="image/webp">
+                <source srcset="{$mobile_image_url|replace:'.webp':'.jpg'}" media="(max-width: 767px)" type="image/jpeg">
+              {/if}
+              {if $desktop_image_url}
+                <source srcset="{$desktop_image_url}" media="(min-width: 768px)" type="image/webp">
+                <source srcset="{$desktop_image_url|replace:'.webp':'.jpg'}" media="(min-width: 768px)" type="image/jpeg">
+              {/if}
+              <img src="{$fallback_image_url|replace:'.webp':'.jpg'}"
                    alt="{$state.name|escape:'htmlall'}"
                    title="{$state.name|escape:'htmlall'}"
                    class="img-fluid w-100 h-100 object-fit-cover"


### PR DESCRIPTION
## Summary
- allow configuring optional desktop and mobile images for the Featured Category Prettyblock
- render the Featured Category template with responsive picture sources that fall back to the legacy image field

## Testing
- php -l src/Service/EverblockPrettyBlocks.php

------
https://chatgpt.com/codex/tasks/task_e_6909a2fa8e7c83228286988db154ad5c