### PR TITLE
Fix Smarty template defaults without null coalescing

### DIFF
--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -1,16 +1,16 @@
 {extends file='page.tpl'}
 
 {block name='page_title'}
-  {$everblock_page->title[$everblock_lang_id] ?? ''}
+  {$everblock_page->title[$everblock_lang_id]|default:''}
 {/block}
 
 {block name='page_content'}
   <article class="everblock-page" itemscope itemtype="https://schema.org/Article">
     <header class="everblock-page__header">
-      <h1 itemprop="headline">{$everblock_page->name[$everblock_lang_id] ?? ''}</h1>
+      <h1 itemprop="headline">{$everblock_page->name[$everblock_lang_id]|default:''}</h1>
       {if $everblock_page_image}
         <figure class="everblock-page__cover">
-          <img src="{$everblock_page_image}" alt="{$everblock_page->title[$everblock_lang_id]|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
+            <img src="{$everblock_page_image}" alt="{$everblock_page->title[$everblock_lang_id]|default:''|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
         </figure>
       {/if}
       {if $everblock_page->short_description[$everblock_lang_id]}


### PR DESCRIPTION
## Summary
- replace PHP null coalescing operator in Smarty template with `default` modifier to avoid syntax errors
- ensure page title, headline, and image alt text fall back to empty strings when missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937efc458448322ac22724bdaa22aa7)