### PR TITLE
Add structured data fallbacks for FAQ templates

### DIFF
--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -50,5 +50,24 @@
     <script type="application/ld+json">
       {$everblock_structured_data|json_encode:$smarty.const.JSON_UNESCAPED_SLASHES|replace:'\/':'/' nofilter}
     </script>
+  {elseif !empty($everblock_faqs)}
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {foreach from=$everblock_faqs item=faq name=faqjson}
+            {
+              "@type": "Question",
+              "name": "{$faq->title|escape:'javascript'}",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "{strip_tags($faq->content)|escape:'javascript'}"
+              }
+            }{if !$smarty.foreach.faqjson.last},{/if}
+          {/foreach}
+        ]
+      }
+    </script>
   {/if}
 {/block}

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -43,22 +43,24 @@
       {/foreach}
     </div>
   </div>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {foreach from=$everFaqs item=faq name=faqjson}
-      {
-        "@type": "Question",
-        "name": "{$faq->title|escape:'htmlall':'UTF-8'}",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "{strip_tags($faq->content)|escape:'htmlall':'UTF-8'}"
-        }
-      }{if !$smarty.foreach.faqjson.last},{/if}
-      {/foreach}
-    ]
-  }
-  </script>
+  {if empty($everblock_structured_data)}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {foreach from=$everFaqs item=faq name=faqjson}
+        {
+          "@type": "Question",
+          "name": "{$faq->title|escape:'htmlall':'UTF-8'}",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "{strip_tags($faq->content)|escape:'htmlall':'UTF-8'}"
+          }
+        }{if !$smarty.foreach.faqjson.last},{/if}
+        {/foreach}
+      ]
+    }
+    </script>
+  {/if}
 {/if}


### PR DESCRIPTION
## Summary
- add fallback JSON-LD generation on the FAQ listing template when no structured data is provided
- guard FAQ block structured data output to avoid duplication when a parent supplies it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938561cc1c483229ef5dd59e01c92fb)