### PR TITLE
Category Tabs: fix slider init and default mobile columns

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -57,7 +57,7 @@
                     {if $tabletItems < 1}
                         {assign var='tabletItems' value=1}
                     {/if}
-                    {assign var='mobileItems' value=$state.products_per_slide_mobile|default:1|intval}
+                    {assign var='mobileItems' value=$state.products_per_slide_mobile|default:2|intval}
                     {if $mobileItems < 1}
                         {assign var='mobileItems' value=1}
                     {/if}
@@ -74,7 +74,7 @@
                             {if $useDesktopSlider}
                                 {assign var='carouselIdDesktop' value="category-tabs-carousel-desktop-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
                                 <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
-                                    <div id="{$carouselIdDesktop}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                    <div id="{$carouselIdDesktop}" class="carousel slide prettyblocks-image-slider" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
                                         <div class="carousel-inner products">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             {foreach from=$block.extra.products[$key] item=product name=desktopProducts}
@@ -114,7 +114,7 @@
                             {if $useMobileSlider}
                                 {assign var='carouselIdMobile' value="category-tabs-carousel-mobile-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
                                 <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-block d-md-none">
-                                    <div id="{$carouselIdMobile}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                    <div id="{$carouselIdMobile}" class="carousel slide prettyblocks-image-slider" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
                                         <div class="carousel-inner products">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             {foreach from=$block.extra.products[$key] item=product name=mobileProducts}


### PR DESCRIPTION
### Motivation
- Fix the Prettyblock Category Tabs slider which was not being initialized by the JS and ensure mobile layout shows two products per row as expected.
- Make carousel blocks use the same marker class used by other prettyblocks carousels so shared JS in `views/js/everblock.js` will initialize them.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to change the default `products_per_slide_mobile` value from `1` to `2`.
- Add the `prettyblocks-image-slider` class to the desktop and mobile carousel container `div`s in the category tabs template so the carousel initialization code targets them.
- Changes are limited to the `prettyblock_category_tabs.tpl` template and do not modify JS behavior.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e547877b0832287239b40271cc764)