### PR TITLE
Make generated blog post strings translatable

### DIFF
--- a/translations/fr.php
+++ b/translations/fr.php
@@ -848,3 +848,5 @@ $_MODULE['<{everblock}prestashop>everblock_preview_select_context'] = 'Sélectio
 $_MODULE['<{everblock}prestashop>everblock_preview_loading'] = 'Chargement de la prévisualisation…';
 $_MODULE['<{everblock}prestashop>everblock_preview_error_generic'] = 'Impossible de charger la prévisualisation. Veuillez réessayer.';
 $_MODULE['<{everblock}prestashop>everblock_preview_update_button'] = 'Actualiser la prévisualisation';
+$_MODULE['<{everblock}prestashop>generated_wp_posts_652646ea148d966b30d2ad88016ffc98'] = 'Les dernières actus de notre blog';
+$_MODULE['<{everblock}prestashop>generated_wp_posts_42a1827953d0470285d9d87c278b01e8'] = 'Visiter notre blog';

--- a/translations/gb.php
+++ b/translations/gb.php
@@ -201,3 +201,5 @@ $_MODULE['<{everblock}prestashop>everblock_preview_select_context'] = 'Select a 
 $_MODULE['<{everblock}prestashop>everblock_preview_loading'] = 'Loading preview...';
 $_MODULE['<{everblock}prestashop>everblock_preview_error_generic'] = 'Unable to load the preview. Please try again.';
 $_MODULE['<{everblock}prestashop>everblock_preview_update_button'] = 'Update preview';
+$_MODULE['<{everblock}prestashop>generated_wp_posts_652646ea148d966b30d2ad88016ffc98'] = 'Latest news from our blog';
+$_MODULE['<{everblock}prestashop>generated_wp_posts_42a1827953d0470285d9d87c278b01e8'] = 'Visit our blog';

--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -1,7 +1,7 @@
 {if isset($everblock_wp_posts) && $everblock_wp_posts|@count > 0}
 <section class="everblock-wp-section text-center my-5">
   <div class="h2 section-title text-uppercase mb-4">
-    <span>Les dernières actus de notre blog</span>
+    <span>{l s='Latest news from our blog' mod='everblock'}</span>
   </div>
 
   <div class="everblock-wp-posts container">
@@ -55,7 +55,7 @@
 
     <div class="text-center mt-3">
       <a href="{$everblock_wp_blog_url|escape:'htmlall':'UTF-8'}" class="btn btn-warning fw-bold text-uppercase px-4 py-2 rounded-pill">
-        Visiter notre blog
+        {l s='Visit our blog' mod='everblock'}
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace hard-coded blog section strings with translated labels in the generated WordPress posts template
- add English and French translations for the new strings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399720b730832296d7056caa134839)