### PR TITLE
Add configurable front pages management

### DIFF
--- a/controllers/admin/AdminEverBlockPageController.php
+++ b/controllers/admin/AdminEverBlockPageController.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockPage.php';
+
+use Everblock\Tools\Service\EverblockTools;
+use Everblock\Tools\Service\EverblockCache;
+
+class AdminEverBlockPageController extends ModuleAdminController
+{
+    protected $delete_mode = 'physical';
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->lang = true;
+        $this->table = 'everblock_page';
+        $this->className = 'EverblockPage';
+        $this->identifier = 'id_everblock_page';
+        $this->context = Context::getContext();
+
+        $this->_select = 'pl.name, pl.title';
+        $this->_join = 'LEFT JOIN `' . _DB_PREFIX_ . 'everblock_page_lang` pl ON (pl.`id_everblock_page` = a.`id_everblock_page` AND pl.`id_lang` = ' . (int) $this->context->language->id . ')';
+
+        $this->fields_list = [
+            'id_everblock_page' => [
+                'title' => $this->l('ID'),
+                'align' => 'left',
+                'width' => 40,
+            ],
+            'name' => [
+                'title' => $this->l('Name'),
+                'align' => 'left',
+            ],
+            'title' => [
+                'title' => $this->l('Meta title'),
+                'align' => 'left',
+            ],
+            'id_shop' => [
+                'title' => $this->l('Shop'),
+                'align' => 'left',
+            ],
+            'active' => [
+                'title' => $this->l('Status'),
+                'type' => 'bool',
+                'active' => 'status',
+                'class' => 'fixed-width-sm',
+            ],
+            'date_add' => [
+                'title' => $this->l('Date add'),
+            ],
+            'date_upd' => [
+                'title' => $this->l('Date upd'),
+            ],
+        ];
+
+        $this->bulk_actions = [
+            'delete' => [
+                'text' => $this->l('Delete selected'),
+                'confirm' => $this->l('Delete selected items?'),
+                'icon' => 'icon-trash',
+            ],
+        ];
+
+        EverblockTools::checkAndFixDatabase();
+
+        parent::__construct();
+    }
+
+    public function setMedia($isNewTheme = false)
+    {
+        parent::setMedia($isNewTheme);
+        $this->addCSS(_PS_MODULE_DIR_ . 'everblock/views/css/ever.css');
+    }
+
+    public function l($string, $class = null, $addslashes = false, $htmlentities = true)
+    {
+        return Context::getContext()->getTranslator()->trans(
+            $string,
+            [],
+            'Modules.Everblock.Admineverblockpagecontroller'
+        );
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        $this->page_header_toolbar_btn['new'] = [
+            'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
+            'desc' => $this->l('Add new page'),
+            'icon' => 'process-icon-new',
+        ];
+        $module_link  = 'index.php?controller=AdminModules&configure=everblock&token=';
+        $module_link .= Tools::getAdminTokenLite('AdminModules');
+        $this->page_header_toolbar_btn['configuration'] = [
+            'href' => $module_link,
+            'desc' => $this->l('Configuration'),
+            'icon' => 'process-icon-save',
+        ];
+
+        parent::initPageHeaderToolbar();
+    }
+
+    public function renderForm()
+    {
+        if (!($obj = $this->loadObject(true))) {
+            return '';
+        }
+
+        $coverImage = false;
+        if ($obj->id && $obj->cover_image) {
+            $coverImage = _MODULE_DIR_ . 'everblock/views/img/pages/' . $obj->cover_image;
+        }
+
+        $this->fields_form = [
+            'legend' => [
+                'title' => $this->l('Page'),
+            ],
+            'input' => [
+                [
+                    'type' => 'switch',
+                    'label' => $this->l('Enabled'),
+                    'name' => 'active',
+                    'is_bool' => true,
+                    'values' => [
+                        [
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->l('Enabled'),
+                        ],
+                        [
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->l('Disabled'),
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Page name'),
+                    'name' => 'name',
+                    'lang' => true,
+                    'required' => true,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Meta title'),
+                    'name' => 'title',
+                    'lang' => true,
+                    'required' => true,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Meta description'),
+                    'name' => 'meta_description',
+                    'lang' => true,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Friendly URL'),
+                    'name' => 'link_rewrite',
+                    'lang' => true,
+                    'hint' => $this->l('If empty, it will be generated from the page name'),
+                ],
+                [
+                    'type' => 'textarea',
+                    'autoload_rte' => true,
+                    'label' => $this->l('Content'),
+                    'name' => 'content',
+                    'lang' => true,
+                    'required' => true,
+                    'desc' => $this->l('Content can include PrettyBlocks zones when the module is installed.'),
+                ],
+                [
+                    'type' => 'file',
+                    'label' => $this->l('Featured image'),
+                    'name' => 'cover_image',
+                    'display_image' => true,
+                    'image' => $coverImage,
+                    'hint' => $this->l('Large hero image displayed on the front-office page'),
+                ],
+                [
+                    'type' => 'group',
+                    'label' => $this->l('Allowed customer groups'),
+                    'name' => 'groupBox',
+                    'values' => Group::getGroups($this->context->language->id),
+                    'hint' => $this->l('If no group is selected, the page will be visible to everyone.'),
+                ],
+            ],
+            'submit' => [
+                'title' => $this->l('Save'),
+            ],
+        ];
+
+        return parent::renderForm();
+    }
+
+    public function postProcess()
+    {
+        parent::postProcess();
+
+        if (Tools::isSubmit('submitAdd' . $this->table) || Tools::isSubmit('submitAdd' . $this->table . 'AndStay')) {
+            $page = new EverblockPage((int) Tools::getValue($this->identifier));
+            $page->id_shop = (int) $this->context->shop->id;
+            $page->active = (int) Tools::getValue('active');
+            $page->groups = json_encode($this->getSelectedGroups());
+
+            foreach (Language::getLanguages(false) as $language) {
+                $langId = (int) $language['id_lang'];
+                $page->name[$langId] = Tools::getValue('name_' . $langId);
+                $page->title[$langId] = Tools::getValue('title_' . $langId);
+                $page->meta_description[$langId] = Tools::getValue('meta_description_' . $langId);
+                $rewrite = Tools::getValue('link_rewrite_' . $langId);
+                if (!$rewrite) {
+                    $rewrite = Tools::getValue('name_' . $langId);
+                }
+                $page->link_rewrite[$langId] = Tools::link_rewrite($rewrite);
+                $page->content[$langId] = Tools::getValue('content_' . $langId, false);
+            }
+
+            $upload = $this->handleImageUpload();
+            if ($upload !== false) {
+                $page->cover_image = $upload;
+            }
+
+            if (!count($this->errors)) {
+                if (!$page->save()) {
+                    $this->errors[] = $this->l('Cannot save the page.');
+                } else {
+                    EverblockCache::cacheDropByPattern('EverblockPage_');
+                    Tools::clearAllCache();
+                }
+            }
+        }
+
+        if (Tools::isSubmit('deleteeverblock_page') || Tools::isSubmit('submitBulkdeleteeverblock_page')) {
+            EverblockCache::cacheDropByPattern('EverblockPage_');
+            Tools::clearAllCache();
+        }
+
+        if (Tools::isSubmit('status' . $this->table)
+            || Tools::isSubmit('submitBulkenableSelection')
+            || Tools::isSubmit('submitBulkdisableSelection')
+        ) {
+            EverblockCache::cacheDropByPattern('EverblockPage_');
+            Tools::clearAllCache();
+        }
+    }
+
+    protected function getSelectedGroups(): array
+    {
+        $groups = Tools::getValue('groupBox');
+        if (!is_array($groups)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_map('intval', $groups)));
+    }
+
+    protected function handleImageUpload()
+    {
+        if (!isset($_FILES['cover_image']) || empty($_FILES['cover_image']['tmp_name'])) {
+            return false;
+        }
+
+        $uploader = new HelperUploader('cover_image');
+        $uploader->setAcceptTypes(['jpg', 'jpeg', 'png', 'gif']);
+        $uploader->setSavePath(_PS_MODULE_DIR_ . 'everblock/views/img/pages/');
+        $uploader->setMaxSize((int) Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024);
+        $files = $uploader->process($_FILES['cover_image']);
+
+        if (!is_array($files) || empty($files[0]['save_path'])) {
+            $this->errors[] = $this->l('Unable to upload the featured image.');
+
+            return false;
+        }
+
+        return basename($files[0]['save_path']);
+    }
+}

--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockPage.php';
+
+class EverblockPageModuleFrontController extends ModuleFrontController
+{
+    public function init()
+    {
+        parent::init();
+        $this->page_name = 'everblock-page';
+    }
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $pageId = (int) Tools::getValue('id_everblock_page');
+        $rewrite = Tools::getValue('rewrite');
+        $customerGroups = EverblockPage::getCustomerGroups($this->context);
+
+        $page = EverblockPage::getById($pageId, (int) $this->context->language->id, (int) $this->context->shop->id);
+        if (!$page || !$page->active || !EverblockPage::isGroupAllowed($page, $customerGroups)) {
+            Tools::redirect('index.php?controller=404');
+
+            return;
+        }
+
+        $expectedRewrite = $page->link_rewrite[(int) $this->context->language->id] ?? '';
+        if ($expectedRewrite && $rewrite && $rewrite !== $expectedRewrite) {
+            Tools::redirect($this->context->link->getModuleLink(
+                $this->module->name,
+                'page',
+                [
+                    'id_everblock_page' => (int) $page->id,
+                    'rewrite' => $expectedRewrite,
+                ]
+            ));
+        }
+
+        $metaDescription = $page->meta_description[(int) $this->context->language->id] ?? '';
+
+        $renderedContent = $page->content[(int) $this->context->language->id] ?? '';
+        if ($this->isPrettyBlocksEnabled()) {
+            $renderedContent = $this->context->smarty->fetch('string:' . $renderedContent);
+        }
+
+        $this->context->smarty->assign([
+            'everblock_page' => $page,
+            'everblock_page_content' => $renderedContent,
+            'everblock_page_image' => $page->cover_image ? _MODULE_DIR_ . 'everblock/views/img/pages/' . $page->cover_image : '',
+            'everblock_lang_id' => (int) $this->context->language->id,
+        ]);
+
+        $this->setTemplate('module:everblock/views/templates/front/page.tpl');
+
+        $this->setTemplateMeta($page->title[(int) $this->context->language->id] ?? '', $metaDescription);
+    }
+
+    protected function setTemplateMeta(string $title, string $description): void
+    {
+        $this->context->smarty->assign('meta_description', $description);
+        $this->context->smarty->assign('meta_title', $title);
+        $this->context->smarty->assign('meta_robots', 'index,follow');
+    }
+
+    protected function isPrettyBlocksEnabled(): bool
+    {
+        return (bool) Module::isInstalled('prettyblocks') === true
+            && (bool) Module::isEnabled('prettyblocks') === true
+            && (bool) Everblock\Tools\Service\EverblockTools::moduleDirectoryExists('prettyblocks') === true;
+    }
+}

--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once _PS_MODULE_DIR_ . 'everblock/models/EverblockPage.php';
+
+class EverblockPagesModuleFrontController extends ModuleFrontController
+{
+    public function initContent()
+    {
+        parent::initContent();
+
+        $customerGroups = EverblockPage::getCustomerGroups($this->context);
+        $pages = EverblockPage::getPages(
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id,
+            true,
+            $customerGroups
+        );
+
+        $pageLinks = [];
+        foreach ($pages as $page) {
+            $pageLinks[(int) $page->id] = $this->context->link->getModuleLink(
+                $this->module->name,
+                'page',
+                [
+                    'id_everblock_page' => (int) $page->id,
+                    'rewrite' => $page->link_rewrite[(int) $this->context->language->id] ?? '',
+                ]
+            );
+        }
+
+        $this->context->smarty->assign([
+            'everblock_pages' => $pages,
+            'everblock_page_links' => $pageLinks,
+            'everblock_lang_id' => (int) $this->context->language->id,
+        ]);
+
+        $this->setTemplate('module:everblock/views/templates/front/pages.tpl');
+    }
+}

--- a/models/EverblockPage.php
+++ b/models/EverblockPage.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+use Everblock\Tools\Service\EverblockCache;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverblockPage extends ObjectModel
+{
+    public $id_everblock_page;
+    public $id_shop;
+    public $groups;
+    public $active;
+    public $cover_image;
+    public $date_add;
+    public $date_upd;
+
+    public $name;
+    public $title;
+    public $meta_description;
+    public $link_rewrite;
+    public $content;
+
+    public static $definition = [
+        'table' => 'everblock_page',
+        'primary' => 'id_everblock_page',
+        'multilang' => true,
+        'fields' => [
+            'id_shop' => [
+                'type' => self::TYPE_INT,
+                'lang' => false,
+                'validate' => 'isUnsignedInt',
+                'required' => true,
+            ],
+            'groups' => [
+                'type' => self::TYPE_STRING,
+                'lang' => false,
+                'validate' => 'isString',
+                'required' => false,
+            ],
+            'active' => [
+                'type' => self::TYPE_BOOL,
+                'lang' => false,
+                'validate' => 'isBool',
+                'required' => false,
+                'default' => 1,
+            ],
+            'cover_image' => [
+                'type' => self::TYPE_STRING,
+                'lang' => false,
+                'validate' => 'isFileName',
+                'required' => false,
+            ],
+            'date_add' => [
+                'type' => self::TYPE_DATE,
+                'lang' => false,
+                'validate' => 'isDateFormat',
+            ],
+            'date_upd' => [
+                'type' => self::TYPE_DATE,
+                'lang' => false,
+                'validate' => 'isDateFormat',
+            ],
+            'name' => [
+                'type' => self::TYPE_STRING,
+                'lang' => true,
+                'validate' => 'isGenericName',
+                'required' => true,
+            ],
+            'title' => [
+                'type' => self::TYPE_STRING,
+                'lang' => true,
+                'validate' => 'isGenericName',
+                'required' => true,
+            ],
+            'meta_description' => [
+                'type' => self::TYPE_STRING,
+                'lang' => true,
+                'validate' => 'isCleanHtml',
+                'required' => false,
+            ],
+            'link_rewrite' => [
+                'type' => self::TYPE_STRING,
+                'lang' => true,
+                'validate' => 'isLinkRewrite',
+                'required' => true,
+            ],
+            'content' => [
+                'type' => self::TYPE_HTML,
+                'lang' => true,
+                'validate' => 'isCleanHtml',
+                'required' => true,
+            ],
+        ],
+    ];
+
+    protected static function resolveShopId(?int $shopId = null): int
+    {
+        if ($shopId) {
+            return (int) $shopId;
+        }
+
+        return (int) Context::getContext()->shop->id;
+    }
+
+    public function getAllowedGroups(): array
+    {
+        if (!$this->groups) {
+            return [];
+        }
+
+        $decoded = json_decode($this->groups, true);
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_map('intval', $decoded)));
+    }
+
+    public function save($nullValues = false, $autoDate = true, $useCache = true)
+    {
+        $this->id_shop = static::resolveShopId((int) $this->id_shop);
+        $this->sanitizeLinkRewrite();
+
+        return parent::save($nullValues, $autoDate, $useCache);
+    }
+
+    public static function getPages(int $langId, ?int $shopId = null, bool $onlyActive = true, array $allowedGroups = []): array
+    {
+        $shopId = static::resolveShopId($shopId);
+        $cacheId = 'EverblockPage_getPages_' . (int) $langId . '_' . (int) $shopId . '_' . (int) $onlyActive . '_' . md5(json_encode($allowedGroups));
+
+        if (EverblockCache::isCacheStored($cacheId)) {
+            return EverblockCache::cacheRetrieve($cacheId);
+        }
+
+        $sql = new DbQuery();
+        $sql->select('p.*, pl.*');
+        $sql->from(self::$definition['table'], 'p');
+        $sql->innerJoin(self::$definition['table'] . '_lang', 'pl', 'p.id_everblock_page = pl.id_everblock_page AND pl.id_lang = ' . (int) $langId);
+        $sql->where('p.id_shop = ' . (int) $shopId);
+
+        if ($onlyActive) {
+            $sql->where('p.active = 1');
+        }
+
+        $sql->orderBy('p.date_add DESC');
+
+        $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        $pages = [];
+        foreach ($rows as $row) {
+            $page = new self((int) $row[self::$definition['primary']], (int) $langId, (int) $shopId);
+            if (!static::isGroupAllowed($page, $allowedGroups)) {
+                continue;
+            }
+            $pages[] = $page;
+        }
+
+        EverblockCache::cacheStore($cacheId, $pages);
+
+        return $pages;
+    }
+
+    public static function getById(int $pageId, int $langId, ?int $shopId = null): ?self
+    {
+        $shopId = static::resolveShopId($shopId);
+        $cacheId = 'EverblockPage_getById_' . (int) $pageId . '_' . (int) $langId . '_' . (int) $shopId;
+
+        if (EverblockCache::isCacheStored($cacheId)) {
+            return EverblockCache::cacheRetrieve($cacheId);
+        }
+
+        $page = new self($pageId, $langId, $shopId);
+        if (!Validate::isLoadedObject($page)) {
+            EverblockCache::cacheStore($cacheId, null);
+
+            return null;
+        }
+
+        EverblockCache::cacheStore($cacheId, $page);
+
+        return $page;
+    }
+
+    public static function isGroupAllowed(self $page, array $customerGroups = []): bool
+    {
+        $allowed = $page->getAllowedGroups();
+        if (empty($allowed)) {
+            return true;
+        }
+
+        return !empty(array_intersect($allowed, $customerGroups));
+    }
+
+    protected function sanitizeLinkRewrite(): void
+    {
+        foreach (Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $rewrite = $this->link_rewrite[$langId] ?? '';
+            $name = $this->name[$langId] ?? '';
+            if (!$rewrite) {
+                $rewrite = $name;
+            }
+            $this->link_rewrite[$langId] = Tools::link_rewrite((string) $rewrite);
+        }
+    }
+
+    public static function getCustomerGroups(Context $context): array
+    {
+        if ($context->customer && $context->customer->id) {
+            return Customer::getGroupsStatic((int) $context->customer->id);
+        }
+
+        $groups = [];
+        $groups[] = (int) Configuration::get('PS_UNIDENTIFIED_GROUP');
+        $groups[] = (int) Configuration::get('PS_GUEST_GROUP');
+        $groups[] = (int) Configuration::get('PS_CUSTOMER_GROUP');
+
+        return array_values(array_unique(array_filter($groups)));
+    }
+}

--- a/sql/install.php
+++ b/sql/install.php
@@ -172,6 +172,29 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_game_play` (
         PRIMARY KEY (`id_everblock_game_play`))
         ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
+// Pages
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_page` (
+        `id_everblock_page` int(10) unsigned NOT NULL auto_increment,
+        `id_shop` int(10) unsigned NOT NULL DEFAULT 1,
+        `groups` text DEFAULT NULL,
+        `cover_image` varchar(255) DEFAULT NULL,
+        `active` int(10) unsigned NOT NULL DEFAULT 1,
+        `date_add` DATETIME DEFAULT NULL,
+        `date_upd` DATETIME DEFAULT NULL,
+        PRIMARY KEY (`id_everblock_page`, `id_shop`)
+    ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_page_lang` (
+        `id_everblock_page` int(10) unsigned NOT NULL,
+        `id_lang` int(10) unsigned NOT NULL,
+        `name` varchar(255) DEFAULT NULL,
+        `title` varchar(255) DEFAULT NULL,
+        `meta_description` text DEFAULT NULL,
+        `link_rewrite` varchar(255) DEFAULT NULL,
+        `content` text DEFAULT NULL,
+        PRIMARY KEY (`id_everblock_page`, `id_lang`)
+    ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+
 foreach ($sql as $s) {
     if (!Db::getInstance()->execute($s)) {
         return false;

--- a/sql/uninstall.php
+++ b/sql/uninstall.php
@@ -37,6 +37,8 @@ $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_flags_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_modal`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_modal_lang`;';
 $sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_game_play`;';
+$sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_page`;';
+$sql[] = 'DROP TABLE IF EXISTS `' . _DB_PREFIX_ . 'everblock_page_lang`;';
 
 foreach ($sql as $s) {
     if (!Db::getInstance()->execute($s)) {

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4541,6 +4541,8 @@ class EverblockTools extends ObjectModel
             _DB_PREFIX_ . 'everblock_modal',
             _DB_PREFIX_ . 'everblock_modal_lang',
             _DB_PREFIX_ . 'everblock_game_play',
+            _DB_PREFIX_ . 'everblock_page',
+            _DB_PREFIX_ . 'everblock_page_lang',
         ];
         $tableExists = false;
         foreach ($tableNames as $tableName) {
@@ -4768,6 +4770,46 @@ class EverblockTools extends ObjectModel
                     $db->execute($query);
                 } catch (Exception $e) {
                     PrestaShopLogger::addLog('Unable to update Ever Block game play database');
+                }
+            }
+        }
+        // Ajoute les colonnes manquantes à la table everblock_page
+        $columnsToAdd = [
+            'id_shop' => 'int(10) unsigned NOT NULL DEFAULT 1',
+            'groups' => 'text DEFAULT NULL',
+            'cover_image' => 'varchar(255) DEFAULT NULL',
+            'active' => 'int(10) unsigned NOT NULL DEFAULT 1',
+            'date_add' => 'DATETIME DEFAULT NULL',
+            'date_upd' => 'DATETIME DEFAULT NULL',
+        ];
+        foreach ($columnsToAdd as $columnName => $columnDefinition) {
+            $columnExists = $db->ExecuteS('DESCRIBE `' . _DB_PREFIX_ . 'everblock_page` `' . pSQL($columnName) . '`');
+            if (!$columnExists) {
+                try {
+                    $query = 'ALTER TABLE `' . _DB_PREFIX_ . 'everblock_page` ADD `' . pSQL($columnName) . '` ' . $columnDefinition;
+                    $db->execute($query);
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('Unable to update Ever Block page database');
+                }
+            }
+        }
+        // Ajoute les colonnes manquantes à la table everblock_page_lang
+        $columnsToAdd = [
+            'id_lang' => 'int(10) unsigned NOT NULL',
+            'name' => 'varchar(255) DEFAULT NULL',
+            'title' => 'varchar(255) DEFAULT NULL',
+            'meta_description' => 'text DEFAULT NULL',
+            'link_rewrite' => 'varchar(255) DEFAULT NULL',
+            'content' => 'text DEFAULT NULL',
+        ];
+        foreach ($columnsToAdd as $columnName => $columnDefinition) {
+            $columnExists = $db->ExecuteS('DESCRIBE `' . _DB_PREFIX_ . 'everblock_page_lang` `' . pSQL($columnName) . '`');
+            if (!$columnExists) {
+                try {
+                    $query = 'ALTER TABLE `' . _DB_PREFIX_ . 'everblock_page_lang` ADD `' . pSQL($columnName) . '` ' . $columnDefinition;
+                    $db->execute($query);
+                } catch (Exception $e) {
+                    PrestaShopLogger::addLog('Unable to update Ever Block page lang database');
                 }
             }
         }

--- a/views/img/pages/index.php
+++ b/views/img/pages/index.php
@@ -1,0 +1,1 @@
+<?php\n// Silence is golden

--- a/views/templates/admin/config/docs/pages.tpl
+++ b/views/templates/admin/config/docs/pages.tpl
@@ -1,0 +1,6 @@
+<div class="panel">
+  <div class="panel-heading">{l s='Pages settings' mod='everblock' d='Modules.Everblock.Config'}</div>
+  <div class="panel-body">
+    <p>{l s='Define the base URL used for the front-office guide pages and access the dedicated pages manager tab to create new content.' mod='everblock' d='Modules.Everblock.Config'}</p>
+  </div>
+</div>

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -1,0 +1,21 @@
+{extends file='page.tpl'}
+
+{block name='page_title'}
+  {$everblock_page->title[$everblock_lang_id] ?? ''}
+{/block}
+
+{block name='page_content'}
+  <article class="everblock-page" itemscope itemtype="https://schema.org/Article">
+    <header class="everblock-page__header">
+      <h1 itemprop="headline">{$everblock_page->name[$everblock_lang_id] ?? ''}</h1>
+      {if $everblock_page_image}
+        <figure class="everblock-page__cover">
+          <img src="{$everblock_page_image}" alt="{$everblock_page->title[$everblock_lang_id]|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
+        </figure>
+      {/if}
+    </header>
+    <div class="everblock-page__content rte" itemprop="articleBody">
+      {$everblock_page_content nofilter}
+    </div>
+  </article>
+{/block}

--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -1,0 +1,26 @@
+{extends file='page.tpl'}
+
+{block name='page_title'}
+  {$smarty.block.parent}
+{/block}
+
+{block name='page_content'}
+  <section class="everblock-pages-list">
+    {if $everblock_pages|@count}
+      <ul class="everblock-pages">
+        {foreach from=$everblock_pages item=page}
+          <li class="everblock-page-item">
+            <a href="{$everblock_page_links[$page->id]|escape:'htmlall':'UTF-8'}" class="everblock-page-link">
+              <h2 class="h4">{$page->name[$everblock_lang_id] ?? ''}</h2>
+              {if $page->meta_description[$everblock_lang_id]}
+                <p class="everblock-page-excerpt">{$page->meta_description[$everblock_lang_id]|truncate:180:'...':true}</p>
+              {/if}
+            </a>
+          </li>
+        {/foreach}
+      </ul>
+    {else}
+      <p class="alert alert-info">{l s='No page available yet.' mod='everblock' d='Modules.Everblock.Front'}</p>
+    {/if}
+  </section>
+{/block}


### PR DESCRIPTION
## Summary
- add a new EverblockPage model with database schema and admin tab for managing multilingual guide pages
- expose configurable base URL and routes plus front controllers/templates to list and display pages with group-based access
- ensure database checks, configuration UI, and assets support the new pages feature

## Testing
- php -l controllers/admin/AdminEverBlockPageController.php
- php -l controllers/front/pages.php
- php -l controllers/front/page.php
- php -l models/EverblockPage.php
- php -l everblock.php
- php -l src/Service/EverblockTools.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e057a4ac8322848b9d95e7659141)