### PR TITLE
Store WordPress posts in temp templates

### DIFF
--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -1,2 +1,6 @@
 {* Auto generated WordPress posts template *}
-<div class="everblock-wp-posts"></div>
+{if isset($everblock_wp_posts_html) && $everblock_wp_posts_html}
+    {$everblock_wp_posts_html nofilter}
+{else}
+    <div class="everblock-wp-posts"></div>
+{/if}


### PR DESCRIPTION
## Summary
- write fetched WordPress posts into uniquely named template files instead of overwriting the base template
- expose the stored HTML through Smarty so the static template renders the latest generated content
- keep the base generated_wp_posts.tpl as a wrapper that outputs either the generated HTML or a fallback container

## Testing
- php -l src/Service/EverblockTools.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f39c6078832289891827d7783501)