### PR TITLE
Make prettyblock guide cards fully clickable

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
@@ -59,7 +59,7 @@
             {assign var='guide_summary' value=$guide_object->short_description|default:$guide_object->meta_description|default:''}
           {/if}
           <div class="col mb-4">
-            <div id="block-{$block.id_prettyblocks}-{$key}" class="prettyblock-guide-card h-100{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_guides_selection_state_spacing_style}">
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="prettyblock-guide-card h-100 position-relative{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_guides_selection_state_spacing_style}">
               {if isset($cover_image_data.url) && $cover_image_data.url}
                 <div class="prettyblock-guide-image mb-3 position-relative overflow-hidden rounded" style="aspect-ratio: {$cover_image_data.width|intval}/{$cover_image_data.height|intval};">
                   <img src="{$cover_image_data.url|escape:'htmlall':'UTF-8'}"
@@ -76,6 +76,9 @@
               {/if}
               {if $guide_summary}
                 <div class="mb-3">{$guide_summary nofilter}</div>
+              {/if}
+              {if $guide_link}
+                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
               {/if}
               {if $guide_link && $state.cta_text}
                 <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary"{if $state.target_blank} target="_blank" rel="noopener"{/if}>

--- a/views/templates/hook/prettyblocks/prettyblock_latest_guides.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_latest_guides.tpl
@@ -42,7 +42,7 @@
       <div class="row row-cols-{$mobile_columns|intval} row-cols-sm-{$tablet_columns|intval} row-cols-md-{$desktop_columns|intval} row-cols-lg-{$desktop_columns|intval}">
         {foreach from=$latest_guides item=guide}
           <div class="col mb-4">
-            <div class="prettyblock-guide-card h-100">
+            <div class="prettyblock-guide-card h-100 position-relative">
               {assign var='cover_image_data' value=$guide->getCoverImageData(Context::getContext())}
               {if $cover_image_data.url}
                 <div class="prettyblock-guide-image mb-3 position-relative overflow-hidden rounded" style="aspect-ratio: {$cover_image_data.width|intval}/{$cover_image_data.height|intval};">
@@ -60,6 +60,9 @@
                 <div class="mb-3">{($guide->short_description|default:$guide->meta_description)|strip_tags|truncate:180:'...':true}</div>
               {/if}
               {assign var='guide_link' value=Context::getContext()->link->getModuleLink('everblock', 'page', ['id_everblock_page' => $guide->id, 'rewrite' => $guide->link_rewrite[Context::getContext()->language->id]|default:''])}
+              {if $guide_link}
+                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link"></a>
+              {/if}
               <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary">
                 {l s='Read guide' mod='everblock' d='Modules.Everblock.Front'}
               </a>

--- a/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
@@ -40,18 +40,21 @@
         {foreach from=$block.states item=state key=key}
           {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_pages_guide_state_spacing_style'}
           {assign var='page_id' value=$state.page.id|default:null}
-          {assign var='page_link' value='#'}
+          {assign var='page_link' value=''}
           {if $page_id}
             {assign var='page_link' value=Context::getContext()->link->getCMSLink($page_id)}
           {/if}
           {assign var='page_title' value=$state.title|default:$state.page.meta_title|default:''}
           <div class="col mb-4">
-            <div id="block-{$block.id_prettyblocks}-{$key}" class="prettyblock-guide-card h-100{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_pages_guide_state_spacing_style}">
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="prettyblock-guide-card h-100 position-relative{if $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_pages_guide_state_spacing_style}">
               {if $page_title}
                 <p class="h5">{$page_title|escape:'htmlall':'UTF-8'}</p>
               {/if}
               {if $state.summary}
                 <div class="mb-3">{$state.summary nofilter}</div>
+              {/if}
+              {if $page_link}
+                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="stretched-link"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
               {/if}
               {if $page_link && $state.cta_text}
                 <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary"{if $state.target_blank} target="_blank" rel="noopener"{/if}>


### PR DESCRIPTION
## Summary
- add stretched-link anchors so prettyblock guide cards are clickable via image or title
- make guide cards position-relative and avoid placeholder links for CMS guides
- retain existing CTAs while ensuring full-card navigation to guide pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693828f833d08322a3252fb932124f55)