### PR TITLE
Add front guide and FAQ links to module config

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -975,6 +975,18 @@ class Everblock extends Module
             'configure' => $this->name,
             'module_name' => $this->name,
         ]);
+        $guideFrontLink = $this->context->link->getModuleLink(
+            $this->name,
+            'pages'
+        );
+        $faqFrontTag = EverblockFaq::getFirstActiveTagName((int) $this->context->shop->id);
+        $faqFrontLink = $faqFrontTag ? $this->context->link->getModuleLink(
+            $this->name,
+            'faqs',
+            [
+                'tag' => $faqFrontTag,
+            ]
+        ) : null;
         $cronLinks = [];
         $cronToken = $this->encrypt($this->name . '/evercron');
         foreach ($this->allowedActions as $action) {
@@ -1008,6 +1020,9 @@ class Everblock extends Module
             'everblock_stats' => $this->getModuleStatistics(),
             'everblock_shortcode_docs' => ShortcodeDocumentationProvider::getDocumentation($this),
             'everblock_show_hero' => true,
+            'everblock_guide_front_link' => $guideFrontLink,
+            'everblock_faq_front_link' => $faqFrontLink,
+            'everblock_faq_front_tag' => $faqFrontTag,
         ]);
         $output = $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/header.tpl'

--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -202,6 +202,31 @@ class EverblockFaq extends ObjectModel
         return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }
 
+    public static function getFirstActiveTagName(?int $shopId = null): ?string
+    {
+        $shopId = self::resolveShopId($shopId);
+        $cacheId = 'EverblockFaq_getFirstActiveTagName_' . (int) $shopId;
+
+        if (!EverblockCache::isCacheStored($cacheId)) {
+            $sql = new DbQuery();
+            $sql->select('tag_name');
+            $sql->from(self::$definition['table']);
+            $sql->where('active = 1');
+            $sql->where('id_shop = ' . (int) $shopId);
+            $sql->orderBy('tag_name ASC, id_everblock_faq ASC');
+
+            $tagName = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+            if (!is_string($tagName) || $tagName === '') {
+                $tagName = null;
+            }
+
+            EverblockCache::cacheStore($cacheId, $tagName);
+            return $tagName;
+        }
+
+        return EverblockCache::cacheRetrieve($cacheId);
+    }
+
     public static function getFaqByTagNamePaginated(
         int $shopId,
         int $langId,

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -57,6 +57,19 @@
                 {l s='Manage shortcodes' mod='everblock'}
             </a>
         {/if}
+        {if isset($everblock_guide_front_link) && $everblock_guide_front_link}
+            <a href="{$everblock_guide_front_link|escape:'htmlall':'UTF-8'}" class="btn btn-info" target="_blank" rel="noopener">
+                <i class="icon-eye-open"></i> {l s='View guides page' mod='everblock'}
+            </a>
+        {/if}
+        {if isset($everblock_faq_front_link) && $everblock_faq_front_link}
+            <a href="{$everblock_faq_front_link|escape:'htmlall':'UTF-8'}" class="btn btn-info" target="_blank" rel="noopener">
+                <i class="icon-eye-open"></i> {l s='View FAQ page' mod='everblock'}
+                {if isset($everblock_faq_front_tag) && $everblock_faq_front_tag}
+                    ({$everblock_faq_front_tag|escape:'htmlall':'UTF-8'})
+                {/if}
+            </a>
+        {/if}
         {if isset($donation_link)}
             <a href="{$donation_link|escape:'htmlall':'UTF-8'}" class="btn btn-warning" target="_blank">
                 <i class="icon-money"></i> {l s='Make a donation' mod='everblock'}


### PR DESCRIPTION
## Summary
- add a helper to fetch the first active FAQ tag for building a front link
- surface buttons in the configuration header to open the guide listing and FAQ page on the storefront
- provide Smarty variables for the new front-office links

## Testing
- php -l models/EverblockFaq.php
- php -l everblock.php
- php -l views/templates/admin/header.tpl

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693851eff0648322b14413fd8783ae51)