### PR TITLE
Remove heading tags from page titles in list

### DIFF
--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -11,7 +11,7 @@
         {foreach from=$everblock_pages item=page}
           <li class="everblock-page-item">
             <a href="{$everblock_page_links[$page->id]|escape:'htmlall':'UTF-8'}" class="everblock-page-link">
-              <h2 class="h4">{$page->name[$everblock_lang_id] ?? ''}</h2>
+              <span class="h4">{$page->name[$everblock_lang_id]|default:''|escape:'htmlall':'UTF-8'}</span>
               {if $page->short_description[$everblock_lang_id]}
                 <p class="everblock-page-excerpt">{$page->short_description[$everblock_lang_id]|strip_tags|truncate:180:'...':true}</p>
               {elseif $page->meta_description[$everblock_lang_id]}


### PR DESCRIPTION
## Summary
- replace h2 heading in the pages template with a span while keeping the h4 class
- ensure no heading tags remain in the pages list markup

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937edd761788322906adbdeec730a49)