### PR TITLE
Add option to open past Advent windows

### DIFF
--- a/controllers/front/advent.php
+++ b/controllers/front/advent.php
@@ -113,7 +113,11 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
             ]);
         }
 
-        if ($calendarSettings['restrict_to_current_day'] && $today->format('Y-m-d') !== $windowDate->format('Y-m-d')) {
+        if (
+            $calendarSettings['restrict_to_current_day']
+            && $today->format('Y-m-d') !== $windowDate->format('Y-m-d')
+            && !($calendarSettings['allow_past_windows'] && $today > $windowDate)
+        ) {
             $this->renderJson([
                 'status' => false,
                 'message' => $this->module->l('You can only open today\'s window.', 'advent'),
@@ -181,10 +185,18 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
     private function resolveCalendarSettings(array $settings)
     {
         $restrict = true;
+        $allowPastWindows = false;
         if (array_key_exists('restrict_to_current_day', $settings)) {
             $restrictValue = $this->resolveConfigValue($settings['restrict_to_current_day']);
             if ($restrictValue !== null) {
                 $restrict = (bool) $restrictValue;
+            }
+        }
+
+        if (array_key_exists('allow_past_windows', $settings)) {
+            $allowPastValue = $this->resolveConfigValue($settings['allow_past_windows']);
+            if ($allowPastValue !== null) {
+                $allowPastWindows = (bool) $allowPastValue;
             }
         }
 
@@ -201,6 +213,7 @@ class EverblockAdventModuleFrontController extends ModuleFrontController
 
         return [
             'restrict_to_current_day' => $restrict,
+            'allow_past_windows' => $allowPastWindows,
             'start_date' => $startDate,
         ];
     }

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -4038,6 +4038,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Calendar start date (YYYY-MM-DD)'),
                             'default' => date('Y') . '-12-01',
                         ],
+                        'allow_past_windows' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Allow opening past windows'),
+                            'default' => false,
+                        ],
                         'restrict_to_current_day' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Allow only the current day to be opened'),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -2402,6 +2402,7 @@ $(document).ready(function(){
             isEmployee = !!everblock_is_employee;
         }
         var restrictToCurrentDay = !!config.restrictToCurrentDay && !isEmployee;
+        var allowPastWindows = !!config.allowPastWindows || isEmployee;
         var startDate = parseDateValue(config.startDate);
         var now = new Date();
         var defaultStart = new Date(now.getFullYear(), 11, 1);
@@ -2632,7 +2633,7 @@ $(document).ready(function(){
                 var windowDate = addDays(startDate, day - 1);
                 $window.data('availableOn', windowDate);
                 if (restrictToCurrentDay) {
-                    if (sameDay(windowDate, today)) {
+                    if (sameDay(windowDate, today) || (allowPastWindows && windowDate < today)) {
                         $window.addClass('ever-advent-calendar__window--available');
                     } else {
                         lockWindow($window);

--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -27,6 +27,7 @@
 {capture assign=instructionsHtml}{$block.settings.instructions nofilter}{/capture}
 {assign var=startDate value=$block.settings.start_date|default:''}
 {assign var=restrictToCurrent value=$block.settings.restrict_to_current_day|default:true}
+{assign var=allowPastWindows value=$block.settings.allow_past_windows|default:false}
 {assign var=openedLabel value=$block.settings.opened_label|default:{l s='Opened' mod='everblock'}}
 {if isset($block.settings.snow_enabled)}
     {assign var=snowEnabled value=$block.settings.snow_enabled|@boolval}
@@ -39,6 +40,7 @@
     'token' => $static_token,
     'startDate' => $startDate,
     'restrictToCurrentDay' => (bool) $restrictToCurrent,
+    'allowPastWindows' => (bool) $allowPastWindows,
     'lockedMessage' => $lockedMessageHtml,
     'openedLabel' => $openedLabel,
     'snowEnabled' => (bool) $snowEnabled,


### PR DESCRIPTION
## Summary
- add a global Advent calendar setting to allow opening past-dated windows
- pass the setting through the front-end template and script so past windows can be opened when enabled
- adjust validation logic to permit catching up on previous days while still blocking future windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab727f1808322b93e477e7ff6d393)