### PR TITLE
Restore admin menu icon when assets limited

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3207,6 +3207,8 @@ class Everblock extends Module
         ];
 
         if (!$isModuleConfiguration && !in_array($controller, $moduleControllers, true)) {
+            $this->context->controller->addCss($this->_path . 'views/css/admin_menu.css');
+
             return;
         }
 

--- a/views/css/admin_menu.css
+++ b/views/css/admin_menu.css
@@ -1,0 +1,9 @@
+/**
+ * Admin menu icon styles for Everblock
+ */
+.mi-icon-team-ever {
+    content: url(../img/logo.png);
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+}


### PR DESCRIPTION
## Summary
- load lightweight admin menu CSS on non-module admin pages to preserve the Everblock icon
- keep full admin assets limited to module-related controllers only

## Testing
- php -l everblock.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392eff407c8322ae148eeb9930535f)