### PR TITLE
Enhance FAQ page design and SEO

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1165,23 +1165,198 @@
 }
 
 /* FAQ styles */
+.everblock-faqs-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.everblock-faqs-hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 1.5rem;
+    border-radius: 1rem;
+    background: linear-gradient(120deg, rgba(13, 110, 253, 0.08), rgba(111, 66, 193, 0.08));
+    border: 1px solid rgba(13, 110, 253, 0.15);
+}
+
+.everblock-faqs-meta {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.everblock-faqs-meta__item {
+    min-width: 120px;
+    background: #ffffff;
+    border: 1px solid #e9ecef;
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+    text-align: center;
+    box-shadow: 0 8px 30px rgba(33, 37, 41, 0.05);
+}
+
+.everblock-faqs-meta__label {
+    display: block;
+    font-size: 0.875rem;
+    color: #6c757d;
+}
+
+.everblock-faqs-meta__value {
+    display: block;
+    font-size: 1.35rem;
+    color: #0d6efd;
+}
+
+.everblock-faqs-tag {
+    text-transform: lowercase;
+    letter-spacing: 0.01em;
+}
+
+.everblock-faqs-nav {
+    border: 1px solid #e9ecef;
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    background-color: #ffffff;
+}
+
+.everblock-faqs-nav__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 0.75rem;
+}
+
+.everblock-faqs-nav__link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    border: 1px solid #e9ecef;
+    border-radius: 0.65rem;
+    padding: 0.9rem 1rem;
+    text-decoration: none;
+    background-color: #f9fbff;
+    color: #212529;
+    transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.everblock-faqs-nav__link:hover,
+.everblock-faqs-nav__link:focus {
+    border-color: #cfe2ff;
+    box-shadow: 0 10px 30px rgba(13, 110, 253, 0.08);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.everblock-faqs-nav__title {
+    font-weight: 600;
+}
+
+.everblock-faqs-nav__pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background-color: #e9f2ff;
+    color: #0d6efd;
+    font-size: 0.8125rem;
+    font-weight: 600;
+}
+
 .faq-accordion .card-header,
 .faq-accordion .accordion-header {
-    background-color: #f7f7f7;
+    background-color: #f9fbff;
+    border: none;
 }
-.faq-question i {
+
+.everblock-faq-accordion {
+    gap: 1rem;
+}
+
+.everblock-faq-item {
+    border: 1px solid #e9ecef;
+    border-radius: 0.85rem;
+    overflow: hidden;
+    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.05);
+}
+
+.everblock-faq-item + .everblock-faq-item {
+    margin-top: 0.5rem;
+}
+
+.faq-question .everblock-faq-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #e9f2ff;
+    position: relative;
+    transition: transform 0.3s ease, background-color 0.2s ease;
+}
+
+.faq-question .everblock-faq-icon::before,
+.faq-question .everblock-faq-icon::after {
+    content: "";
+    position: absolute;
+    background-color: #0d6efd;
     transition: transform 0.3s ease;
 }
+
+.faq-question .everblock-faq-icon::before {
+    width: 2px;
+    height: 10px;
+}
+
+.faq-question .everblock-faq-icon::after {
+    width: 10px;
+    height: 2px;
+}
+
 .faq-accordion .accordion-button {
     background: none;
     box-shadow: none;
+    font-weight: 600;
 }
-.faq-question[aria-expanded="true"] i {
-    transform: rotate(180deg);
+
+.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon {
+    background-color: #0d6efd;
+    transform: rotate(45deg);
 }
+
+.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon::before,
+.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon::after {
+    background-color: #ffffff;
+}
+
+.faq-accordion .accordion-button:focus {
+    border-color: rgba(13, 110, 253, 0.35);
+    box-shadow: 0 0 0 0.1rem rgba(13, 110, 253, 0.2);
+}
+
 .faq-answer,
 .faq-accordion .accordion-body {
-    padding: 15px;
+    padding: 16px 20px 20px;
+    background: #ffffff;
+    line-height: 1.7;
+}
+
+.everblock-faq-chip {
+    text-transform: lowercase;
+}
+
+@media (max-width: 767px) {
+    .everblock-faqs-hero {
+        flex-direction: column;
+    }
+
+    .everblock-faqs-meta {
+        width: 100%;
+    }
 }
 
 /* Table of Contents styles */

--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -5,18 +5,52 @@
 {/block}
 
 {block name='page_content'}
-  <section class="everblock-faqs-list">
+  <section class="everblock-faqs-list" aria-label="{l s='Frequently asked questions' mod='everblock' d='Modules.Everblock.Front'}">
     <header class="mb-4">
-      {if $everblock_is_all_faqs_page}
-        <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
-        <p class="text-muted mb-0">{l s='All frequently asked questions across every available group.' mod='everblock' d='Modules.Everblock.Front'}</p>
-      {else}
-        <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'} - {$everblock_tag_name|escape:'htmlall':'UTF-8'}</h1>
-        <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
-      {/if}
+      <div class="everblock-faqs-hero">
+        <div>
+          {if $everblock_is_all_faqs_page}
+            <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
+            <p class="text-muted mb-0">{l s='Browse every question and answer available across all groups.' mod='everblock' d='Modules.Everblock.Front'}</p>
+          {else}
+            <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
+              <h1 class="h2 mb-0">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
+              <span class="badge bg-primary everblock-faqs-tag" aria-label="{l s='Current FAQ tag' mod='everblock' d='Modules.Everblock.Front'}">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</span>
+            </div>
+            <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
+          {/if}
+        </div>
+
+        {if $everblock_faqs|@count}
+          <div class="everblock-faqs-meta">
+            <div class="everblock-faqs-meta__item">
+              <span class="everblock-faqs-meta__label">{l s='Questions' mod='everblock' d='Modules.Everblock.Front'}</span>
+              <strong class="everblock-faqs-meta__value">{$everblock_faqs|@count}</strong>
+            </div>
+            {if !$everblock_is_all_faqs_page && isset($everblock_tag_name)}
+              <div class="everblock-faqs-meta__item">
+                <span class="everblock-faqs-meta__label">{l s='Group' mod='everblock' d='Modules.Everblock.Front'}</span>
+                <strong class="everblock-faqs-meta__value">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</strong>
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
     </header>
 
     {if $everblock_faqs|@count}
+      <div class="everblock-faqs-nav mb-4" aria-label="{l s='Jump to a question' mod='everblock' d='Modules.Everblock.Front'}">
+        <h2 class="h5 mb-3">{l s='Quick navigation' mod='everblock' d='Modules.Everblock.Front'}</h2>
+        <div class="everblock-faqs-nav__list" role="list">
+          {foreach from=$everblock_faqs item=faq}
+            <a class="everblock-faqs-nav__link" href="#headingEverFaq{$faq->id_everblock_faq}" role="listitem">
+              <span class="everblock-faqs-nav__title">{$faq->title}</span>
+              <span class="everblock-faqs-nav__pill">{l s='View answer' mod='everblock' d='Modules.Everblock.Front'}</span>
+            </a>
+          {/foreach}
+        </div>
+      </div>
+
       {assign var='everFaqs' value=$everblock_faqs}
       {include file='module:everblock/views/templates/hook/faq.tpl'}
 

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -18,18 +18,18 @@
 
 {if isset($everFaqs) && $everFaqs}
   <div id="everblockFaq">
-    <div class="accordion faq-accordion" id="faqAccordion">
+    <div class="accordion faq-accordion everblock-faq-accordion" id="faqAccordion">
       {foreach from=$everFaqs item=faq name=faqloop}
-        <div class="accordion-item card mb-4">
+        <article class="accordion-item card mb-4 everblock-faq-item" itemscope itemtype="https://schema.org/Question">
           <div class="accordion-header card-header p-0 h2" id="headingEverFaq{$faq->id_everblock_faq}">
             <div class="d-flex align-items-center gap-2 px-4 py-3">
               <button class="accordion-button btn btn-link faq-question flex-grow-1 d-flex justify-content-between align-items-center w-100 text-body p-0 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
-                      aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}">
+                      aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}" itemprop="name">
                 <span>{$faq->title}</span>
-                <i class="icon-angle-down" aria-hidden="true"></i>
+                <span class="everblock-faq-icon" aria-hidden="true"></span>
               </button>
               {if isset($faq->tag_link) && $faq->tag_link}
-                <a class="badge bg-primary text-decoration-none" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
+                <a class="badge bg-secondary text-decoration-none everblock-faq-chip" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
                   {$faq->tag_name|escape:'htmlall':'UTF-8'}
                 </a>
               {/if}
@@ -37,9 +37,11 @@
           </div>
           <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
                aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
-            <div class="accordion-body card-body faq-answer">{$faq->content nofilter}</div>
+            <div class="accordion-body card-body faq-answer" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+              <div itemprop="text">{$faq->content nofilter}</div>
+            </div>
           </div>
-        </div>
+        </article>
       {/foreach}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- refresh FAQ page hero, metadata badges, and quick navigation for better UX
- improve accordion semantics with schema.org markup and accessible labels
- update FAQ styling for clearer visuals and hover states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa8acdb608322b9aac034caf8229b)