### PR TITLE
Add link option to Prettyblock cover block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2699,6 +2699,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Content'),
                             'default' => '',
                         ],
+                        'cover_link' => [
+                            'type' => 'text',
+                            'label' => $module->l('Full cover link'),
+                            'default' => '',
+                        ],
                         'background_image' => [
                             'type' => 'fileupload',
                             'label' => $module->l('Background image'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -730,6 +730,21 @@
     align-items: center;
     text-align: center;
     padding: 1rem;
+    z-index: 2;
+}
+
+.prettyblock-cover-overlay > * {
+    position: relative;
+    z-index: 2;
+}
+
+.prettyblock-cover-full-link {
+    z-index: 3;
+}
+
+.prettyblock-cover-overlay .btn {
+    position: relative;
+    z-index: 4;
 }
 
 .prettyblock-cover-overlay.position-desktop-top {

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -65,6 +65,7 @@
           {/if}
         {/capture}
         {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
+        {assign var='prettyblock_cover_link' value=$state.cover_link|default:''}
         <div id="block-{$block.id_prettyblocks}-{$key}"
              class="prettyblock-cover-item{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
             {if isset($state.background_image.url) && $state.background_image.url}
@@ -111,6 +112,9 @@
                 {/if}
               </div>
             {/if}
+            {if $prettyblock_cover_link}
+              <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}"></a>
+            {/if}
           </div>
         </div>
         {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
@@ -150,6 +154,7 @@
         {/if}
       {/capture}
       {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
+      {assign var='prettyblock_cover_link' value=$state.cover_link|default:''}
       {assign var='prettyblock_cover_item_base_class' value='prettyblock-cover-item'}
       {if $use_columns_layout}
         {assign var='prettyblock_cover_item_base_class' value=$columns_item_classes}
@@ -199,6 +204,9 @@
                 <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
               {/if}
             </div>
+          {/if}
+          {if $prettyblock_cover_link}
+            <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}"></a>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add configuration field to set a full-cover link on Prettyblock cover items
- render cover items with stretched link overlay while keeping buttons clickable
- adjust cover block styles to layer the overlay link correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8b948eb48322a5b20722ed448a36)