### PR TITLE
Fix escaping of custom data attributes

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -1800,7 +1800,7 @@ class AdminEverBlockController extends ModuleAdminController
             $everblock_obj->position = (int) Tools::getValue('position');
             $everblock_obj->background =  pSQL(Tools::getValue('background'));
             $everblock_obj->css_class =  pSQL(Tools::getValue('css_class'));
-            $everblock_obj->data_attribute =  pSQL(Tools::getValue('data_attribute'));
+            $everblock_obj->data_attribute = Tools::getValue('data_attribute');
             $everblock_obj->bootstrap_class =  pSQL(Tools::getValue('bootstrap_class'));
             $everblock_obj->device = (int) Tools::getValue('device');
             if (!Tools::getValue('groupBox')


### PR DESCRIPTION
## Summary
- stop double escaping the custom data attributes on block save

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693952021b548322a57ac8582c18f241)