### PR TITLE
Hide hero block outside module configuration

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -307,6 +307,7 @@ class AdminEverBlockController extends ModuleAdminController
             'everblock_notifications' => $notifications,
             'everblock_form' => $lists,
             'display_upgrade' => $displayUpgrade,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(
@@ -1072,6 +1073,7 @@ class AdminEverBlockController extends ModuleAdminController
             'everblock_preview_contexts' => $previewContexts,
             'everblock_preview_url' => $previewUrl,
             'everblock_preview_available' => $previewAvailable,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(

--- a/controllers/admin/AdminEverBlockFaqController.php
+++ b/controllers/admin/AdminEverBlockFaqController.php
@@ -247,6 +247,7 @@ class AdminEverBlockFaqController extends ModuleAdminController
             'everblock_notifications' => $notifications,
             'everblock_form' => $lists,
             'display_upgrade' => $displayUpgrade,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(

--- a/controllers/admin/AdminEverBlockHookController.php
+++ b/controllers/admin/AdminEverBlockHookController.php
@@ -219,6 +219,7 @@ class AdminEverBlockHookController extends ModuleAdminController
             'everblock_notifications' => $notifications,
             'everblock_form' => $lists,
             'display_upgrade' => $displayUpgrade,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(
@@ -369,6 +370,7 @@ class AdminEverBlockHookController extends ModuleAdminController
             'everblock_notifications' => $notifications,
             'everblock_form' => $helper->generateForm($fields_form),
             'display_upgrade' => $displayUpgrade,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(

--- a/controllers/admin/AdminEverBlockShortcodeController.php
+++ b/controllers/admin/AdminEverBlockShortcodeController.php
@@ -185,6 +185,7 @@ class AdminEverBlockShortcodeController extends ModuleAdminController
             'everblock_notifications' => $notifications,
             'everblock_form' => $lists,
             'display_upgrade' => $displayUpgrade,
+            'everblock_show_hero' => false,
         ]);
 
         $content = $this->context->smarty->fetch(

--- a/everblock.php
+++ b/everblock.php
@@ -976,6 +976,7 @@ class Everblock extends Module
             'display_upgrade' => $displayUpgrade,
             'everblock_stats' => $this->getModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($this),
+            'everblock_show_hero' => true,
         ]);
         $output = $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/header.tpl'

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -23,46 +23,48 @@
         </div>
     {/if}
 
-    <section class="everblock-config__hero">
-        <div class="everblock-config__hero-main">
-            <span class="everblock-config__badge">{l s='Module' mod='everblock'}</span>
-            <h2 class="everblock-config__hero-title">
-                {$module_name|escape:'htmlall':'UTF-8'}
-            </h2>
-            <p class="everblock-config__hero-description">
-                {l s='Fine-tune the behaviour, integrations and automation rules of Ever Block from a single, curated control centre.' mod='everblock'}
-            </p>
-            <div class="everblock-config__hero-meta">
-                <span class="everblock-chip">
-                    <i class="icon-tag"></i>
-                    {l s='Version' mod='everblock'} {$everblock_version|escape:'htmlall':'UTF-8'}
-                </span>
-                <span class="everblock-chip">
-                    <i class="icon-check"></i>
-                    {l s='Content managed (total)' mod='everblock'}: {$everblock_stats.blocks_total|intval}
-                </span>
+    {if !isset($everblock_show_hero) || $everblock_show_hero}
+        <section class="everblock-config__hero">
+            <div class="everblock-config__hero-main">
+                <span class="everblock-config__badge">{l s='Module' mod='everblock'}</span>
+                <h2 class="everblock-config__hero-title">
+                    {$module_name|escape:'htmlall':'UTF-8'}
+                </h2>
+                <p class="everblock-config__hero-description">
+                    {l s='Fine-tune the behaviour, integrations and automation rules of Ever Block from a single, curated control centre.' mod='everblock'}
+                </p>
+                <div class="everblock-config__hero-meta">
+                    <span class="everblock-chip">
+                        <i class="icon-tag"></i>
+                        {l s='Version' mod='everblock'} {$everblock_version|escape:'htmlall':'UTF-8'}
+                    </span>
+                    <span class="everblock-chip">
+                        <i class="icon-check"></i>
+                        {l s='Content managed (total)' mod='everblock'}: {$everblock_stats.blocks_total|intval}
+                    </span>
+                </div>
             </div>
-        </div>
 
-        <div class="everblock-config__hero-stats">
-            <div class="everblock-config__stat">
-                <div class="everblock-config__stat-value">{$everblock_stats.blocks_active|intval}</div>
-                <div class="everblock-config__stat-label">{l s='Active blocks' mod='everblock'}</div>
+            <div class="everblock-config__hero-stats">
+                <div class="everblock-config__stat">
+                    <div class="everblock-config__stat-value">{$everblock_stats.blocks_active|intval}</div>
+                    <div class="everblock-config__stat-label">{l s='Active blocks' mod='everblock'}</div>
+                </div>
+                <div class="everblock-config__stat">
+                    <div class="everblock-config__stat-value">{$everblock_stats.shortcodes|intval}</div>
+                    <div class="everblock-config__stat-label">{l s='Shortcodes' mod='everblock'}</div>
+                </div>
+                <div class="everblock-config__stat">
+                    <div class="everblock-config__stat-value">{$everblock_stats.flags|intval}</div>
+                    <div class="everblock-config__stat-label">{l s='Flags' mod='everblock'}</div>
+                </div>
+                <div class="everblock-config__stat">
+                    <div class="everblock-config__stat-value">{$everblock_stats.tabs|intval}</div>
+                    <div class="everblock-config__stat-label">{l s='Product tabs' mod='everblock'}</div>
+                </div>
             </div>
-            <div class="everblock-config__stat">
-                <div class="everblock-config__stat-value">{$everblock_stats.shortcodes|intval}</div>
-                <div class="everblock-config__stat-label">{l s='Shortcodes' mod='everblock'}</div>
-            </div>
-            <div class="everblock-config__stat">
-                <div class="everblock-config__stat-value">{$everblock_stats.flags|intval}</div>
-                <div class="everblock-config__stat-label">{l s='Flags' mod='everblock'}</div>
-            </div>
-            <div class="everblock-config__stat">
-                <div class="everblock-config__stat-value">{$everblock_stats.tabs|intval}</div>
-                <div class="everblock-config__stat-label">{l s='Product tabs' mod='everblock'}</div>
-            </div>
-        </div>
-    </section>
+        </section>
+    {/if}
 
     <div class="everblock-config__layout">
         <div class="everblock-config__main">


### PR DESCRIPTION
## Summary
- gate the Ever Block hero card in the shared admin template behind a flag so it can be disabled outside the module configuration page
- set the flag to true for the module configuration rendering path and to false for all dedicated admin controllers so the hero block is hidden there

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173858a7e88322b5cce181b7ba8477)