### PR TITLE
Synchronize guide meta data with template page context

### DIFF
--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -133,6 +133,14 @@ class EverblockPageModuleFrontController extends ModuleFrontController
             'meta_robots' => 'index,follow',
             'canonical' => $this->getCanonicalURL(),
         ]);
+
+        $page = $this->context->controller->getTemplateVarPage();
+        $page['meta']['title'] = $title;
+        $page['meta']['description'] = $description;
+        $page['meta']['robots'] = 'index,follow';
+        $page['canonical'] = $this->getCanonicalURL();
+
+        $this->context->smarty->assign('page', $page);
     }
 
     public function getCanonicalURL()

--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -195,6 +195,14 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
             'meta_robots' => 'index,follow',
             'canonical' => $this->getCanonicalURL(),
         ]);
+
+        $page = $this->context->controller->getTemplateVarPage();
+        $page['meta']['title'] = $title;
+        $page['meta']['description'] = $description;
+        $page['meta']['robots'] = 'index,follow';
+        $page['canonical'] = $this->getCanonicalURL();
+
+        $this->context->smarty->assign('page', $page);
     }
 
     public function getCanonicalURL()


### PR DESCRIPTION
## Summary
- sync guide listing and detail pages with PrestaShop template page meta structure
- propagate meta title, description, robots, and canonical URLs to the page variable for front controllers

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381b0212e48322b2034cd684d25fcd)