### PR TITLE
Add FAQ association management for products

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -155,6 +155,7 @@ return [
     'views/js/everblock-obfuscation.js',
     'views/js/everblock.js',
     'views/js/index.php',
+    'views/js/product-faq.js',
     'views/js/product-modal.js',
     'views/js/slick-min.js',
     'views/templates/admin/config/docs/cron.tpl',

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -115,6 +115,13 @@ class AdminEverBlockFaqController extends ModuleAdminController
                 'orderby' => false,
                 'class' => 'fixed-width-sm',
             ],
+            'linked_products' => [
+                'title' => $this->l('Linked products'),
+                'align' => 'center',
+                'orderby' => false,
+                'search' => false,
+                'callback' => 'renderLinkedProductsBadge',
+            ],
             'date_add' => [
                 'title' => $this->l('Date add'),
                 'align' => 'left',
@@ -173,6 +180,37 @@ class AdminEverBlockFaqController extends ModuleAdminController
             'icon' => 'process-icon-download',
         ];
         parent::initPageHeaderToolbar();
+    }
+
+    public function renderLinkedProductsBadge($value, $row)
+    {
+        $faqId = (int) ($row['id_everblock_faq'] ?? 0);
+        if ($faqId <= 0) {
+            return '-';
+        }
+
+        static $relationsCache = [];
+        if (!array_key_exists($faqId, $relationsCache)) {
+            $relationsCache[$faqId] = EverblockFaq::getProductsByFaq($faqId, (int) $this->context->shop->id);
+        }
+
+        $products = $relationsCache[$faqId];
+        $count = count($products);
+        if ($count === 0) {
+            return '<span class="badge badge-secondary">0</span>';
+        }
+
+        $ids = array_map(function ($product) {
+            return (int) $product['id_product'];
+        }, $products);
+
+        $title = sprintf(
+            $this->l('%d product(s): %s'),
+            $count,
+            implode(', ', $ids)
+        );
+
+        return '<span class="badge badge-info" title="' . Tools::safeOutput($title) . '">' . (int) $count . '</span>';
     }
 
     public function renderList()

--- a/views/js/product-faq.js
+++ b/views/js/product-faq.js
@@ -1,0 +1,89 @@
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+(function ($) {
+  'use strict';
+
+  function formatFaqOption(option) {
+    if (!option || typeof option !== 'object') {
+      return '';
+    }
+    if (option.loading) {
+      return option.text;
+    }
+    return option.text || '';
+  }
+
+  function initFaqSelector($select) {
+    if (!$select || !$select.length) {
+      return;
+    }
+    var ajaxUrl = $select.data('ajax-url');
+    var placeholder = $select.data('placeholder') || '';
+
+    if ($.fn.select2 && ajaxUrl) {
+      $select.select2({
+        width: '100%',
+        allowClear: false,
+        placeholder: placeholder,
+        multiple: true,
+        ajax: {
+          url: ajaxUrl,
+          dataType: 'json',
+          delay: 250,
+          cache: true,
+          data: function (params) {
+            params = params || {};
+            return {
+              ajax: 1,
+              action: 'EverblockSearchFaq',
+              configure: 'everblock',
+              q: params.term || '',
+              page: params.page || 1
+            };
+          },
+          processResults: function (data, params) {
+            params = params || {};
+            params.page = params.page || 1;
+            var results = Array.isArray(data.results) ? data.results : [];
+            return {
+              results: results,
+              pagination: {
+                more: data.pagination && data.pagination.more === true
+              }
+            };
+          }
+        },
+        templateResult: formatFaqOption,
+        templateSelection: function (option) {
+          return formatFaqOption(option) || option.text || '';
+        },
+        escapeMarkup: function (markup) {
+          return markup;
+        }
+      });
+    } else if ($.fn.chosen) {
+      $select.chosen({width: '100%'});
+    }
+  }
+
+  $(document).ready(function () {
+    $('.js-everblock-faq-selector').each(function () {
+      initFaqSelector($(this));
+    });
+  });
+})(window.jQuery);

--- a/views/templates/admin/productTab.tpl
+++ b/views/templates/admin/productTab.tpl
@@ -60,5 +60,32 @@
             </div>
         </div>
         {/foreach}
+
+        {if isset($everblock_faq_selector)}
+        <div class="container border rounded p-3 mb-3">
+            <div class="row">
+                <div class="col-lg-12 col-xl-12">
+                    <h4 class="h4 mb-3">{l s='FAQ associations' mod='everblock'}</h4>
+                    <p class="text-muted">{l s='Select the FAQ entries that should be displayed with this product. Use the search bar to quickly find them by tag or title.' mod='everblock'}</p>
+                    <select
+                        name="everblock_faq_ids[]"
+                        class="form-control js-everblock-faq-selector"
+                        multiple="multiple"
+                        data-ajax-url="{$everblock_faq_selector.ajax_url|escape:'htmlall':'UTF-8'}"
+                        data-placeholder="{$everblock_faq_selector.placeholder|escape:'htmlall':'UTF-8'}"
+                    >
+                        {if isset($everblock_faq_selector.selected_options)}
+                            {foreach from=$everblock_faq_selector.selected_options item=faqOption}
+                                <option value="{$faqOption.id|intval}" selected="selected" data-active="{if $faqOption.active}1{else}0{/if}">
+                                    {$faqOption.text|escape:'htmlall':'UTF-8'}{if !$faqOption.active} ({l s='Inactive' mod='everblock'}){/if}
+                                </option>
+                            {/foreach}
+                        {/if}
+                    </select>
+                    <p class="help-block mt-2">{l s='The order of the selected items will be used when displaying the FAQ on the product page.' mod='everblock'}</p>
+                </div>
+            </div>
+        </div>
+        {/if}
     </fieldset>
 </div>


### PR DESCRIPTION
## Summary
- add an AJAX-powered FAQ multi-select to the product admin tab along with the JS helper that drives it
- synchronize FAQ relations on product save using the existing pivot helpers and expose a dedicated search endpoint
- display a linked-products badge in the FAQ admin grid to help auditing associations

## Testing
- php -l everblock.php
- php -l models/EverblockFaq.php
- php -l controllers/admin/AdminEverBlockFaqController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691704df9b1883229a7bf2630485ab11)