### PR TITLE
Adjust reassurance block layout defaults

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -535,7 +535,7 @@ class EverblockPrettyBlocks
                         'display_inline' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Display reassurances side by side'),
-                            'default' => false,
+                            'default' => true,
                         ],
                         'columns' => [
                             'type' => 'select',

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -20,7 +20,7 @@
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0 mt-20px{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row g-10px">
-  {elseif $block.settings.default.container}
+  {elseif $block.settings.default.container || $block.settings.default.display_inline}
     <div class="row">
   {/if}
 
@@ -79,7 +79,7 @@
     {/foreach}
   {/if}
 
-  {if $block.settings.default.force_full_width || $block.settings.default.container}
+  {if $block.settings.default.force_full_width || $block.settings.default.container || $block.settings.default.display_inline}
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- set reassurance block to display reassurance items side-by-side by default
- ensure inline reassurance layouts get a row wrapper so column counts apply

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c6599eb08322a00fc015dca275c0)