### PR TITLE
Make FAQ tag route parameter optional

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5767,7 +5767,11 @@ class Everblock extends Module
                 'controller' => 'faqs',
                 'rule' => $faqBase . '/{tag}',
                 'keywords' => [
-                    'tag' => ['regexp' => '[_a-zA-Z0-9\pL-]+', 'param' => 'tag'],
+                    'tag' => [
+                        'regexp' => '[_a-zA-Z0-9\pL-]*',
+                        'param' => 'tag',
+                        'required' => false,
+                    ],
                 ],
                 'params' => [
                     'fc' => 'module',


### PR DESCRIPTION
## Summary
- allow the FAQ front-office route to handle requests without a tag parameter
- relax the route keyword requirements so listing pages can be generated safely

## Testing
- php -l everblock.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693856e1d6f08322b61e9d7d987fd8ac)