### PR TITLE
Fix sanitizeUrl signature compatibility

### DIFF
--- a/controllers/front/advent.php
+++ b/controllers/front/advent.php
@@ -337,19 +337,19 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
 
         if (!empty($window['button_url'])) {
             $url = $this->sanitizeUrl($window['button_url']);
-            if ($url !== null) {
+            if ($url !== '') {
                 $payload['button_url'] = $url;
             }
         }
 
         if (!empty($window['image']) && is_array($window['image'])) {
             $imageUrl = $this->sanitizeUrl($window['image']['url'] ?? '');
-            if ($imageUrl !== null) {
+            if ($imageUrl !== '') {
                 $payload['image'] = ['url' => $imageUrl];
             }
         } elseif (!empty($window['image']) && is_string($window['image'])) {
             $imageUrl = $this->sanitizeUrl($window['image']);
-            if ($imageUrl !== null) {
+            if ($imageUrl !== '') {
                 $payload['image'] = ['url' => $imageUrl];
             }
         }
@@ -401,19 +401,15 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
         return strip_tags($content, '<p><br><strong><em><ul><ol><li><span><div><a>');
     }
 
-    private function sanitizeUrl($value)
+    public static function sanitizeUrl(string $url): string
     {
-        if (!is_scalar($value)) {
-            return null;
-        }
-
-        $url = trim((string) $value);
+        $url = trim($url);
         if ($url === '') {
-            return null;
+            return '';
         }
 
         if (stripos($url, 'javascript:') === 0) {
-            return null;
+            return '';
         }
 
         if (preg_match('/^(mailto|tel):[^\s]+$/i', $url)) {
@@ -432,7 +428,7 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
             return $url;
         }
 
-        return null;
+        return '';
     }
 
     private function sanitizeColor($value)


### PR DESCRIPTION
## Summary
- update sanitizeUrl signature to match FrontControllerCore contract
- return empty string for invalid URLs and adjust callers to handle empty values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab4d937e4832283fce5c9848251ab)