### PR TITLE
Fix FAQ tag links in accordion header

### DIFF
--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -22,18 +22,18 @@
       {foreach from=$everFaqs item=faq name=faqloop}
         <div class="accordion-item card mb-4">
           <div class="accordion-header card-header p-0 h2" id="headingEverFaq{$faq->id_everblock_faq}">
-            <button class="accordion-button btn btn-link faq-question d-flex justify-content-between align-items-center w-100 text-body py-3 px-4 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
-                    aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
-              <span class="d-flex align-items-center gap-2">
+            <div class="d-flex align-items-center gap-2 px-4 py-3">
+              <button class="accordion-button btn btn-link faq-question flex-grow-1 d-flex justify-content-between align-items-center w-100 text-body p-0 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
+                      aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
                 <span>{$faq->title}</span>
-                {if isset($faq->tag_link) && $faq->tag_link}
-                  <a class="badge bg-primary text-decoration-none" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
-                    {$faq->tag_name|escape:'htmlall':'UTF-8'}
-                  </a>
-                {/if}
-              </span>
-              <i class="icon-angle-down" aria-hidden="true"></i>
-            </button>
+                <i class="icon-angle-down" aria-hidden="true"></i>
+              </button>
+              {if isset($faq->tag_link) && $faq->tag_link}
+                <a class="badge bg-primary text-decoration-none" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
+                  {$faq->tag_name|escape:'htmlall':'UTF-8'}
+                </a>
+              {/if}
+            </div>
           </div>
           <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
                aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">


### PR DESCRIPTION
## Summary
- separate FAQ accordion toggle from tag badge so group links remain clickable
- adjust header layout to preserve spacing while removing nested interactive elements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939291acbcc83228c3da4742f6eb548)