### PR TITLE
Fix category tabs carousel initialization when slick is absent

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -116,6 +116,58 @@ $(document).ready(function(){
         }
         return url + separator + 'autoplay=1&loop=1';
     }
+    function initPrettyblocksImageSlider($context) {
+        var $scope = $context && $context.length ? $context : $(document);
+        $scope.find('.prettyblocks-image-slider').each(function(){
+            var $carousel = $(this);
+            if ($carousel.hasClass('prettyblocks-carousel-initialised')) {
+                return;
+            }
+            var $slides = $carousel.find('.carousel-item');
+            if ($slides.length <= 1) {
+                $carousel.addClass('prettyblocks-carousel-initialised');
+                return;
+            }
+            var autoplay = parseInt($carousel.data('autoplay'), 10) === 1;
+            var autoplaySpeed = parseInt($carousel.data('autoplaySpeed'), 10);
+            if (isNaN(autoplaySpeed) || autoplaySpeed <= 0) {
+                autoplaySpeed = 5000;
+            }
+            var transitionSpeed = parseInt($carousel.data('transitionSpeed'), 10);
+            if (!isNaN(transitionSpeed) && transitionSpeed > 0) {
+                $carousel.css('--prettyblocks-transition-speed', transitionSpeed + 'ms');
+            }
+            var pauseOnHover = parseInt($carousel.data('pauseOnHover'), 10) !== 0 ? 'hover' : false;
+            var config = {
+                interval: autoplay ? autoplaySpeed : false,
+                pause: pauseOnHover,
+                ride: autoplay ? 'carousel' : false,
+                wrap: true,
+                keyboard: true,
+                touch: true
+            };
+            try {
+                if (typeof bootstrap !== 'undefined' && typeof bootstrap.Carousel !== 'undefined') {
+                    var existingInstance = bootstrap.Carousel.getInstance($carousel[0]);
+                    if (existingInstance) {
+                        existingInstance.dispose();
+                    }
+                    var newInstance = new bootstrap.Carousel($carousel[0], config);
+                    if (!autoplay && newInstance && typeof newInstance.pause === 'function') {
+                        newInstance.pause();
+                    }
+                } else if (typeof $carousel.carousel === 'function') {
+                    $carousel.carousel(config);
+                    if (!autoplay) {
+                        $carousel.carousel('pause');
+                    }
+                }
+            } catch (e) {
+                console.error('Prettyblocks carousel initialization failed', e);
+            }
+            $carousel.addClass('prettyblocks-carousel-initialised');
+        });
+    }
     if ($.fn.slick) {
         $('.ever-slick-carousel:not(.slick-initialised)').each(function(){
             var $carousel = $(this);
@@ -187,56 +239,8 @@ $(document).ready(function(){
                 }]
             });
         });
-        $('.prettyblocks-image-slider').each(function(){
-            var $carousel = $(this);
-            if ($carousel.hasClass('prettyblocks-carousel-initialised')) {
-                return;
-            }
-            var $slides = $carousel.find('.carousel-item');
-            if ($slides.length <= 1) {
-                $carousel.addClass('prettyblocks-carousel-initialised');
-                return;
-            }
-            var autoplay = parseInt($carousel.data('autoplay'), 10) === 1;
-            var autoplaySpeed = parseInt($carousel.data('autoplaySpeed'), 10);
-            if (isNaN(autoplaySpeed) || autoplaySpeed <= 0) {
-                autoplaySpeed = 5000;
-            }
-            var transitionSpeed = parseInt($carousel.data('transitionSpeed'), 10);
-            if (!isNaN(transitionSpeed) && transitionSpeed > 0) {
-                $carousel.css('--prettyblocks-transition-speed', transitionSpeed + 'ms');
-            }
-            var pauseOnHover = parseInt($carousel.data('pauseOnHover'), 10) !== 0 ? 'hover' : false;
-            var config = {
-                interval: autoplay ? autoplaySpeed : false,
-                pause: pauseOnHover,
-                ride: autoplay ? 'carousel' : false,
-                wrap: true,
-                keyboard: true,
-                touch: true
-            };
-            try {
-                if (typeof bootstrap !== 'undefined' && typeof bootstrap.Carousel !== 'undefined') {
-                    var existingInstance = bootstrap.Carousel.getInstance($carousel[0]);
-                    if (existingInstance) {
-                        existingInstance.dispose();
-                    }
-                    var newInstance = new bootstrap.Carousel($carousel[0], config);
-                    if (!autoplay && newInstance && typeof newInstance.pause === 'function') {
-                        newInstance.pause();
-                    }
-                } else if (typeof $carousel.carousel === 'function') {
-                    $carousel.carousel(config);
-                    if (!autoplay) {
-                        $carousel.carousel('pause');
-                    }
-                }
-            } catch (e) {
-                console.error('Prettyblocks carousel initialization failed', e);
-            }
-            $carousel.addClass('prettyblocks-carousel-initialised');
-        });
     }
+    initPrettyblocksImageSlider();
     $('[data-ever-infinite-carousel="1"]').each(function(){
         var $carousel = $(this);
         var $inner = $carousel.find('.carousel-inner');
@@ -3182,6 +3186,7 @@ $(document).ready(function(){
 
             setTimeout(function () {
                 $(window).trigger('resize');
+                initPrettyblocksImageSlider($context);
             }, 0);
         }
 


### PR DESCRIPTION
### Motivation
- The Category Tabs prettyblock slider was not initializing when the slick plugin was not present, making the slider toggle ineffective on desktop and mobile.
- Carousel init code for `.prettyblocks-image-slider` was embedded inside a `$.fn.slick` guard, preventing Bootstrap carousels from being initialized independently.
- Tab content updates (when switching tabs) need the carousels to be re-initialized because DOM/product lists are replaced dynamically.

### Description
- Added a reusable `initPrettyblocksImageSlider($context)` function that initializes `.prettyblocks-image-slider` carousels using `bootstrap.Carousel` or fallback jQuery carousel API. 
- Replaced the duplicated inline carousel loop by calling `initPrettyblocksImageSlider()` on document ready and after tab refreshes. 
- Hooked `initPrettyblocksImageSlider($context)` into the category-tabs refresh flow (`refreshProducts`) so carousels are re-initialized after a tab is shown. 
- Preserved prior behavior for autoplay, pause, transition speed and single-slide optimization, and mark carousels with `prettyblocks-carousel-initialised` to avoid double-init.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e56d054cc8322a919edfaa820dd9a)