### PR TITLE
Add Prettyblock pages guide block

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -332,6 +332,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl',
     'views/templates/hook/prettyblocks/prettyblock_podcasts.tpl',
     'views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl',
     'views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl',
     'views/templates/hook/prettyblocks/prettyblock_product_selector.tpl',
     'views/templates/hook/prettyblocks/prettyblock_reassurance.tpl',

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -159,6 +159,7 @@ class EverblockPrettyBlocks
             $wheelTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl';
             $mysteryBoxesTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl';
             $slotMachineTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_slot_machine.tpl';
+            $pagesGuideTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl';
             $slotMachineDefaultStartDate = date('Y-m-d 00:00:00');
             $slotMachineDefaultEndDate = date('Y-m-d 23:59:59', strtotime('+30 days'));
             $slotMachineDefaultWinningCombinations = json_encode(
@@ -3018,6 +3019,87 @@ class EverblockPrettyBlocks
                         'answers' => [
                             'type' => 'textarea',
                             'label' => $module->l('Answers (one per line: "Answer label|Answer link")'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Guide pages'),
+                'description' => $module->l('Display a curated list of CMS pages'),
+                'code' => 'everblock_pages_guide',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $pagesGuideTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Block title'),
+                            'default' => $module->l('Our guides'),
+                        ],
+                        'description' => [
+                            'type' => 'editor',
+                            'label' => $module->l('Introduction'),
+                            'default' => '',
+                        ],
+                        'desktop_columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns on desktop'),
+                            'choices' => static::getColumnChoices($module),
+                            'default' => '3',
+                        ],
+                        'tablet_columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns on tablet'),
+                            'choices' => static::getColumnChoices($module),
+                            'default' => '2',
+                        ],
+                        'mobile_columns' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns on mobile'),
+                            'choices' => static::getColumnChoices($module),
+                            'default' => '1',
+                        ],
+                    ], $module),
+                ],
+                'repeater' => [
+                    'name' => 'Page',
+                    'nameFrom' => 'title',
+                    'groups' => static::appendSpacingFields([
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Page title (optional)'),
+                            'default' => '',
+                        ],
+                        'page' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Choose a CMS page'),
+                            'collection' => 'CmsPage',
+                            'selector' => '{id} - {meta_title}',
+                            'default' => '',
+                        ],
+                        'summary' => [
+                            'type' => 'textarea',
+                            'label' => $module->l('Summary'),
+                            'default' => '',
+                        ],
+                        'cta_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('CTA label'),
+                            'default' => $module->l('Read more'),
+                        ],
+                        'target_blank' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Open in a new tab'),
+                            'default' => 0,
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
                     ], $module),

--- a/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
@@ -1,0 +1,70 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_pages_guide_spacing_style'}
+
+{assign var='desktop_columns' value=$block.settings.desktop_columns|default:3}
+{assign var='tablet_columns' value=$block.settings.tablet_columns|default:2}
+{assign var='mobile_columns' value=$block.settings.mobile_columns|default:1}
+
+<div id="block-{$block.id_prettyblocks}" class="prettyblock-pages-guide{if $block.settings.default.force_full_width} container-fluid px-0 mx-0{elseif $block.settings.default.container} container{/if}{$prettyblock_visibility_class}" style="{$prettyblock_pages_guide_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  <div class="mt-2{if $block.settings.default.container} container{/if}">
+    {if $block.settings.title}
+      <h2 class="mb-3">{$block.settings.title|escape:'htmlall':'UTF-8'}</h2>
+    {/if}
+    {if $block.settings.description}
+      <div class="mb-4">{$block.settings.description nofilter}</div>
+    {/if}
+    {if isset($block.states) && $block.states}
+      <div class="row row-cols-{$mobile_columns|intval} row-cols-sm-{$tablet_columns|intval} row-cols-md-{$desktop_columns|intval} row-cols-lg-{$desktop_columns|intval}">
+        {foreach from=$block.states item=state key=key}
+          {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_pages_guide_state_spacing_style'}
+          {assign var='page_id' value=$state.page.id|default:null}
+          {assign var='page_link' value='#'}
+          {if $page_id}
+            {assign var='page_link' value=Context::getContext()->link->getCMSLink($page_id)}
+          {/if}
+          {assign var='page_title' value=$state.title|default:$state.page.meta_title|default:''}
+          <div class="col mb-4">
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="prettyblock-guide-card h-100{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_pages_guide_state_spacing_style}">
+              {if $page_title}
+                <h3 class="h5">{$page_title|escape:'htmlall':'UTF-8'}</h3>
+              {/if}
+              {if $state.summary}
+                <div class="mb-3">{$state.summary nofilter}</div>
+              {/if}
+              {if $page_link && $state.cta_text}
+                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary"{if $state.target_blank} target="_blank" rel="noopener"{/if}>
+                  {$state.cta_text|escape:'htmlall':'UTF-8'}
+                </a>
+              {/if}
+            </div>
+          </div>
+        {/foreach}
+      </div>
+    {/if}
+  </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add a Prettyblock configuration for displaying selected CMS guide pages
- render the guide pages with a new template using configurable columns and CTA labels
- allow the new template file through the module whitelist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e6fbad74832292c8223d97f68aac)