### PR TITLE
feat: split meta integrations into dedicated tabs

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1251,6 +1251,7 @@ class Everblock extends Module
             'settings' => $this->l('Réglages'),
             'stats' => $this->l('Statistiques'),
             'meta_tools' => $this->l('Meta Tools'),
+            'wordpress_tools' => $this->l('WordPress Tools'),
             'google_maps' => $this->l('Google Tools'),
             'migration' => $this->l('Migration des URL'),
             'tools' => $this->l('Outils'),
@@ -1287,6 +1288,7 @@ class Everblock extends Module
             'settings' => 'settings.tpl',
             'stats' => 'stats.tpl',
             'meta_tools' => 'meta_tools.tpl',
+            'wordpress_tools' => 'wordpress_tools.tpl',
             'google_maps' => 'google_maps.tpl',
             'migration' => 'migration.tpl',
             'tools' => 'tools.tpl',
@@ -1588,7 +1590,7 @@ class Everblock extends Module
         ];
 
         foreach ($wordpressInputs as $input) {
-            $input['tab'] = 'meta_tools';
+            $input['tab'] = 'wordpress_tools';
             $form['form']['input'][] = $input;
         }
 
@@ -1699,7 +1701,7 @@ class Everblock extends Module
         ];
 
         foreach ($googleReviewsInputs as $input) {
-            $input['tab'] = 'meta_tools';
+            $input['tab'] = 'google_maps';
             $form['form']['input'][] = $input;
         }
 

--- a/views/templates/admin/config/docs/google_maps.tpl
+++ b/views/templates/admin/config/docs/google_maps.tpl
@@ -27,6 +27,8 @@
             <li>{l s='Remember to clear the module cache after changing the marker if the old icon is still displayed.' mod='everblock'}</li>
             <li>{l s='Paste the Google Places API key into the dedicated field and save the settings each time you rotate or restrict the key.' mod='everblock'}</li>
             <li>{l s='Store your Google Place ID in the provided field so the reviews shortcode knows which location to display.' mod='everblock'}</li>
+            <li>{l s='Use the review settings to adjust sorting, visibility of the global rating, avatars and call-to-action button.' mod='everblock'}</li>
+            <li>{l s='Limit the number of reviews displayed and filter them with the minimum rating option to highlight your best feedback.' mod='everblock'}</li>
         </ul>
         <p>{l s='Use the Google Place ID Finder from Google Maps Platform to retrieve the identifier that matches the location of your store, then copy it here.' mod='everblock'}</p>
         <p>{l s='If your API key changes or you revoke access from the Google Cloud console, update the key in this tab to keep the autocomplete widget and reviews working.' mod='everblock'}</p>

--- a/views/templates/admin/config/docs/meta_tools.tpl
+++ b/views/templates/admin/config/docs/meta_tools.tpl
@@ -20,15 +20,7 @@
             <i class="icon-cogs"></i>
             {l s='Meta Tools integrations' mod='everblock'}
         </h3>
-        <p>{l s='This tab centralises the external services connected to Ever Block. Use it to authenticate WordPress and Instagram so their content can be embedded inside your store.' mod='everblock'}</p>
-
-        <h4><i class="icon-wordpress"></i> {l s='WordPress integration' mod='everblock'}</h4>
-        <ul>
-            <li>{l s='API URL must target the posts endpoint, for example: https://example.com/wp-json/wp/v2/posts' mod='everblock'}</li>
-            <li>{l s='User and password are used for Basic Auth when the WordPress site requires authentication.' mod='everblock'}</li>
-            <li>{l s='Use the “Number of blog posts to display” field to limit the feed when rendering the shortcode.' mod='everblock'}</li>
-        </ul>
-        <p>{l s='Once saved, the module can fetch and cache the remote posts that you will embed through the [everwp] shortcode.' mod='everblock'}</p>
+        <p>{l s='This tab centralises the Meta services connected to Ever Block. Use it to authenticate Instagram so its content can be embedded inside your store.' mod='everblock'}</p>
 
         <h4><i class="icon-instagram"></i> {l s='Instagram integration' mod='everblock'}</h4>
         <ul>

--- a/views/templates/admin/config/docs/wordpress_tools.tpl
+++ b/views/templates/admin/config/docs/wordpress_tools.tpl
@@ -1,0 +1,31 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+
+<div class="card everblock-doc mt-3">
+    <div class="card-body">
+        <h3 class="card-title">
+            <i class="icon-wordpress"></i>
+            {l s='WordPress Tools integrations' mod='everblock'}
+        </h3>
+        <p>{l s='Configure the connection to your WordPress site so the module can fetch and cache blog posts.' mod='everblock'}</p>
+
+        <ul>
+            <li>{l s='API URL must target the posts endpoint, for example: https://example.com/wp-json/wp/v2/posts' mod='everblock'}</li>
+            <li>{l s='Set the number of posts to display to limit the feed when rendering the shortcode.' mod='everblock'}</li>
+        </ul>
+        <p>{l s='Once saved, the module can fetch and cache the remote posts that you will embed through the [everwp] shortcode.' mod='everblock'}</p>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated WordPress Tools tab and move the related configuration and documentation there
- keep Meta Tools focused on Instagram and move Google review settings to the Google Tools tab
- update contextual documentation to reflect the new tab structure

## Testing
- php -l everblock.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911eda3e69883229e3f6351827291f8)