### PR TITLE
Update reassurance block configuration

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -644,13 +644,8 @@ class EverblockPrettyBlocks
                 'templates' => [
                     'default' => $reassuranceTemplate,
                 ],
-                'settings' => [
-                    'default' => [
-                        'display_inline' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Display reassurances side by side'),
-                            'default' => true,
-                        ],
+                'config' => [
+                    'fields' => [
                         'items_per_row' => [
                             'type' => 'select',
                             'label' => $module->l('Reassurances per row'),
@@ -661,18 +656,6 @@ class EverblockPrettyBlocks
                                 '4' => $module->l('4 items per row'),
                                 '5' => $module->l('5 items per row'),
                                 '6' => $module->l('6 items per row'),
-                            ],
-                            'default' => '3',
-                        ],
-                        'columns' => [
-                            'type' => 'select',
-                            'label' => $module->l('Number of columns per row'),
-                            'choices' => [
-                                '1' => $module->l('1 column'),
-                                '2' => $module->l('2 columns'),
-                                '3' => $module->l('3 columns'),
-                                '4' => $module->l('4 columns'),
-                                '6' => $module->l('6 columns'),
                             ],
                             'default' => '3',
                         ],


### PR DESCRIPTION
## Summary
- move the reassurance block layout options under `config` like other blocks
- remove the unused `columns` option and rely solely on `items_per_row`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c85c869083229e0cfc875170f794)