### PR TITLE
Fix Smarty template default for page titles

### DIFF
--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -11,7 +11,7 @@
         {foreach from=$everblock_pages item=page}
           <li class="everblock-page-item">
             <a href="{$everblock_page_links[$page->id]|escape:'htmlall':'UTF-8'}" class="everblock-page-link">
-              <h2 class="h4">{$page->name[$everblock_lang_id] ?? ''}</h2>
+              <h2 class="h4">{$page->name[$everblock_lang_id]|default:''}</h2>
               {if $page->meta_description[$everblock_lang_id]}
                 <p class="everblock-page-excerpt">{$page->meta_description[$everblock_lang_id]|truncate:180:'...':true}</p>
               {/if}


### PR DESCRIPTION
## Summary
- replace unsupported null coalescing operator with Smarty default filter for page title
- ensure page titles render without syntax errors when language value missing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e6ba4bbc8322beb0bdac0151732e)