### PR TITLE
Add items per row setting to reassurance block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -549,6 +549,19 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Display reassurances side by side'),
                             'default' => true,
                         ],
+                        'items_per_row' => [
+                            'type' => 'select',
+                            'label' => $module->l('Reassurances per row'),
+                            'choices' => [
+                                '1' => $module->l('1 item per row'),
+                                '2' => $module->l('2 items per row'),
+                                '3' => $module->l('3 items per row'),
+                                '4' => $module->l('4 items per row'),
+                                '5' => $module->l('5 items per row'),
+                                '6' => $module->l('6 items per row'),
+                            ],
+                            'default' => '3',
+                        ],
                         'columns' => [
                             'type' => 'select',
                             'label' => $module->l('Number of columns per row'),

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -20,11 +20,11 @@
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0 mt-20px{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row g-10px">
-  {elseif $block.settings.default.container || $block.settings.default.display_inline}
+  {elseif $block.settings.default.container || $block.settings.default.display_inline || $reassuranceColumns > 0}
     <div class="row">
   {/if}
 
-{assign var='reassuranceColumns' value=$block.settings.default.columns|default:0|intval}
+{assign var='reassuranceColumns' value=$block.settings.default.items_per_row|default:$block.settings.default.columns|default:0|intval}
 {assign var='reassuranceColumnClass' value=''}
 {if $reassuranceColumns > 0}
   {math assign="reassuranceColumnWidth" equation="12 / x" x=$reassuranceColumns format="%.0f"}
@@ -79,7 +79,7 @@
     {/foreach}
   {/if}
 
-  {if $block.settings.default.force_full_width || $block.settings.default.container || $block.settings.default.display_inline}
+  {if $block.settings.default.force_full_width || $block.settings.default.container || $block.settings.default.display_inline || $reassuranceColumns > 0}
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- add a parent-level selector to choose the number of reassurance items per row
- update the reassurance template to use the configured items-per-row when rendering columns

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936af2dcde08322a0e743c3c3f83ab3)