### PR TITLE
Fix sanitizeUrl visibility for Advent controller

### DIFF
--- a/controllers/front/advent.php
+++ b/controllers/front/advent.php
@@ -401,7 +401,7 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
         return strip_tags($content, '<p><br><strong><em><ul><ol><li><span><div><a>');
     }
 
-    private function sanitizeUrl($value)
+    protected function sanitizeUrl($value)
     {
         if (!is_scalar($value)) {
             return null;


### PR DESCRIPTION
## Summary
- adjust Everblock advent front controller sanitizeUrl visibility to match parent signature and avoid fatal error

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab42a2fe88322a28c8dac6fb8e1ab)