### PR TITLE
Remove statistics tab from module configuration

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -1347,7 +1347,6 @@ class Everblock extends Module
 
         $tabs = [
             'settings' => $this->l('Réglages'),
-            'stats' => $this->l('Statistiques'),
             'meta_tools' => $this->l('Meta Tools'),
             'wordpress_tools' => $this->l('WordPress Tools'),
             'google_maps' => $this->l('Google Tools'),
@@ -1385,7 +1384,6 @@ class Everblock extends Module
 
         $docTemplates = [
             'settings' => 'settings.tpl',
-            'stats' => 'stats.tpl',
             'meta_tools' => 'meta_tools.tpl',
             'wordpress_tools' => 'wordpress_tools.tpl',
             'google_maps' => 'google_maps.tpl',


### PR DESCRIPTION
## Summary
- remove the statistics tab from the module configuration tabs
- stop registering the statistics documentation template so the tab is hidden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693851ca89288322b263d29e6ec69dee)