### PR TITLE
Add full FAQ listing page with tag links

### DIFF
--- a/controllers/front/faqs.php
+++ b/controllers/front/faqs.php
@@ -28,11 +28,14 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
 {
     /** @var string */
     protected $tagName = '';
+    /** @var bool */
+    protected $isAllFaqsPage = false;
 
     public function init()
     {
         parent::init();
         $this->tagName = (string) Tools::getValue('tag', '');
+        $this->isAllFaqsPage = trim($this->tagName) === '';
     }
 
     public function initContent()
@@ -40,9 +43,6 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
         parent::initContent();
 
         $tagName = trim($this->tagName);
-        if ($tagName === '') {
-            Tools::redirect($this->context->link->getPageLink('index'));
-        }
 
         $itemsPerPage = (int) Configuration::get('EVERBLOCK_FAQ_PER_PAGE');
         if ($itemsPerPage <= 0) {
@@ -53,23 +53,47 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
         $shopId = (int) $this->context->shop->id;
         $langId = (int) $this->context->language->id;
 
-        $totalItems = EverblockFaq::countActiveByTagName($shopId, $tagName);
-        $totalPages = $totalItems > 0 ? (int) ceil($totalItems / $itemsPerPage) : 0;
-        if ($totalPages > 0 && $currentPage > $totalPages) {
-            $currentPage = $totalPages;
+        if ($this->isAllFaqsPage) {
+            $totalItems = EverblockFaq::countAllActive($shopId);
+            $totalPages = $totalItems > 0 ? (int) ceil($totalItems / $itemsPerPage) : 0;
+            if ($totalPages > 0 && $currentPage > $totalPages) {
+                $currentPage = $totalPages;
+            }
+
+            $faqs = EverblockFaq::getAllActivePaginated(
+                $shopId,
+                $langId,
+                $currentPage,
+                $itemsPerPage
+            );
+        } else {
+            $totalItems = EverblockFaq::countActiveByTagName($shopId, $tagName);
+            $totalPages = $totalItems > 0 ? (int) ceil($totalItems / $itemsPerPage) : 0;
+            if ($totalPages > 0 && $currentPage > $totalPages) {
+                $currentPage = $totalPages;
+            }
+
+            $faqs = EverblockFaq::getFaqByTagNamePaginated(
+                $shopId,
+                $langId,
+                $tagName,
+                $currentPage,
+                $itemsPerPage
+            );
         }
 
-        $faqs = EverblockFaq::getFaqByTagNamePaginated(
-            $shopId,
-            $langId,
-            $tagName,
-            $currentPage,
-            $itemsPerPage
-        );
+        $faqsWithLinks = $this->attachTagLinks($faqs);
+
+        $title = $this->isAllFaqsPage
+            ? $this->trans('FAQ', [], 'Modules.Everblock.Front')
+            : $this->trans('FAQ', [], 'Modules.Everblock.Front') . ' - ' . $tagName;
+        $description = $this->isAllFaqsPage
+            ? $this->trans('All frequently asked questions, across every group.', [], 'Modules.Everblock.Front')
+            : $this->trans('Frequently asked questions grouped by tag.', [], 'Modules.Everblock.Front');
 
         $this->context->smarty->assign([
             'everblock_tag_name' => $tagName,
-            'everblock_faqs' => $faqs,
+            'everblock_faqs' => $faqsWithLinks,
             'everblock_pagination' => $this->buildPagination(
                 $currentPage,
                 $totalPages,
@@ -77,14 +101,12 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
                 $totalItems
             ),
             'everblock_structured_data' => $this->buildStructuredData($faqs),
+            'everblock_is_all_faqs_page' => $this->isAllFaqsPage,
         ]);
 
         $this->setTemplate('module:everblock/views/templates/front/faqs.tpl');
 
-        $this->setTemplateMeta(
-            $this->trans('FAQ', [], 'Modules.Everblock.Front') . ' - ' . $tagName,
-            $this->trans('Frequently asked questions grouped by tag.', [], 'Modules.Everblock.Front')
-        );
+        $this->setTemplateMeta($title, $description);
     }
 
     public function getBreadcrumbLinks()
@@ -93,7 +115,7 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
 
         $breadcrumb['links'][] = [
             'title' => $this->trans('FAQ', [], 'Modules.Everblock.Front'),
-            'url' => '',
+            'url' => $this->isAllFaqsPage ? $this->getCanonicalURL() : '',
         ];
 
         if ($this->tagName !== '') {
@@ -108,9 +130,12 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
 
     protected function buildPagination(int $currentPage, int $totalPages, int $itemsPerPage, int $totalItems): array
     {
-        $baseLink = $this->context->link->getModuleLink($this->module->name, 'faqs', [
-            'tag' => $this->tagName,
-        ]);
+        $baseParams = [];
+        if (!$this->isAllFaqsPage) {
+            $baseParams['tag'] = $this->tagName;
+        }
+
+        $baseLink = $this->context->link->getModuleLink($this->module->name, 'faqs', $baseParams);
         $pages = [];
 
         for ($page = 1; $page <= $totalPages; ++$page) {
@@ -118,10 +143,9 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
                 'number' => $page,
                 'link' => $page === 1
                     ? $baseLink
-                    : $this->context->link->getModuleLink($this->module->name, 'faqs', [
-                        'tag' => $this->tagName,
+                    : $this->context->link->getModuleLink($this->module->name, 'faqs', array_merge($baseParams, [
                         'page' => $page,
-                    ]),
+                    ])),
                 'active' => $page === $currentPage,
             ];
         }
@@ -136,16 +160,14 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
             'previous_link' => $currentPage > 1
                 ? ($currentPage - 1 === 1
                     ? $baseLink
-                    : $this->context->link->getModuleLink($this->module->name, 'faqs', [
-                        'tag' => $this->tagName,
+                    : $this->context->link->getModuleLink($this->module->name, 'faqs', array_merge($baseParams, [
                         'page' => $currentPage - 1,
-                    ]))
+                    ])))
                 : $baseLink,
             'next_link' => $currentPage < $totalPages
-                ? $this->context->link->getModuleLink($this->module->name, 'faqs', [
-                    'tag' => $this->tagName,
+                ? $this->context->link->getModuleLink($this->module->name, 'faqs', array_merge($baseParams, [
                     'page' => $currentPage + 1,
-                ])
+                ]))
                 : $baseLink,
             'pages' => $pages,
         ];
@@ -172,7 +194,9 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
         return [
             '@context' => 'https://schema.org',
             '@type' => 'FAQPage',
-            'name' => $this->trans('FAQ', [], 'Modules.Everblock.Front') . ' - ' . $this->tagName,
+            'name' => $this->tagName === ''
+                ? $this->trans('FAQ', [], 'Modules.Everblock.Front')
+                : $this->trans('FAQ', [], 'Modules.Everblock.Front') . ' - ' . $this->tagName,
             'mainEntity' => $entities,
         ];
     }
@@ -199,8 +223,24 @@ class EverblockFaqsModuleFrontController extends ModuleFrontController
 
     public function getCanonicalURL()
     {
-        return $this->context->link->getModuleLink($this->module->name, 'faqs', [
-            'tag' => $this->tagName,
-        ]);
+        $params = [];
+        if (!$this->isAllFaqsPage) {
+            $params['tag'] = $this->tagName;
+        }
+
+        return $this->context->link->getModuleLink($this->module->name, 'faqs', $params);
+    }
+
+    protected function attachTagLinks(array $faqs): array
+    {
+        foreach ($faqs as $faq) {
+            if (!isset($faq->tag_link)) {
+                $faq->tag_link = $this->context->link->getModuleLink($this->module->name, 'faqs', [
+                    'tag' => $faq->tag_name,
+                ]);
+            }
+        }
+
+        return $faqs;
     }
 }

--- a/everblock.php
+++ b/everblock.php
@@ -5748,6 +5748,15 @@ class Everblock extends Module
                     'module' => $this->name,
                 ],
             ],
+            'module-everblock-faqs-list' => [
+                'controller' => 'faqs',
+                'rule' => $faqBase,
+                'keywords' => [],
+                'params' => [
+                    'fc' => 'module',
+                    'module' => $this->name,
+                ],
+            ],
             'module-everblock-faqs' => [
                 'controller' => 'faqs',
                 'rule' => $faqBase . '/{tag}',

--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -7,8 +7,13 @@
 {block name='page_content'}
   <section class="everblock-faqs-list">
     <header class="mb-4">
-      <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'} - {$everblock_tag_name|escape:'htmlall':'UTF-8'}</h1>
-      <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
+      {if $everblock_is_all_faqs_page}
+        <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
+        <p class="text-muted mb-0">{l s='All frequently asked questions across every available group.' mod='everblock' d='Modules.Everblock.Front'}</p>
+      {else}
+        <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'} - {$everblock_tag_name|escape:'htmlall':'UTF-8'}</h1>
+        <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
+      {/if}
     </header>
 
     {if $everblock_faqs|@count}
@@ -37,7 +42,7 @@
         </nav>
       {/if}
     {else}
-      <p class="alert alert-info">{l s='No FAQ available for this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
+      <p class="alert alert-info">{l s='No FAQ available at the moment.' mod='everblock' d='Modules.Everblock.Front'}</p>
     {/if}
   </section>
 

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -24,7 +24,15 @@
           <div class="accordion-header card-header p-0 h2" id="headingEverFaq{$faq->id_everblock_faq}">
             <button class="accordion-button btn btn-link faq-question d-flex justify-content-between align-items-center w-100 text-body py-3 px-4 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
                     aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
-              <span>{$faq->title}</span><i class="icon-angle-down" aria-hidden="true"></i>
+              <span class="d-flex align-items-center gap-2">
+                <span>{$faq->title}</span>
+                {if isset($faq->tag_link) && $faq->tag_link}
+                  <a class="badge bg-primary text-decoration-none" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
+                    {$faq->tag_name|escape:'htmlall':'UTF-8'}
+                  </a>
+                {/if}
+              </span>
+              <i class="icon-angle-down" aria-hidden="true"></i>
             </button>
           </div>
           <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"


### PR DESCRIPTION
## Summary
- allow the FAQ front controller to render a global listing when no tag is provided
- expose routes and templates for the all-FAQ view while preserving tag pagination
- attach tag links/badges to FAQ items so visitors can jump to grouped views

## Testing
- php -l controllers/front/faqs.php
- php -l models/EverblockFaq.php
- php -l everblock.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69385470307c83229ff8ddd6e9bb780c)