### PR TITLE
Add PrettyBlocks zones for pages listing

### DIFF
--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -85,7 +85,8 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
             'everblock_page_links' => $pageLinks,
             'everblock_structured_data' => $structuredData,
             'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
-            'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone' : '',
+            'everblock_prettyblocks_top_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone_top' : '',
+            'everblock_prettyblocks_bottom_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone_bottom' : '',
             'everblock_pagination' => $pagination,
         ]);
 

--- a/views/templates/front/pages.tpl
+++ b/views/templates/front/pages.tpl
@@ -5,6 +5,10 @@
 {/block}
 
 {block name='page_content'}
+  {if $everblock_prettyblocks_enabled}
+    {prettyblocks_zone zone_name=$everblock_prettyblocks_top_zone_name}
+  {/if}
+
   <section class="everblock-pages-list">
     {if $everblock_pages|@count}
       <div class="row">
@@ -81,7 +85,7 @@
   </section>
 
   {if $everblock_prettyblocks_enabled}
-    {prettyblocks_zone zone_name=$everblock_prettyblocks_zone_name}
+    {prettyblocks_zone zone_name=$everblock_prettyblocks_bottom_zone_name}
   {/if}
 
   {if !empty($everblock_structured_data)}


### PR DESCRIPTION
## Summary
- add dedicated PrettyBlocks zones to the top and bottom of the pages listing template
- expose separate zone names from the controller when PrettyBlocks is enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382b5610cc8322b1a21d507b2336d1)