### PR TITLE
Use default customer group for Prettyblock visibility

### DIFF
--- a/views/templates/hook/prettyblocks/_partials/visibility_class.tpl
+++ b/views/templates/hook/prettyblocks/_partials/visibility_class.tpl
@@ -1,9 +1,27 @@
 {assign var='prettyblock_visibility' value=$block.settings.display_on|default:'Mobile and desktop'}
 {assign var='prettyblock_visibility_class' value='' scope='parent'}
+{assign var='prettyblock_is_allowed_group' value=true scope='parent'}
+
+{* Hide blocks when the current customer group is not allowed *}
+{assign var='prettyblock_allowed_groups' value=$block.settings.allowed_customer_groups|default:[]}
+
+{if $prettyblock_allowed_groups|@count}
+  {assign var='prettyblock_is_allowed_group' value=false scope='parent'}
+  {if isset($customer) && $customer.id_default_group}
+    {if in_array($customer.id_default_group, $prettyblock_allowed_groups)}
+      {assign var='prettyblock_is_allowed_group' value=true scope='parent'}
+    {/if}
+  {/if}
+{/if}
+
 {if $prettyblock_visibility === 'Mobile only'}
   {assign var='prettyblock_visibility_class' value=' everblock-visibility-mobile' scope='parent'}
 {elseif $prettyblock_visibility === 'Desktop only'}
   {assign var='prettyblock_visibility_class' value=' everblock-visibility-desktop' scope='parent'}
 {elseif $prettyblock_visibility === 'Nowhere'}
+  {assign var='prettyblock_visibility_class' value=' everblock-visibility-none' scope='parent'}
+{/if}
+
+{if !$prettyblock_is_allowed_group}
   {assign var='prettyblock_visibility_class' value=' everblock-visibility-none' scope='parent'}
 {/if}


### PR DESCRIPTION
## Summary
- check Prettyblock visibility using the customer's default group from `$customer.id_default_group`
- block rendering disabled when the default group is not allowed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb86e43a4832295ce73f4af20484a)