### PR TITLE
Rename PrettyBlocks zone identifiers

### DIFF
--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -65,7 +65,9 @@ class EverblockPageModuleFrontController extends ModuleFrontController
         $metaDescription = $page->meta_description[(int) $this->context->language->id] ?? '';
 
         $renderedContent = $page->content[(int) $this->context->language->id] ?? '';
-        if ($this->isPrettyBlocksEnabled()) {
+        $isPrettyBlocksEnabled = $this->isPrettyBlocksEnabled();
+
+        if ($isPrettyBlocksEnabled) {
             $renderedContent = $this->context->smarty->fetch('string:' . $renderedContent);
         }
 
@@ -98,6 +100,8 @@ class EverblockPageModuleFrontController extends ModuleFrontController
                 : '',
             'everblock_lang_id' => (int) $this->context->language->id,
             'everblock_structured_data' => $this->buildItemListStructuredData($pages, $pageLinks),
+            'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
+            'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_page_zone_' . (int) $page->id : '',
         ]);
 
         $this->setTemplate('module:everblock/views/templates/front/page.tpl');

--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -51,12 +51,15 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
         }
 
         $structuredData = $this->buildItemListStructuredData($pages, $pageLinks);
+        $isPrettyBlocksEnabled = $this->isPrettyBlocksEnabled();
 
         $this->context->smarty->assign([
             'everblock_pages' => $pages,
             'everblock_page_links' => $pageLinks,
             'everblock_lang_id' => (int) $this->context->language->id,
             'everblock_structured_data' => $structuredData,
+            'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
+            'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone' : '',
         ]);
 
         $this->setTemplate('module:everblock/views/templates/front/pages.tpl');
@@ -107,5 +110,12 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
             'description' => $this->trans('Découvrez nos guides pratiques pour ...', [], 'Modules.Everblock.Front'),
             'itemListElement' => $elements,
         ];
+    }
+
+    protected function isPrettyBlocksEnabled(): bool
+    {
+        return (bool) Module::isInstalled('prettyblocks') === true
+            && (bool) Module::isEnabled('prettyblocks') === true
+            && (bool) Everblock\Tools\Service\EverblockTools::moduleDirectoryExists('prettyblocks') === true;
     }
 }

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -30,6 +30,10 @@
     </div>
   </article>
 
+  {if $everblock_prettyblocks_enabled}
+    {prettyblocks_zone zone_name=$everblock_prettyblocks_zone_name}
+  {/if}
+
   {if !empty($everblock_structured_data)}
     <script type="application/ld+json">
       {$everblock_structured_data|json_encode:$smarty.const.JSON_UNESCAPED_SLASHES|replace:'\/':'/' nofilter}

--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -38,6 +38,10 @@
     {/if}
   </section>
 
+  {if $everblock_prettyblocks_enabled}
+    {prettyblocks_zone zone_name=$everblock_prettyblocks_zone_name}
+  {/if}
+
   {if !empty($everblock_structured_data)}
     <script type="application/ld+json">
       {$everblock_structured_data|json_encode:$smarty.const.JSON_UNESCAPED_SLASHES|replace:'\/':'/' nofilter}


### PR DESCRIPTION
## Summary
- rename PrettyBlocks zone name for individual pages to `everblock_page_zone_{id}` for specificity
- adjust listing controller to use `everblock_pages_listing_zone` instead of a generic label

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ec596e9883228f0cc1a874a78e6f)