### PR TITLE
Ensure reassurance block uses default column count

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -18,7 +18,7 @@
 
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 
-{assign var='reassuranceColumns' value=$block.settings.items_per_row|default:$block.settings.default.items_per_row|default:$block.settings.columns|default:$block.settings.default.columns|default:0|intval}
+{assign var='reassuranceColumns' value=$block.settings.items_per_row|default:$block.settings.default.items_per_row|default:$block.settings.columns|default:$block.settings.default.columns|default:3|intval}
 {assign var='reassuranceColumnClass' value=''}
 {if $reassuranceColumns > 0}
   {math assign="reassuranceColumnWidth" equation="12 / x" x=$reassuranceColumns format="%.0f"}


### PR DESCRIPTION
## Summary
- ensure reassurance items fall back to a default column count when the configured value is missing so repeaters stay aligned

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936eba8379c8322973b51f4ad2c59f1)