### PR TITLE
Replace heading tag with h2 class for WP posts

### DIFF
--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -1,8 +1,8 @@
 {if isset($everblock_wp_posts) && $everblock_wp_posts|@count > 0}
 <section class="everblock-wp-section text-center my-5">
-  <h2 class="section-title text-uppercase mb-4">
+  <div class="h2 section-title text-uppercase mb-4">
     <span>Les dernières actus de notre blog</span>
-  </h2>
+  </div>
 
   <div class="everblock-wp-posts container">
     <div class="row justify-content-center align-items-stretch">


### PR DESCRIPTION
## Summary
- replace the h2 tag with a div carrying the h2 class for the WordPress posts section title

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396bd156348322b38d5e016d693674)