### PR TITLE
Decode WordPress post entities

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -5530,9 +5530,17 @@ class EverblockTools extends ObjectModel
         $preparedPosts = [];
         foreach ($posts as $post) {
             $postId = (int) ($post['id'] ?? 0);
-            $title = strip_tags($post['title']['rendered'] ?? '');
+            $title = html_entity_decode(
+                strip_tags($post['title']['rendered'] ?? ''),
+                ENT_QUOTES | ENT_HTML5,
+                'UTF-8'
+            );
             $link = $post['link'] ?? '#';
-            $excerpt = strip_tags($post['excerpt']['rendered'] ?? '');
+            $excerpt = html_entity_decode(
+                strip_tags($post['excerpt']['rendered'] ?? ''),
+                ENT_QUOTES | ENT_HTML5,
+                'UTF-8'
+            );
 
             $mediaData = self::resolveWordpressFeaturedMedia($post, $apiBaseUrl);
             $featuredImageUrl = $mediaData['url'] ?? '';


### PR DESCRIPTION
## Summary
- decode HTML entities in WordPress post titles and excerpts when importing posts
- keep cached WordPress posts display-ready by resolving typographic entities

## Testing
- php -l src/Service/EverblockTools.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392f46a85c8322b85f62842e201226)