### PR TITLE
Allow configuring heading block title alignment

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -351,6 +351,16 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
+                        'title_alignment' => [
+                            'type' => 'select',
+                            'label' => $module->l('Title alignment'),
+                            'choices' => [
+                                'left' => $module->l('Left'),
+                                'center' => $module->l('Center'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'left',
+                        ],
                         'text_color' => [
                             'type' => 'color',
                             'label' => $module->l('Text color'),

--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -29,7 +29,14 @@
     {if $block.settings.default.container}
         <div class="row">
     {/if}
-        <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if isset($block.settings.text_color) && $block.settings.text_color} style="color:{$block.settings.text_color|escape:'htmlall':'UTF-8'};"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
+        {assign var='heading_styles' value=''}
+        {if isset($block.settings.text_color) && $block.settings.text_color}
+          {assign var='heading_styles' value="{$heading_styles}color:{$block.settings.text_color|escape:'htmlall':'UTF-8'};"}
+        {/if}
+        {if isset($block.settings.title_alignment) && $block.settings.title_alignment}
+          {assign var='heading_styles' value="{$heading_styles}text-align:{$block.settings.title_alignment|escape:'htmlall':'UTF-8'};"}
+        {/if}
+        <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
     {if $block.settings.default.container}
         </div>
     {/if}


### PR DESCRIPTION
## Summary
- add a title alignment selector to the heading block configuration
- render the heading with the chosen alignment alongside existing styling options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693687720f208322a124cbb375e6eb79)