### PR TITLE
Avoid generating empty SVG icon URLs

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_counters.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_counters.tpl
@@ -32,7 +32,7 @@
       {assign var="icon_url" value=false}
       {if (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
         {assign var="icon_url" value=$state.icon.url}
-      {elseif isset($state.icon) && is_string($state.icon)}
+      {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
         {if $state.icon|substr:-4 != '.svg'}
           {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
         {else}

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -59,7 +59,7 @@
         {assign var="icon_url" value=$state.image.url}
       {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
         {assign var="icon_url" value=$state.icon.url}
-      {elseif isset($state.icon) && is_string($state.icon)}
+      {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
         {if $state.icon|substr:-4 != '.svg'}
           {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
         {else}

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -38,7 +38,7 @@
             {assign var="icon_url" value=false}
             {if (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
               {assign var="icon_url" value=$state.icon.url}
-            {elseif isset($state.icon) && is_string($state.icon)}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
               {if $state.icon|substr:-4 == '.svg'}
                 {assign var="icon_url" value=$smarty.const._PS_MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
               {else}


### PR DESCRIPTION
## Summary
- avoid building SVG URLs when the icon value is an empty string in reassurance, counters, and social link blocks
- keep existing behavior for valid icons while preventing requests to `.svg`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69385664c5488322beaeda11a4d4e941)