### PR TITLE
Add device-specific sliders to category tabs block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2491,6 +2491,36 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Number of products to display (0 for default)'),
                             'default' => 0,
                         ],
+                        'slider' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable slider'),
+                            'default' => 0,
+                        ],
+                        'slider_devices' => [
+                            'type' => 'select',
+                            'label' => $module->l('Enable slider on'),
+                            'choices' => [
+                                'both' => $module->l('Desktop and mobile'),
+                                'desktop' => $module->l('Desktop only'),
+                                'mobile' => $module->l('Mobile only'),
+                            ],
+                            'default' => 'both',
+                        ],
+                        'products_per_slide_desktop' => [
+                            'type' => 'text',
+                            'label' => $module->l('Products per slide on desktop'),
+                            'default' => '4',
+                        ],
+                        'products_per_slide_tablet' => [
+                            'type' => 'text',
+                            'label' => $module->l('Products per slide on tablet'),
+                            'default' => '2',
+                        ],
+                        'products_per_slide_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Products per slide on mobile'),
+                            'default' => '1',
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -45,17 +45,123 @@
                 {foreach from=$block.states item=state key=key name=categorytabs}
                     {assign var='tabId' value="tab-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key}
                     {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
-                    <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" id="{$tabId}" role="tabpanel" aria-labelledby="{$tabId}-tab" style="{$prettyblock_state_spacing_style}{if isset($state.background_color) && $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if isset($state.text_color) && $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
+                    {assign var='useSlider' value=(isset($state.slider) && $state.slider && isset($block.extra.products[$key]) && $block.extra.products[$key])}
+                    {assign var='sliderDevices' value=$state.slider_devices|default:'both'}
+                    {assign var='useDesktopSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'desktop'))}
+                    {assign var='useMobileSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'mobile'))}
+                    {assign var='desktopItems' value=$state.products_per_slide_desktop|default:4|intval}
+                    {if $desktopItems < 1}
+                        {assign var='desktopItems' value=1}
+                    {/if}
+                    {assign var='tabletItems' value=$state.products_per_slide_tablet|default:2|intval}
+                    {if $tabletItems < 1}
+                        {assign var='tabletItems' value=1}
+                    {/if}
+                    {assign var='mobileItems' value=$state.products_per_slide_mobile|default:1|intval}
+                    {if $mobileItems < 1}
+                        {assign var='mobileItems' value=1}
+                    {/if}
+                    {math equation="ceil(12 / x)" x=$mobileItems assign='mobileColumnWidth'}
+                    {math equation="ceil(12 / x)" x=$tabletItems assign='tabletColumnWidth'}
+                    {math equation="ceil(12 / x)" x=$desktopItems assign='desktopColumnWidth'}
+                    {assign var='productColumnClasses' value="col-"|cat:$mobileColumnWidth}
+                    {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-sm-"|cat:$tabletColumnWidth}
+                    {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-lg-"|cat:$desktopColumnWidth}
+                    {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-xl-"|cat:$desktopColumnWidth}
+                    <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" id="{$tabId}" role="tabpanel" aria-labelledby="{$tabId}-tab"style="{$prettyblock_state_spacing_style}{if isset($state.background_color) && $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if isset($state.text_color) && $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
                         {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-                        <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
-                            <div class="products row">
-                                {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
-                                {foreach from=$block.extra.products[$key] item=product}
-                                    {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
-                                {/foreach}
-                                {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
-                            </div>
-                        </section>
+                        {if $useDesktopSlider || $useMobileSlider}
+                            {if $useDesktopSlider}
+                                {assign var='carouselIdDesktop' value="category-tabs-carousel-desktop-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
+                                <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
+                                    <div id="{$carouselIdDesktop}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                        <div class="carousel-inner products">
+                                            {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                            {foreach from=$block.extra.products[$key] item=product name=desktopProducts}
+                                                {if $product@index % $desktopItems == 0}
+                                                    <div class="carousel-item{if $product@first} active{/if}">
+                                                        <div class="row">
+                                                {/if}
+                                                {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                                {if ($product@index + 1) % $desktopItems == 0 || $product@last}
+                                                        </div>
+                                                    </div>
+                                                {/if}
+                                            {/foreach}
+                                            {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                        </div>
+                                        <button class="carousel-control-prev" type="button" data-bs-target="#{$carouselIdDesktop}" data-bs-slide="prev">
+                                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+                                        </button>
+                                        <button class="carousel-control-next" type="button" data-bs-target="#{$carouselIdDesktop}" data-bs-slide="next">
+                                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+                                        </button>
+                                    </div>
+                                </section>
+                            {else}
+                                <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
+                                    <div class="products row">
+                                        {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                        {foreach from=$block.extra.products[$key] item=product}
+                                            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                        {/foreach}
+                                        {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                    </div>
+                                </section>
+                            {/if}
+                            {if $useMobileSlider}
+                                {assign var='carouselIdMobile' value="category-tabs-carousel-mobile-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
+                                <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-block d-md-none">
+                                    <div id="{$carouselIdMobile}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                        <div class="carousel-inner products">
+                                            {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                            {foreach from=$block.extra.products[$key] item=product name=mobileProducts}
+                                                {if $product@index % $mobileItems == 0}
+                                                    <div class="carousel-item{if $product@first} active{/if}">
+                                                        <div class="row">
+                                                {/if}
+                                                {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                                {if ($product@index + 1) % $mobileItems == 0 || $product@last}
+                                                        </div>
+                                                    </div>
+                                                {/if}
+                                            {/foreach}
+                                            {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                        </div>
+                                        <button class="carousel-control-prev" type="button" data-bs-target="#{$carouselIdMobile}" data-bs-slide="prev">
+                                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+                                        </button>
+                                        <button class="carousel-control-next" type="button" data-bs-target="#{$carouselIdMobile}" data-bs-slide="next">
+                                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+                                        </button>
+                                    </div>
+                                </section>
+                            {else}
+                                <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-block d-md-none">
+                                    <div class="products row">
+                                        {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                        {foreach from=$block.extra.products[$key] item=product}
+                                            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                        {/foreach}
+                                        {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                    </div>
+                                </section>
+                            {/if}
+                        {else}
+                            <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
+                                <div class="products row">
+                                    {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                    {foreach from=$block.extra.products[$key] item=product}
+                                        {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                    {/foreach}
+                                    {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                </div>
+                            </section>
+                        {/if}
                         {/if}
                     </div>
                 {/foreach}


### PR DESCRIPTION
## Summary
- add configuration options to enable sliders per tab and target desktop, mobile, or both
- render category tab products using responsive carousels with per-device product counts

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8c8e4ec48322b21d7019028146bb)