### PR TITLE
Remove FAQ quick navigation block

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1215,57 +1215,6 @@
     letter-spacing: 0.01em;
 }
 
-.everblock-faqs-nav {
-    border: 1px solid #e9ecef;
-    border-radius: 0.75rem;
-    padding: 1.25rem;
-    background-color: #ffffff;
-}
-
-.everblock-faqs-nav__list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 0.75rem;
-}
-
-.everblock-faqs-nav__link {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    border: 1px solid #e9ecef;
-    border-radius: 0.65rem;
-    padding: 0.9rem 1rem;
-    text-decoration: none;
-    background-color: #f9fbff;
-    color: #212529;
-    transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.everblock-faqs-nav__link:hover,
-.everblock-faqs-nav__link:focus {
-    border-color: #cfe2ff;
-    box-shadow: 0 10px 30px rgba(13, 110, 253, 0.08);
-    transform: translateY(-1px);
-    outline: none;
-}
-
-.everblock-faqs-nav__title {
-    font-weight: 600;
-}
-
-.everblock-faqs-nav__pill {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    align-self: flex-start;
-    padding: 0.2rem 0.65rem;
-    border-radius: 999px;
-    background-color: #e9f2ff;
-    color: #0d6efd;
-    font-size: 0.8125rem;
-    font-weight: 600;
-}
-
 .faq-accordion .card-header,
 .faq-accordion .accordion-header {
     background-color: #f9fbff;

--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -39,18 +39,6 @@
     </header>
 
     {if $everblock_faqs|@count}
-      <div class="everblock-faqs-nav mb-4" aria-label="{l s='Jump to a question' mod='everblock' d='Modules.Everblock.Front'}">
-        <h2 class="h5 mb-3">{l s='Quick navigation' mod='everblock' d='Modules.Everblock.Front'}</h2>
-        <div class="everblock-faqs-nav__list" role="list">
-          {foreach from=$everblock_faqs item=faq}
-            <a class="everblock-faqs-nav__link" href="#headingEverFaq{$faq->id_everblock_faq}" role="listitem">
-              <span class="everblock-faqs-nav__title">{$faq->title}</span>
-              <span class="everblock-faqs-nav__pill">{l s='View answer' mod='everblock' d='Modules.Everblock.Front'}</span>
-            </a>
-          {/foreach}
-        </div>
-      </div>
-
       {assign var='everFaqs' value=$everblock_faqs}
       {include file='module:everblock/views/templates/hook/faq.tpl'}
 


### PR DESCRIPTION
## Summary
- remove the FAQ page quick navigation section from the template
- delete styling associated with the retired quick navigation component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab99a6d788322b2d0023a7ca829d8)