### PR TITLE
Remove module stats from admin controllers

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -70,7 +70,6 @@ class AdminEverBlockController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
-            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -71,7 +71,6 @@ class AdminEverBlockFaqController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
-            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -70,7 +70,6 @@ class AdminEverBlockHookController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
-            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
         $this->fields_list = [

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -71,7 +71,6 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
             'module_link' => $module_link,
             'everblock_dir' => _MODULE_DIR_ . '/everblock/',
             'donation_link' => 'https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE',
-            'everblock_stats' => $m->getAdminModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($m),
         ]);
 


### PR DESCRIPTION
## Summary
- stop assigning module statistics data inside each admin controller since it is no longer needed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a553d83c8322a4bf3bd9a75f85bf)