### PR TITLE
Add cover images to guides listing with layout stability

### DIFF
--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -67,6 +67,8 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
                     'rewrite' => $page->link_rewrite,
                 ]
             );
+
+            $page->cover_image_data = $page->getCoverImageData($this->context);
         }
 
         $structuredData = $this->buildItemListStructuredData($pages, $pageLinks);

--- a/models/EverblockPage.php
+++ b/models/EverblockPage.php
@@ -261,6 +261,47 @@ class EverblockPage extends ObjectModel
         return $count;
     }
 
+    /**
+     * Retrieve cover image data with width/height for layout stability.
+     */
+    public function getCoverImageData(Context $context): array
+    {
+        if (!$this->cover_image) {
+            return [
+                'url' => '',
+                'width' => 0,
+                'height' => 0,
+                'alt' => $this->title ?: $this->name ?: '',
+            ];
+        }
+
+        $imagePath = _PS_IMG_DIR_ . 'pages/' . $this->cover_image;
+        $imageUrl = $context->link->getMediaLink(_PS_IMG_ . 'pages/' . $this->cover_image);
+        $width = 0;
+        $height = 0;
+
+        if (is_file($imagePath)) {
+            $imageSize = @getimagesize($imagePath);
+
+            if ($imageSize) {
+                $width = (int) $imageSize[0];
+                $height = (int) $imageSize[1];
+            }
+        }
+
+        if ($width <= 0 || $height <= 0) {
+            $width = 1200;
+            $height = 675;
+        }
+
+        return [
+            'url' => $imageUrl,
+            'width' => $width,
+            'height' => $height,
+            'alt' => $this->title ?: $this->name ?: '',
+        ];
+    }
+
     public static function getById(int $pageId, int $langId, ?int $shopId = null): ?self
     {
         $shopId = static::resolveShopId($shopId);

--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -11,6 +11,19 @@
         {foreach from=$everblock_pages item=page}
           <div class="col-md-6 col-lg-4 mb-4">
             <article class="card h-100 shadow-sm border-0">
+              {assign var='coverImage' value=$page->cover_image_data|default:null}
+              {if $coverImage && $coverImage.url}
+                <div class="position-relative overflow-hidden rounded-top"
+                     style="aspect-ratio: {$coverImage.width|intval}/{$coverImage.height|intval};">
+                  <img src="{$coverImage.url|escape:'htmlall':'UTF-8'}"
+                       alt="{$coverImage.alt|default:$page->title|default:''|escape:'htmlall':'UTF-8'}"
+                       class="w-100 h-100"
+                       style="object-fit: cover;"
+                       loading="lazy"
+                       width="{$coverImage.width|intval}"
+                       height="{$coverImage.height|intval}" />
+                </div>
+              {/if}
               <div class="card-body d-flex flex-column">
                 <h3 class="h5 card-title text-primary">
                   <a href="{$everblock_page_links[$page->id]|escape:'htmlall':'UTF-8'}" class="stretched-link text-decoration-none">


### PR DESCRIPTION
## Summary
- add a helper on EverblockPage to expose cover image URLs with safe dimensions
- attach cover image metadata to guides before rendering the listing
- render guide cover images in the listing with reserved aspect ratio and lazy loading to reduce CLS

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381924f2588322b99ba353fab12091)