### PR TITLE
Add FAQ/product pivot table and helper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Dev documentation show every native PrestaShop hook :
 [PrestaShop 1.7 hook list](https://devdocs.prestashop.com/1.7/modules/concepts/hooks/)
 Please check ps_hook table on your database to see every available hook on your shop. Only display hooks are used with this module
 
+## FAQ ↔ product associations
+Ever Block ships a pivot table named `everblock_faq_product` that stores the FAQ → product relations (`id_everblock_faq`, `id_product`, `id_shop`, `position`). The installer and the 8.0.7 upgrade script automatically create it and keep it in sync across multishop setups.
+
+Use the static helpers exposed by `models/EverblockFaq.php` to manage those links from your own integrations:
+
+- `EverblockFaq::linkToProduct($faqId, $productId, $shopId = null, $position = null)` attaches a FAQ to a product (the position defaults to the next slot).
+- `EverblockFaq::unlinkProductFaqs($productId, $shopId = null, array $faqIds = null)` removes either all relations for a product or just the provided FAQ IDs.
+- `EverblockFaq::getFaqIdsByProduct($productId, $shopId = null)` returns the ordered FAQ identifiers assigned to a product in the current (or provided) shop.
+- `EverblockFaq::getProductsByFaq($faqId, $shopId = null)` lists the product IDs (and their positions) that consume a FAQ inside a shop.
+
+All helpers are multishop-aware, keep the multilingual cache up-to-date and trigger the same invalidation logic as the `actionObjectEverblockFaq*` hooks. You can safely call them from cron jobs, custom controllers or import scripts.
+
 ## Pretty Blocks compatibility
 This module is compatible with the Pretty Blocks page builder. [Find this free module here.](https://prettyblocks.io/)
 

--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -105,6 +105,7 @@ return [
     'translations/it.php',
     'translations/nl.php',
     'upgrade/index.php',
+    'upgrade/upgrade-8.0.7.php',
     'vendor/.htaccess',
     'vendor/autoload.php',
     'vendor/bin/index.php',

--- a/everblock.php
+++ b/everblock.php
@@ -67,7 +67,7 @@ class Everblock extends Module
     {
         $this->name = 'everblock';
         $this->tab = 'front_office_features';
-        $this->version = '8.0.6';
+        $this->version = '8.0.7';
         $this->author = 'Team Ever';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -3614,18 +3614,36 @@ class Everblock extends Module
     {
         $cachePattern = $this->name . '-id_hook-';
         EverblockCache::cacheDropByPattern($cachePattern);
-        $cachePattern = 'EverblockShortcode_getFaqByTagName_';
+        $cachePattern = 'EverblockFaq_getAllFaq_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getFaqByTagName_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getFaqIdsByProduct_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getProductsByFaq_';
         EverblockCache::cacheDropByPattern($cachePattern);
         $cachePattern = 'fetchInstagramImages';
         EverblockCache::cacheDropByPattern($cachePattern);
+        if (!empty($params['object']->id)) {
+            EverblockFaq::invalidateRelationsForFaq((int) $params['object']->id, (int) $params['object']->id_shop);
+        }
     }
 
     public function hookActionObjectEverblockFaqUpdateAfter($params)
     {
         $cachePattern = $this->name . '-id_hook-';
         EverblockCache::cacheDropByPattern($cachePattern);
-        $cachePattern = 'EverblockShortcode_getFaqByTagName_';
+        $cachePattern = 'EverblockFaq_getAllFaq_';
         EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getFaqByTagName_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getFaqIdsByProduct_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        $cachePattern = 'EverblockFaq_getProductsByFaq_';
+        EverblockCache::cacheDropByPattern($cachePattern);
+        if (!empty($params['object']->id)) {
+            EverblockFaq::invalidateRelationsForFaq((int) $params['object']->id, (int) $params['object']->id_shop);
+        }
     }
 
     public function hookActionObjectProductUpdateAfter($params)

--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -93,6 +93,44 @@ class EverblockFaq extends ObjectModel
         ],
     ];
 
+    protected static function resolveShopId(?int $shopId = null): int
+    {
+        if ($shopId) {
+            return (int) $shopId;
+        }
+
+        return (int) Context::getContext()->shop->id;
+    }
+
+    protected static function getFaqProductTable(): string
+    {
+        return _DB_PREFIX_ . 'everblock_faq_product';
+    }
+
+    protected static function getProductCacheKey(int $productId, int $shopId): string
+    {
+        return 'EverblockFaq_getFaqIdsByProduct_' . (int) $shopId . '_' . (int) $productId;
+    }
+
+    protected static function getFaqCacheKey(int $faqId, int $shopId): string
+    {
+        return 'EverblockFaq_getProductsByFaq_' . (int) $shopId . '_' . (int) $faqId;
+    }
+
+    protected static function clearRelationCaches(int $shopId, array $productIds = [], array $faqIds = []): void
+    {
+        $productIds = array_unique(array_filter(array_map('intval', $productIds)));
+        $faqIds = array_unique(array_filter(array_map('intval', $faqIds)));
+
+        foreach ($productIds as $productId) {
+            EverblockCache::cacheDrop(static::getProductCacheKey($productId, $shopId));
+        }
+
+        foreach ($faqIds as $faqId) {
+            EverblockCache::cacheDrop(static::getFaqCacheKey($faqId, $shopId));
+        }
+    }
+
     public static function getAllFaq(int $shopId, int $langId): array
     {
         $cache_id = 'EverblockFaq_getAllFaq_'
@@ -102,8 +140,8 @@ class EverblockFaq extends ObjectModel
         if (!EverblockCache::isCacheStored($cache_id)) {
             $sql = new DbQuery();
             $sql->select('*');
-            $sql->from(self::definition['table']);
-            $sql->where('id_shop = ' . (int) $idShop);
+            $sql->from(self::$definition['table']);
+            $sql->where('id_shop = ' . (int) $shopId);
             $sql->where('active = 1');
             $sql->orderBy('position ASC');
             $faqs = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -150,5 +188,194 @@ class EverblockFaq extends ObjectModel
             return $return;
         }
         return EverblockCache::cacheRetrieve($cache_id);
+    }
+
+    public static function getFaqIdsByProduct(int $productId, ?int $shopId = null): array
+    {
+        $shopId = static::resolveShopId($shopId);
+        $productId = (int) $productId;
+
+        if ($productId <= 0) {
+            return [];
+        }
+
+        $cacheId = static::getProductCacheKey($productId, $shopId);
+        if (EverblockCache::isCacheStored($cacheId)) {
+            return (array) EverblockCache::cacheRetrieve($cacheId);
+        }
+
+        $sql = new DbQuery();
+        $sql->select('id_everblock_faq');
+        $sql->from('everblock_faq_product');
+        $sql->where('id_product = ' . (int) $productId);
+        $sql->where('id_shop = ' . (int) $shopId);
+        $sql->orderBy('position ASC, id_everblock_faq_product ASC');
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        $faqIds = [];
+        foreach ($rows as $row) {
+            $faqIds[] = (int) $row['id_everblock_faq'];
+        }
+
+        EverblockCache::cacheStore($cacheId, $faqIds);
+
+        return $faqIds;
+    }
+
+    public static function getProductsByFaq(int $faqId, ?int $shopId = null): array
+    {
+        $shopId = static::resolveShopId($shopId);
+        $faqId = (int) $faqId;
+
+        if ($faqId <= 0) {
+            return [];
+        }
+
+        $cacheId = static::getFaqCacheKey($faqId, $shopId);
+        if (EverblockCache::isCacheStored($cacheId)) {
+            return (array) EverblockCache::cacheRetrieve($cacheId);
+        }
+
+        $sql = new DbQuery();
+        $sql->select('id_product, position');
+        $sql->from('everblock_faq_product');
+        $sql->where('id_everblock_faq = ' . (int) $faqId);
+        $sql->where('id_shop = ' . (int) $shopId);
+        $sql->orderBy('position ASC, id_everblock_faq_product ASC');
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        $products = [];
+        foreach ($rows as $row) {
+            $products[] = [
+                'id_product' => (int) $row['id_product'],
+                'position' => (int) $row['position'],
+            ];
+        }
+
+        EverblockCache::cacheStore($cacheId, $products);
+
+        return $products;
+    }
+
+    public static function linkToProduct(int $faqId, int $productId, ?int $shopId = null, ?int $position = null): bool
+    {
+        $shopId = static::resolveShopId($shopId);
+        $faqId = (int) $faqId;
+        $productId = (int) $productId;
+
+        if ($faqId <= 0 || $productId <= 0) {
+            return false;
+        }
+
+        $db = Db::getInstance();
+
+        if ($position === null) {
+            $position = (int) $db->getValue(
+                'SELECT IFNULL(MAX(position), -1) FROM `' . static::getFaqProductTable() . '`'
+                . ' WHERE id_product = ' . (int) $productId
+                . ' AND id_shop = ' . (int) $shopId
+            ) + 1;
+        }
+
+        $data = [
+            'id_everblock_faq' => $faqId,
+            'id_product' => $productId,
+            'id_shop' => $shopId,
+            'position' => (int) $position,
+        ];
+
+        $where = 'id_everblock_faq = ' . (int) $faqId
+            . ' AND id_product = ' . (int) $productId
+            . ' AND id_shop = ' . (int) $shopId;
+
+        $existingId = $db->getValue(
+            'SELECT id_everblock_faq_product FROM `' . static::getFaqProductTable() . '` WHERE ' . $where
+        );
+
+        if ($existingId) {
+            $result = $db->update('everblock_faq_product', ['position' => (int) $position], $where);
+        } else {
+            $result = $db->insert('everblock_faq_product', $data);
+        }
+
+        if ($result) {
+            static::clearRelationCaches($shopId, [$productId], [$faqId]);
+        }
+
+        return (bool) $result;
+    }
+
+    public static function unlinkProductFaqs(int $productId, ?int $shopId = null, ?array $faqIds = null): bool
+    {
+        $shopId = static::resolveShopId($shopId);
+        $productId = (int) $productId;
+
+        if ($productId <= 0) {
+            return false;
+        }
+
+        $db = Db::getInstance();
+
+        $whereParts = [
+            'id_product = ' . (int) $productId,
+            'id_shop = ' . (int) $shopId,
+        ];
+
+        $faqIdsToDelete = [];
+
+        if ($faqIds !== null) {
+            foreach ($faqIds as $faqId) {
+                $faqId = (int) $faqId;
+                if ($faqId > 0) {
+                    $faqIdsToDelete[] = $faqId;
+                }
+            }
+
+            if (empty($faqIdsToDelete)) {
+                return true;
+            }
+
+            $whereParts[] = 'id_everblock_faq IN (' . implode(',', $faqIdsToDelete) . ')';
+        } else {
+            $existing = $db->executeS(
+                'SELECT id_everblock_faq FROM `' . static::getFaqProductTable() . '`'
+                . ' WHERE id_product = ' . (int) $productId
+                . ' AND id_shop = ' . (int) $shopId
+            );
+            foreach ($existing as $row) {
+                $faqIdsToDelete[] = (int) $row['id_everblock_faq'];
+            }
+        }
+
+        $result = $db->delete('everblock_faq_product', implode(' AND ', $whereParts));
+
+        if ($result) {
+            static::clearRelationCaches($shopId, [$productId], $faqIdsToDelete);
+        }
+
+        return (bool) $result;
+    }
+
+    public static function invalidateRelationsForFaq(int $faqId, ?int $shopId = null): void
+    {
+        $shopId = static::resolveShopId($shopId);
+        $faqId = (int) $faqId;
+
+        if ($faqId <= 0) {
+            return;
+        }
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT id_product FROM `' . static::getFaqProductTable() . '`'
+            . ' WHERE id_everblock_faq = ' . (int) $faqId
+            . ' AND id_shop = ' . (int) $shopId
+        );
+
+        $productIds = [];
+        foreach ($rows as $row) {
+            $productIds[] = (int) $row['id_product'];
+        }
+
+        static::clearRelationCaches($shopId, $productIds, [$faqId]);
     }
 }

--- a/sql/install.php
+++ b/sql/install.php
@@ -102,6 +102,16 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_lang` (
         PRIMARY KEY (`id_everblock_faq`, `id_lang`)
     ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
 
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product` (
+        `id_everblock_faq_product` int(10) unsigned NOT NULL auto_increment,
+        `id_everblock_faq` int(10) unsigned NOT NULL,
+        `id_product` int(10) unsigned NOT NULL,
+        `id_shop` int(10) unsigned NOT NULL,
+        `position` int(10) unsigned NOT NULL DEFAULT 0,
+        PRIMARY KEY (`id_everblock_faq_product`),
+        UNIQUE KEY `everblock_faq_product_unique` (`id_everblock_faq`, `id_product`, `id_shop`)
+    ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+
 /* Tabs */
 $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_tabs` (
          `id_everblock_tabs` int(10) unsigned NOT NULL auto_increment,

--- a/sql/uninstall.php
+++ b/sql/uninstall.php
@@ -29,6 +29,7 @@ $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_shortcode`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_shortcode_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq_lang`;';
+$sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_tabs`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_tabs_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_flags`;';

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4463,6 +4463,7 @@ class EverblockTools extends ObjectModel
             _DB_PREFIX_ . 'everblock_shortcode_lang',
             _DB_PREFIX_ . 'everblock_faq',
             _DB_PREFIX_ . 'everblock_faq_lang',
+            _DB_PREFIX_ . 'everblock_faq_product',
             _DB_PREFIX_ . 'everblock_tabs',
             _DB_PREFIX_ . 'everblock_flags',
             _DB_PREFIX_ . 'everblock_modal',

--- a/upgrade/upgrade-8.0.7.php
+++ b/upgrade/upgrade-8.0.7.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+use Everblock\Tools\Service\EverblockTools;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'everblock/src/Service/EverblockTools.php';
+
+function upgrade_module_8_0_7($module)
+{
+    $sql = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_faq_product` (
+        `id_everblock_faq_product` int(10) unsigned NOT NULL auto_increment,
+        `id_everblock_faq` int(10) unsigned NOT NULL,
+        `id_product` int(10) unsigned NOT NULL,
+        `id_shop` int(10) unsigned NOT NULL,
+        `position` int(10) unsigned NOT NULL DEFAULT 0,
+        PRIMARY KEY (`id_everblock_faq_product`),
+        UNIQUE KEY `everblock_faq_product_unique` (`id_everblock_faq`, `id_product`, `id_shop`)
+    ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+
+    if (!Db::getInstance()->execute($sql)) {
+        return false;
+    }
+
+    EverblockTools::checkAndFixDatabase();
+    $module->checkHooks();
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- add the `everblock_faq_product` pivot table to the installer/uninstaller and provide an upgrade script so existing shops can create it
- extend `EverblockFaq` with helper methods and cache invalidation hooks so FAQ/product relations stay in sync across multishop setups
- document the new API and whitelist the new upgrade script

## Testing
- `php -l models/EverblockFaq.php`
- `php -l upgrade/upgrade-8.0.7.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916fe69041883229356697594a0a520)