### PR TITLE
Add all FAQs link in module config

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -979,13 +979,18 @@ class Everblock extends Module
             $this->name,
             'pages'
         );
-        $faqFrontTag = EverblockFaq::getFirstActiveTagName((int) $this->context->shop->id);
+        $shopId = (int) $this->context->shop->id;
+        $faqFrontTag = EverblockFaq::getFirstActiveTagName($shopId);
         $faqFrontLink = $faqFrontTag ? $this->context->link->getModuleLink(
             $this->name,
             'faqs',
             [
                 'tag' => $faqFrontTag,
             ]
+        ) : null;
+        $faqAllFrontLink = EverblockFaq::countAllActive($shopId) > 0 ? $this->context->link->getModuleLink(
+            $this->name,
+            'faqs'
         ) : null;
         $cronLinks = [];
         $cronToken = $this->encrypt($this->name . '/evercron');
@@ -1023,6 +1028,7 @@ class Everblock extends Module
             'everblock_guide_front_link' => $guideFrontLink,
             'everblock_faq_front_link' => $faqFrontLink,
             'everblock_faq_front_tag' => $faqFrontTag,
+            'everblock_all_faqs_front_link' => $faqAllFrontLink,
         ]);
         $output = $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/header.tpl'

--- a/views/templates/admin/header.tpl
+++ b/views/templates/admin/header.tpl
@@ -62,6 +62,11 @@
                 <i class="icon-eye-open"></i> {l s='View guides page' mod='everblock'}
             </a>
         {/if}
+        {if isset($everblock_all_faqs_front_link) && $everblock_all_faqs_front_link}
+            <a href="{$everblock_all_faqs_front_link|escape:'htmlall':'UTF-8'}" class="btn btn-info" target="_blank" rel="noopener">
+                <i class="icon-list"></i> {l s='View all FAQs' mod='everblock'}
+            </a>
+        {/if}
         {if isset($everblock_faq_front_link) && $everblock_faq_front_link}
             <a href="{$everblock_faq_front_link|escape:'htmlall':'UTF-8'}" class="btn btn-info" target="_blank" rel="noopener">
                 <i class="icon-eye-open"></i> {l s='View FAQ page' mod='everblock'}


### PR DESCRIPTION
## Summary
- add all FAQs front-office link to module configuration header
- keep existing active FAQ link while exposing full FAQ listing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693855c4982c83229790316aae999fb1)