### PR TITLE
Remove language id lookups from page templates

### DIFF
--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -94,7 +94,6 @@ class EverblockPageModuleFrontController extends ModuleFrontController
             'everblock_page_image' => $page->cover_image
                 ? $this->context->link->getMediaLink(_PS_IMG_ . 'pages/' . $page->cover_image)
                 : '',
-            'everblock_lang_id' => (int) $this->context->language->id,
             'everblock_structured_data' => $this->buildItemListStructuredData($pages, $pageLinks),
             'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
             'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_page_zone_' . (int) $page->id : '',

--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -56,7 +56,6 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
         $this->context->smarty->assign([
             'everblock_pages' => $pages,
             'everblock_page_links' => $pageLinks,
-            'everblock_lang_id' => (int) $this->context->language->id,
             'everblock_structured_data' => $structuredData,
             'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
             'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone' : '',

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -1,21 +1,21 @@
 {extends file='page.tpl'}
 
 {block name='page_title'}
-  {$everblock_page->title[$everblock_lang_id]|default:''}
+  {$everblock_page->title|default:''}
 {/block}
 
 {block name='page_content'}
   <article class="everblock-page" itemscope itemtype="https://schema.org/Article">
     <header class="everblock-page__header">
-      <h1 itemprop="headline">{$everblock_page->name[$everblock_lang_id]|default:''}</h1>
+      <h1 itemprop="headline">{$everblock_page->name|default:''}</h1>
       {if $everblock_page_image}
         <figure class="everblock-page__cover">
-            <img src="{$everblock_page_image}" alt="{$everblock_page->title[$everblock_lang_id]|default:''|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
+            <img src="{$everblock_page_image}" alt="{$everblock_page->title|default:''|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
         </figure>
       {/if}
-      {if $everblock_page->short_description[$everblock_lang_id]}
+      {if $everblock_page->short_description}
         <div class="everblock-page__intro rte" itemprop="description">
-          {$everblock_page->short_description[$everblock_lang_id] nofilter}
+          {$everblock_page->short_description nofilter}
         </div>
       {/if}
       {if $everblock_page->date_add}

--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -11,11 +11,11 @@
         {foreach from=$everblock_pages item=page}
           <li class="everblock-page-item">
             <a href="{$everblock_page_links[$page->id]|escape:'htmlall':'UTF-8'}" class="everblock-page-link">
-              <span class="h4">{$page->name[$everblock_lang_id]|default:''|escape:'htmlall':'UTF-8'}</span>
-              {if $page->short_description[$everblock_lang_id]}
-                <p class="everblock-page-excerpt">{$page->short_description[$everblock_lang_id]|strip_tags|truncate:180:'...':true}</p>
-              {elseif $page->meta_description[$everblock_lang_id]}
-                <p class="everblock-page-excerpt">{$page->meta_description[$everblock_lang_id]|truncate:180:'...':true}</p>
+              <span class="h4">{$page->name|default:''|escape:'htmlall':'UTF-8'}</span>
+              {if $page->short_description}
+                <p class="everblock-page-excerpt">{$page->short_description|strip_tags|truncate:180:'...':true}</p>
+              {elseif $page->meta_description}
+                <p class="everblock-page-excerpt">{$page->meta_description|truncate:180:'...':true}</p>
               {/if}
               <div class="everblock-page-meta">
                 {if $page->date_add}


### PR DESCRIPTION
## Summary
- remove language-specific array access from page templates now that controllers provide localized values
- drop unused Smarty assignment of `everblock_lang_id` from page controllers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f40e926c8322be632039ea6acf0f)