### PR TITLE
Add structured data to Prettyblock FAQ

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -112,6 +112,7 @@ class EverblockPrettyBlocks
             $contactTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_contact.tpl';
             $shoppingCartTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl';
             $accordeonTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_accordeon.tpl';
+            $faqTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_faq.tpl';
             $textAndImageTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl';
             $layoutTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_layout.tpl';
             $featuredCategoryTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl';
@@ -479,6 +480,107 @@ class EverblockPrettyBlocks
                             'type' => 'color',
                             'default' => '#000000',
                             'label' => $module->l('Accordeon background color')
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('FAQ list'),
+                'description' => $module->l('Display a Prettyblock FAQ with badges and links'),
+                'code' => 'everblock_faq',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $faqTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Section title'),
+                            'default' => $module->l('Frequently asked questions'),
+                        ],
+                        'subtitle' => [
+                            'type' => 'textarea',
+                            'label' => $module->l('Section subtitle'),
+                            'default' => '',
+                        ],
+                        'cta_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('CTA label'),
+                            'default' => $module->l('See all FAQs'),
+                        ],
+                        'cta_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('CTA link'),
+                            'default' => '#',
+                        ],
+                        'badge_background' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Default badge background'),
+                            'default' => '#f3f0ff',
+                        ],
+                        'badge_text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Default badge text color'),
+                            'default' => '#5b35c3',
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Section background color'),
+                            'default' => '#f7f9fc',
+                        ],
+                    ], $module),
+                ],
+                'repeater' => [
+                    'name' => 'FAQ',
+                    'nameFrom' => 'question',
+                    'groups' => static::appendSpacingFields([
+                        'question' => [
+                            'type' => 'text',
+                            'label' => $module->l('Question'),
+                            'default' => $module->l('What do you want to know?'),
+                        ],
+                        'answer' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Answer'),
+                            'default' => $module->l('Share the most helpful information about this topic.'),
+                        ],
+                        'link_label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Link label'),
+                            'default' => $module->l('Learn more'),
+                        ],
+                        'link_url' => [
+                            'type' => 'text',
+                            'label' => $module->l('Link URL'),
+                            'default' => '#',
+                        ],
+                        'badge_label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Badge text'),
+                            'default' => '?',
+                        ],
+                        'badge_background' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Badge background'),
+                            'default' => '',
+                        ],
+                        'badge_text_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'label' => $module->l('Badge text color'),
+                            'default' => '',
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -2975,3 +2975,63 @@
 .everblock-wp-section .btn-warning {
   background-color: #f28c3a;
   border
+
+/* Prettyblock FAQ */
+.prettyblock-faq {
+  gap: 1rem;
+}
+
+.prettyblock-faq-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.prettyblock-faq-item {
+  border-radius: 18px;
+  box-shadow: 0 16px 48px rgba(49, 63, 105, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.prettyblock-faq-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 56px rgba(49, 63, 105, 0.12);
+  border-color: #d7deea;
+}
+
+.prettyblock-faq-badge {
+  width: 56px;
+  height: 56px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  background-color: #f3f0ff;
+  color: #5b35c3;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.prettyblock-faq-question {
+  color: #111827;
+  line-height: 1.35;
+}
+
+.prettyblock-faq-answer {
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.prettyblock-faq-link {
+  color: #111827;
+  text-decoration: none;
+}
+
+.prettyblock-faq-link:hover {
+  color: #0d6efd;
+  text-decoration: underline;
+}
+
+.prettyblock-faq-cta {
+  min-width: 240px;
+}

--- a/views/templates/hook/prettyblocks/prettyblock_faq.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_faq.tpl
@@ -1,0 +1,129 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+
+{capture name='prettyblock_faq_wrapper_style'}
+  {$prettyblock_spacing_style}
+  {if isset($block.settings.background_color) && $block.settings.background_color}
+    background-color:{$block.settings.background_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_faq_wrapper_style' value=$smarty.capture.prettyblock_faq_wrapper_style|trim}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  <div class="{if $block.settings.default.container}container{/if} py-4 py-md-5"{if $prettyblock_faq_wrapper_style} style="{$prettyblock_faq_wrapper_style}"{/if}>
+    <div class="prettyblock-faq">
+      {if $block.settings.title || $block.settings.subtitle}
+        <div class="prettyblock-faq-header mb-4">
+          {if $block.settings.title}
+            <h2 class="h3 fw-bold mb-2">{$block.settings.title|escape:'htmlall':'UTF-8'}</h2>
+          {/if}
+          {if $block.settings.subtitle}
+            <p class="text-muted mb-0">{$block.settings.subtitle|escape:'htmlall':'UTF-8'}</p>
+          {/if}
+        </div>
+      {/if}
+
+      {if isset($block.states) && $block.states}
+        <div class="prettyblock-faq-list d-flex flex-column gap-3">
+          {foreach from=$block.states item=state}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_faq_state_spacing_style'}
+            {capture name='prettyblock_faq_badge_style'}
+              {if $state.badge_background}
+                background-color:{$state.badge_background|escape:'htmlall':'UTF-8'};
+              {elseif $block.settings.badge_background}
+                background-color:{$block.settings.badge_background|escape:'htmlall':'UTF-8'};
+              {/if}
+              {if $state.badge_text_color}
+                color:{$state.badge_text_color|escape:'htmlall':'UTF-8'};
+              {elseif $block.settings.badge_text_color}
+                color:{$block.settings.badge_text_color|escape:'htmlall':'UTF-8'};
+              {/if}
+            {/capture}
+            {assign var='prettyblock_faq_badge_style' value=$smarty.capture.prettyblock_faq_badge_style|trim}
+            {assign var='prettyblock_faq_badge_text' value=$state.badge_label|default:($state.question|substr:0:1)}
+            {assign var='prettyblock_faq_state_style' value=$prettyblock_faq_state_spacing_style|trim}
+
+            <article class="prettyblock-faq-item border border-light-subtle rounded-4 shadow-sm bg-white p-4 p-md-5 d-flex align-items-start gap-3{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}"{if $prettyblock_faq_state_style} style="{$prettyblock_faq_state_style}"{/if}>
+              <div class="prettyblock-faq-badge flex-shrink-0"{if $prettyblock_faq_badge_style} style="{$prettyblock_faq_badge_style}"{/if} aria-hidden="true">
+                {$prettyblock_faq_badge_text|escape:'htmlall':'UTF-8'}
+              </div>
+              <div class="prettyblock-faq-content">
+                {if $state.question}
+                  <h3 class="prettyblock-faq-question h4 fw-semibold mb-3">{$state.question|escape:'htmlall':'UTF-8'}</h3>
+                {/if}
+                {if $state.answer}
+                  <div class="prettyblock-faq-answer text-body-secondary mb-3">{$state.answer nofilter}</div>
+                {/if}
+                {if $state.link_url}
+                  <a class="prettyblock-faq-link d-inline-flex align-items-center fw-semibold" href="{$state.link_url|escape:'htmlall':'UTF-8'}">
+                    <span>{$state.link_label|default:$module->l('Learn more')|escape:'htmlall':'UTF-8'}</span>
+                    <span class="ms-2" aria-hidden="true">&rarr;</span>
+                  </a>
+                {/if}
+              </div>
+            </article>
+          {/foreach}
+        </div>
+      {/if}
+
+      {if $block.settings.cta_link}
+        <div class="mt-4 text-center">
+          <a class="btn btn-dark rounded-pill px-4 py-3 prettyblock-faq-cta" href="{$block.settings.cta_link|escape:'htmlall':'UTF-8'}">
+            {$block.settings.cta_text|escape:'htmlall':'UTF-8'}
+          </a>
+        </div>
+      {/if}
+
+      {if isset($block.states) && $block.states}
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": [
+              {assign var='faq_entity_index' value=0}
+              {foreach from=$block.states item=state}
+                {if $state.question && $state.answer}
+                  {if $faq_entity_index gt 0},{/if}
+                  {
+                    "@type": "Question",
+                    "name": "{$state.question|escape:'javascript'}",
+                    "acceptedAnswer": {
+                      "@type": "Answer",
+                      "text": "{$state.answer|strip_tags|escape:'javascript'}"
+                    }
+                  }
+                  {assign var='faq_entity_index' value=$faq_entity_index+1}
+                {/if}
+              {/foreach}
+            ]
+          }
+        </script>
+      {/if}
+    </div>
+  </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- embed schema.org FAQPage structured data into the Prettyblock FAQ template
- ensure questions and answers are sanitized for JSON-LD output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936afa49e948322b6542c942673ba80)