### PR TITLE
Enable Bootstrap modal for guide images

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -3315,6 +3315,29 @@ $(document).ready(function(){
         });
     }
 
+    var $everblockImageModal = $('#everblockImageModal');
+    if ($everblockImageModal.length) {
+        $(document).on('click', '.everblock-page__content img', function (event) {
+            var $clickedImage = $(this);
+            var imageSrc = $clickedImage.attr('src');
+            if (!imageSrc) {
+                return;
+            }
+            event.preventDefault();
+            var imageAlt = $clickedImage.attr('alt') || '';
+            var imageTitle = $clickedImage.attr('title') || imageAlt;
+            var $modalImage = $everblockImageModal.find('.everblock-image-modal__img');
+            $modalImage.attr('src', imageSrc).attr('alt', imageAlt);
+            var $caption = $everblockImageModal.find('.everblock-image-modal__caption');
+            if (imageTitle) {
+                $caption.text(imageTitle).removeClass('d-none');
+            } else {
+                $caption.addClass('d-none').text('');
+            }
+            $everblockImageModal.modal('show');
+        });
+    }
+
     // Exit intent modal
     var exitIntentShown = false;
     $(document).on('mouseout', function(e) {

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -30,9 +30,21 @@
     {prettyblocks_zone zone_name=$everblock_prettyblocks_zone_name}
   {/if}
 
+  <div class="modal fade everblock-image-modal" id="everblockImageModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-body position-relative p-0">
+          <button type="button" class="btn-close position-absolute end-0 top-0 m-3" data-bs-dismiss="modal" data-dismiss="modal" aria-label="{l s='Close' mod='everblock' d='Modules.Everblock.Front'}"></button>
+          <img src="" alt="" class="img-fluid w-100 everblock-image-modal__img" loading="lazy">
+          <p class="everblock-image-modal__caption px-4 pb-4 pt-3 mb-0 small text-center text-muted d-none"></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   {if !empty($everblock_structured_data)}
     <script type="application/ld+json">
-      {$everblock_structured_data|json_encode:$smarty.const.JSON_UNESCAPED_SLASHES|replace:'\/':'/' nofilter}
+      {$everblock_structured_data|json_encode:$smarty.const.JSON_UNESCAPED_SLASHES|replace:'\\/':'/' nofilter}
     </script>
   {/if}
 {/block}


### PR DESCRIPTION
## Summary
- add Bootstrap modal markup to guide pages to display full-size images
- wire guide content images to open inside the modal with optional caption

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381725ec748322a18067d7ed293030)