### PR TITLE
Store guide page covers in shared img directory

### DIFF
--- a/controllers/admin/AdminEverBlockPageController.php
+++ b/controllers/admin/AdminEverBlockPageController.php
@@ -136,7 +136,7 @@ class AdminEverBlockPageController extends ModuleAdminController
 
         $coverImage = false;
         if ($obj->id && $obj->cover_image) {
-            $coverImage = _MODULE_DIR_ . 'everblock/views/img/pages/' . $obj->cover_image;
+            $coverImage = _PS_IMG_ . 'pages/' . $obj->cover_image;
         }
 
         $this->fields_form = [
@@ -310,9 +310,14 @@ class AdminEverBlockPageController extends ModuleAdminController
             return false;
         }
 
+        $destination = _PS_IMG_DIR_ . 'pages/';
+        if (!is_dir($destination)) {
+            @mkdir($destination, 0755, true);
+        }
+
         $uploader = new HelperUploader('cover_image');
         $uploader->setAcceptTypes(['jpg', 'jpeg', 'png', 'gif']);
-        $uploader->setSavePath(_PS_MODULE_DIR_ . 'everblock/views/img/pages/');
+        $uploader->setSavePath($destination);
         $uploader->setMaxSize((int) Configuration::get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024);
         $files = $uploader->process($_FILES['cover_image']);
 

--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -93,7 +93,9 @@ class EverblockPageModuleFrontController extends ModuleFrontController
         $this->context->smarty->assign([
             'everblock_page' => $page,
             'everblock_page_content' => $renderedContent,
-            'everblock_page_image' => $page->cover_image ? _MODULE_DIR_ . 'everblock/views/img/pages/' . $page->cover_image : '',
+            'everblock_page_image' => $page->cover_image
+                ? $this->context->link->getMediaLink(_PS_IMG_ . 'pages/' . $page->cover_image)
+                : '',
             'everblock_lang_id' => (int) $this->context->language->id,
             'everblock_structured_data' => $this->buildItemListStructuredData($pages, $pageLinks),
         ]);


### PR DESCRIPTION
## Summary
- save guide page cover uploads under the shared /img/pages directory instead of the module folder
- display existing cover images from the public img/pages path in both back-office preview and front rendering
- ensure the target directory exists before processing uploads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937eaa7b2cc8322b856e6fd71cb8fec)