### PR TITLE
Adjust FAQ front template structure

### DIFF
--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -17,26 +17,22 @@
 *}
 
 {if isset($everFaqs) && $everFaqs}
-  <div class="container" id="everblockFaq">
-    <div class="row">
-      <div class="col-12">
-        <div class="accordion faq-accordion" id="faqAccordion">
-          {foreach from=$everFaqs item=faq name=faqloop}
-            <div class="accordion-item card mb-4">
-              <h2 class="accordion-header card-header p-0" id="headingEverFaq{$faq->id_everblock_faq}">
-                <button class="accordion-button btn btn-link faq-question d-flex justify-content-between align-items-center w-100 text-body py-3 px-4 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
-                        aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
-                  <span>{$faq->title}</span><i class="icon-angle-down" aria-hidden="true"></i>
-                </button>
-              </h2>
-              <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
-                   aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
-                <div class="accordion-body card-body faq-answer">{$faq->content nofilter}</div>
-              </div>
-            </div>
-          {/foreach}
+  <div id="everblockFaq">
+    <div class="accordion faq-accordion" id="faqAccordion">
+      {foreach from=$everFaqs item=faq name=faqloop}
+        <div class="accordion-item card mb-4">
+          <div class="accordion-header card-header p-0 h2" id="headingEverFaq{$faq->id_everblock_faq}">
+            <button class="accordion-button btn btn-link faq-question d-flex justify-content-between align-items-center w-100 text-body py-3 px-4 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
+                    aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
+              <span>{$faq->title}</span><i class="icon-angle-down" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
+               aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
+            <div class="accordion-body card-body faq-answer">{$faq->content nofilter}</div>
+          </div>
         </div>
-      </div>
+      {/foreach}
     </div>
   </div>
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- remove layout-specific container and row wrappers from the front-office FAQ template
- replace the h2 heading element with a simple wrapper using the `h2` class to avoid heading levels in the front template

## Testing
- not run; not requested


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917342c67188322bfbf8cd63e54715f)