### PR TITLE
Improve product FAQ selector order and style

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -79,6 +79,71 @@
     padding: 15px;
 }
 
+/* Admin - Product FAQ selector */
+#everblock .everblock-faq-selector-card {
+    background: #fdfdfd;
+    border-color: #e3e8ef;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+#everblock .everblock-faq-search-tip {
+    border: 1px dashed #94a3b8;
+    background: #f8fafc;
+    color: #334155;
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    font-weight: 500;
+}
+
+#everblock .everblock-faq-selector-wrapper label {
+    color: #0f172a;
+}
+
+#everblock .everblock-faq-selected-counter {
+    font-size: .9rem;
+    padding: .5rem 1rem;
+}
+
+#everblock .everblock-faq-selector-wrapper select[multiple] {
+    min-height: 70px;
+    border-width: 2px;
+    border-color: #4f46e5;
+    border-radius: .75rem;
+    padding: .65rem;
+    box-shadow: 0 0 0 .1rem rgba(79, 70, 229, 0.15);
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-container--default .select2-selection--multiple {
+    border: 2px solid #4f46e5;
+    border-radius: .75rem;
+    min-height: 56px;
+    padding: .35rem;
+    transition: box-shadow .2s ease, border-color .2s ease;
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    background-color: rgba(79, 70, 229, 0.15);
+    border: none;
+    color: #312e81;
+    font-weight: 600;
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-container--default .select2-selection--multiple .select2-search__field {
+    padding: .4rem;
+    font-size: 1rem;
+    color: #0f172a;
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-container--default.select2-container--focus .select2-selection--multiple {
+    box-shadow: 0 0 0 .2rem rgba(79, 70, 229, 0.2);
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-search--inline .select2-search__field::placeholder {
+    color: #4f46e5;
+    font-weight: 600;
+}
+
 /* Pricing table styles */
 .everblock-pricing-table .pricing-plan {
     border: 1px solid #dee2e6;

--- a/views/templates/admin/productTab.tpl
+++ b/views/templates/admin/productTab.tpl
@@ -17,6 +17,53 @@
 *}
 <div id="everblock" class="panel">
     <fieldset class="form-group">
+        {if isset($everblock_faq_selector)}
+        <div class="container border rounded p-3 mb-3 everblock-faq-selector-card">
+            <div class="row">
+                <div class="col-lg-12 col-xl-12">
+                    {assign var=faqSelectedCount value=0}
+                    {if isset($everblock_faq_selector.selected_options)}
+                        {assign var=faqSelectedCount value=$everblock_faq_selector.selected_options|@count}
+                    {/if}
+                    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-2 mb-2">
+                        <div>
+                            <h4 class="h4 mb-2">{l s='FAQ associations' mod='everblock'}</h4>
+                            <p class="text-muted mb-0">{l s='Select the FAQ entries that should be displayed with this product. Use the search bar to quickly find them by tag or title.' mod='everblock'}</p>
+                        </div>
+                        {if $faqSelectedCount > 0}
+                            <span class="badge bg-primary everblock-faq-selected-counter">{l s='%d FAQ selected' sprintf=[$faqSelectedCount] mod='everblock'}</span>
+                        {/if}
+                    </div>
+                    <div class="everblock-faq-search-tip alert alert-info py-2 px-3 mb-3">
+                        <i class="icon-search" aria-hidden="true"></i>
+                        <span>{l s='Start typing to highlight the search bar and filter the FAQs by tag or title.' mod='everblock'}</span>
+                    </div>
+                    <div class="everblock-faq-selector-wrapper">
+                        <label for="everblock_faq_selector" class="form-label fw-semibold">{l s='Search and select FAQ entries' mod='everblock'}</label>
+                        <select
+                            id="everblock_faq_selector"
+                            name="everblock_faq_ids[]"
+                            class="form-control js-everblock-faq-selector"
+                            multiple="multiple"
+                            data-ajax-url="{$everblock_faq_selector.ajax_url|escape:'htmlall':'UTF-8'}"
+                            data-placeholder="{$everblock_faq_selector.placeholder|escape:'htmlall':'UTF-8'}"
+                            aria-describedby="everblock_faq_selector_hint"
+                        >
+                            {if isset($everblock_faq_selector.selected_options)}
+                                {foreach from=$everblock_faq_selector.selected_options item=faqOption}
+                                    <option value="{$faqOption.id|intval}" selected="selected" data-active="{if $faqOption.active}1{else}0{/if}">
+                                        {$faqOption.text|escape:'htmlall':'UTF-8'}{if !$faqOption.active} ({l s='Inactive' mod='everblock'}){/if}
+                                    </option>
+                                {/foreach}
+                            {/if}
+                        </select>
+                        <p id="everblock_faq_selector_hint" class="help-block mt-2 mb-0">{l s='The order of the selected items will be used when displaying the FAQ on the product page.' mod='everblock'}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {/if}
+
         {foreach from=$tabsData key=tabNumber item=everpstabs}
         <div class="container border rounded p-3 mb-3">
             <div class="row">
@@ -60,32 +107,5 @@
             </div>
         </div>
         {/foreach}
-
-        {if isset($everblock_faq_selector)}
-        <div class="container border rounded p-3 mb-3">
-            <div class="row">
-                <div class="col-lg-12 col-xl-12">
-                    <h4 class="h4 mb-3">{l s='FAQ associations' mod='everblock'}</h4>
-                    <p class="text-muted">{l s='Select the FAQ entries that should be displayed with this product. Use the search bar to quickly find them by tag or title.' mod='everblock'}</p>
-                    <select
-                        name="everblock_faq_ids[]"
-                        class="form-control js-everblock-faq-selector"
-                        multiple="multiple"
-                        data-ajax-url="{$everblock_faq_selector.ajax_url|escape:'htmlall':'UTF-8'}"
-                        data-placeholder="{$everblock_faq_selector.placeholder|escape:'htmlall':'UTF-8'}"
-                    >
-                        {if isset($everblock_faq_selector.selected_options)}
-                            {foreach from=$everblock_faq_selector.selected_options item=faqOption}
-                                <option value="{$faqOption.id|intval}" selected="selected" data-active="{if $faqOption.active}1{else}0{/if}">
-                                    {$faqOption.text|escape:'htmlall':'UTF-8'}{if !$faqOption.active} ({l s='Inactive' mod='everblock'}){/if}
-                                </option>
-                            {/foreach}
-                        {/if}
-                    </select>
-                    <p class="help-block mt-2">{l s='The order of the selected items will be used when displaying the FAQ on the product page.' mod='everblock'}</p>
-                </div>
-            </div>
-        </div>
-        {/if}
     </fieldset>
 </div>


### PR DESCRIPTION
## Summary
- display the FAQ association block at the top of the product tab when available so it is immediately visible when editing a product
- add richer markup for the FAQ selector, including count information and clearer helper text, to guide merchants when linking FAQs
- style the FAQ selector/search field to improve contrast and highlight the search input, covering both Select2 and native multi-select fallbacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691735734d108322ace3669a2e02a76e)