### PR TITLE
Add Prettyblock for custom iframe embedding

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -105,6 +105,7 @@ class EverblockPrettyBlocks
             $alertTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_alert.tpl';
             $buttonTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_button.tpl';
             $gmapTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_gmap.tpl';
+            $customIframeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl';
             $shortcodeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_shortcode.tpl';
             $iframeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_iframe.tpl';
             $scrollVideoTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl';
@@ -2062,6 +2063,52 @@ class EverblockPrettyBlocks
                         'iframe' => [
                             'type' => 'text',
                             'label' => $module->l('Map iframe link'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+
+            $blocks[] = [
+                'name' => $module->l('Iframe'),
+                'description' => $module->l('Display custom iframe content'),
+                'code' => 'everblock_custom_iframe',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $customIframeTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'iframe_src' => [
+                            'type' => 'text',
+                            'label' => $module->l('Iframe source URL'),
+                            'default' => '',
+                        ],
+                        'iframe_width' => [
+                            'type' => 'text',
+                            'label' => $module->l('Iframe width (like 100% or 600px)'),
+                            'default' => '100%',
+                        ],
+                        'iframe_height' => [
+                            'type' => 'text',
+                            'label' => $module->l('Iframe height (like 400 or 400px)'),
+                            'default' => '400',
+                        ],
+                        'allow_fullscreen' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Allow fullscreen'),
+                            'default' => true,
+                        ],
+                        'loading_behavior' => [
+                            'type' => 'text',
+                            'label' => $module->l('Loading attribute (like lazy)'),
+                            'default' => 'lazy',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
                     ], $module),

--- a/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
@@ -1,0 +1,48 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+  <div class="{if $block.settings.default.container}container{/if}">
+    {if $block.settings.default.container}
+      <div class="row">
+    {/if}
+      <div class="everblock {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+        {if isset($block.settings.iframe_src) && $block.settings.iframe_src}
+          <iframe src="{$block.settings.iframe_src|escape:'htmlall':'UTF-8'}"
+                  width="{if isset($block.settings.iframe_width) && $block.settings.iframe_width}{$block.settings.iframe_width|escape:'htmlall':'UTF-8'}{else}100%{/if}"
+                  height="{if isset($block.settings.iframe_height) && $block.settings.iframe_height}{$block.settings.iframe_height|escape:'htmlall':'UTF-8'}{else}400{/if}"
+                  style="border:0;"
+                  {if isset($block.settings.loading_behavior) && $block.settings.loading_behavior}loading="{$block.settings.loading_behavior|escape:'htmlall':'UTF-8'}"{/if}
+                  {if $block.settings.allow_fullscreen}allowfullscreen{/if}></iframe>
+        {/if}
+      </div>
+    {if $block.settings.default.container}
+      </div>
+    {/if}
+  </div>
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- register a new Prettyblock type for embedding custom iframe content with configurable attributes
- add Smarty template to render the iframe with sizing, loading, and fullscreen options

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579823366c8322b7b32a04be50e087)