### PR TITLE
Add title attributes to Prettyblock template links

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl
@@ -132,7 +132,7 @@
                                         <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
                                     </form>
                                     <div class="text-center mt-3">
-                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}" title="{l s='Create account' mod='everblock'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
                                 </div>
                             </div>

--- a/views/templates/hook/prettyblocks/prettyblock_button.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_button.tpl
@@ -32,7 +32,7 @@
                 {$state.button_content nofilter}
             </span>
             {else}
-            <a href="{$state.button_link}" class="btn btn-{$state.button_type} {if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}"{if isset($state.color) && $state.color} style="color:{$state.color|escape:'htmlall':'UTF-8'};"{/if}>
+            <a href="{$state.button_link}" class="btn btn-{$state.button_type} {if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" title="{$state.button_content|strip_tags|escape:'htmlall':'UTF-8'}"{if isset($state.color) && $state.color} style="color:{$state.color|escape:'htmlall':'UTF-8'};"{/if}>
                 {$state.button_content nofilter}
             </a>
             {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -35,7 +35,7 @@
                 {foreach from=$block.states item=state key=key name=categorytabs}
                     {assign var='tabId' value="tab-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key}
                     <li class="nav-item">
-                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" id="{$tabId}-tab" data-toggle="tab" data-bs-toggle="tab" data-bs-target="#{$tabId}" href="#{$tabId}" role="tab" aria-controls="{$tabId}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}">
+                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" id="{$tabId}-tab" data-toggle="tab" data-bs-toggle="tab" data-bs-target="#{$tabId}" href="#{$tabId}" role="tab" aria-controls="{$tabId}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}" title="{$state.name|escape:'htmlall'}">
                             {$state.name}
                         </a>
                     </li>

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -105,15 +105,15 @@
             {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
               <div class="d-flex justify-content-center gap-2">
                 {if $state.btn1_text && $state.btn1_link}
-                  <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
+                  <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}" title="{$state.btn1_text|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
                 {/if}
                 {if $state.btn2_text && $state.btn2_link}
-                  <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
+                  <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}" title="{$state.btn2_text|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
                 {/if}
               </div>
             {/if}
             {if $prettyblock_cover_link}
-              <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}"></a>
+              <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}" title="{$state.title|default:''|escape:'htmlall'}"></a>
             {/if}
           </div>
         </div>
@@ -198,15 +198,15 @@
           {if ($state.btn1_text && $state.btn1_link) || ($state.btn2_text && $state.btn2_link)}
             <div class="d-flex justify-content-center gap-2">
               {if $state.btn1_text && $state.btn1_link}
-                <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
+                <a href="{$state.btn1_link|escape:'htmlall'}" class="btn btn-{$state.btn1_type|escape:'htmlall'}" title="{$state.btn1_text|escape:'htmlall'}">{$state.btn1_text|escape:'htmlall'}</a>
               {/if}
               {if $state.btn2_text && $state.btn2_link}
-                <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
+                <a href="{$state.btn2_link|escape:'htmlall'}" class="btn btn-{$state.btn2_type|escape:'htmlall'}" title="{$state.btn2_text|escape:'htmlall'}">{$state.btn2_text|escape:'htmlall'}</a>
               {/if}
             </div>
           {/if}
           {if $prettyblock_cover_link}
-            <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}"></a>
+            <a href="{$prettyblock_cover_link|escape:'htmlall'}" class="prettyblock-cover-full-link stretched-link" aria-label="{$state.title|default:''|escape:'htmlall'}" title="{$state.title|default:''|escape:'htmlall'}"></a>
           {/if}
         </div>
       </div>

--- a/views/templates/hook/prettyblocks/prettyblock_cta.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cta.tpl
@@ -45,7 +45,7 @@
             {$state.content nofilter}
           {/if}
           {if $state.cta_link && $state.cta_text}
-            <a href="{$state.cta_link|escape:'htmlall'}" class="btn btn-primary btn-cta mt-3">
+            <a href="{$state.cta_link|escape:'htmlall'}" class="btn btn-primary btn-cta mt-3" title="{$state.cta_text|strip_tags|escape:'htmlall'}">
               {$state.cta_text nofilter}
             </a>
           {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
@@ -44,7 +44,7 @@
           {/if}
           <div>
             {if isset($state.file.url) && $state.file.url}
-              <a href="{$state.file.url|escape:'htmlall'}" class="download-title" download>{$state.title|escape:'htmlall'}</a>
+              <a href="{$state.file.url|escape:'htmlall'}" class="download-title" download title="{$state.title|escape:'htmlall'}">{$state.title|escape:'htmlall'}</a>
             {else}
               <span class="download-title">{$state.title|escape:'htmlall'}</span>
             {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl
@@ -37,7 +37,7 @@
             {if $state.title}<h4>{$state.title}</h4>{/if}
             {if $state.message}<p>{$state.message}</p>{/if}
             {if $state.cta_label}
-              <a href="{$state.cta_url}" class="btn btn-primary">{$state.cta_label}</a>
+              <a href="{$state.cta_url}" class="btn btn-primary" title="{$state.cta_label|escape:'htmlall'}">{$state.cta_label}</a>
             {/if}
           </div>
         </div>

--- a/views/templates/hook/prettyblocks/prettyblock_faq.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_faq.tpl
@@ -77,7 +77,7 @@
                   <div class="prettyblock-faq-answer text-body-secondary mb-3">{$state.answer nofilter}</div>
                 {/if}
                 {if $state.link_url}
-                  <a class="prettyblock-faq-link d-inline-flex align-items-center fw-semibold" href="{$state.link_url|escape:'htmlall':'UTF-8'}">
+                  <a class="prettyblock-faq-link d-inline-flex align-items-center fw-semibold" href="{$state.link_url|escape:'htmlall':'UTF-8'}" title="{$state.link_label|default:$module->l('Learn more')|escape:'htmlall':'UTF-8'}">
                     <span>{$state.link_label|default:$module->l('Learn more')|escape:'htmlall':'UTF-8'}</span>
                     <span class="ms-2" aria-hidden="true">&rarr;</span>
                   </a>
@@ -90,7 +90,7 @@
 
       {if $block.settings.cta_link}
         <div class="mt-4 text-center">
-          <a class="btn btn-dark rounded-pill px-4 py-3 prettyblock-faq-cta" href="{$block.settings.cta_link|escape:'htmlall':'UTF-8'}">
+          <a class="btn btn-dark rounded-pill px-4 py-3 prettyblock-faq-cta" href="{$block.settings.cta_link|escape:'htmlall':'UTF-8'}" title="{$block.settings.cta_text|escape:'htmlall':'UTF-8'}">
             {$block.settings.cta_text|escape:'htmlall':'UTF-8'}
           </a>
         </div>

--- a/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
@@ -78,10 +78,10 @@
                 <div class="mb-3">{$guide_summary nofilter}</div>
               {/if}
               {if $guide_link}
-                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
+                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link" title="{$guide_title|default:$state.cta_text|escape:'htmlall':'UTF-8'}"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
               {/if}
               {if $guide_link && $state.cta_text}
-                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary"{if $state.target_blank} target="_blank" rel="noopener"{/if}>
+                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary" title="{$state.cta_text|escape:'htmlall':'UTF-8'}"{if $state.target_blank} target="_blank" rel="noopener"{/if}>
                   {$state.cta_text|escape:'htmlall':'UTF-8'}
                 </a>
               {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_image_map.tpl
@@ -34,7 +34,7 @@
         <div>{$block.settings.content nofilter}</div>
       {/if}
       {if $block.settings.button_link && $block.settings.button_text}
-        <a href="{$block.settings.button_link|escape:'htmlall'}" class="btn btn-primary mt-3">
+        <a href="{$block.settings.button_link|escape:'htmlall'}" class="btn btn-primary mt-3" title="{$block.settings.button_text|escape:'htmlall'}">
           {$block.settings.button_text|escape:'htmlall'}
         </a>
       {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -80,7 +80,7 @@
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">
             {if isset($state.url) && $state.url}
-              <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative">
+              <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
             {/if}
               <picture>
                 {if isset($state.banner_mobile.url) && $state.banner_mobile.url}
@@ -152,7 +152,7 @@
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">
             {if isset($state.url) && $state.url}
-              <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative">
+              <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
             {/if}
               <picture>
                 {if isset($state.banner_mobile.url) && $state.banner_mobile.url}

--- a/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl
@@ -215,11 +215,11 @@
             {/foreach}
           </div>
           {if $showArrows}
-            <a class="carousel-control-prev" href="#{$carouselId}" role="button" data-slide="prev" data-bs-slide="prev">
+            <a class="carousel-control-prev" href="#{$carouselId}" role="button" data-slide="prev" data-bs-slide="prev" title="{l s='Previous' mod='everblock'}">
               <span class="carousel-control-prev-icon" aria-hidden="true"></span>
               <span class="sr-only visually-hidden">Previous</span>
             </a>
-            <a class="carousel-control-next" href="#{$carouselId}" role="button" data-slide="next" data-bs-slide="next">
+            <a class="carousel-control-next" href="#{$carouselId}" role="button" data-slide="next" data-bs-slide="next" title="{l s='Next' mod='everblock'}">
               <span class="carousel-control-next-icon" aria-hidden="true"></span>
               <span class="sr-only visually-hidden">Next</span>
             </a>

--- a/views/templates/hook/prettyblocks/prettyblock_latest_guides.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_latest_guides.tpl
@@ -61,9 +61,9 @@
               {/if}
               {assign var='guide_link' value=Context::getContext()->link->getModuleLink('everblock', 'page', ['id_everblock_page' => $guide->id, 'rewrite' => $guide->link_rewrite[Context::getContext()->language->id]|default:''])}
               {if $guide_link}
-                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link"></a>
+                <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="stretched-link" title="{$guide->title|default:$guide->name|default:''|escape:'htmlall':'UTF-8'}"></a>
               {/if}
-              <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary">
+              <a href="{$guide_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary" title="{l s='Read guide' mod='everblock' d='Modules.Everblock.Front'}">
                 {l s='Read guide' mod='everblock' d='Modules.Everblock.Front'}
               </a>
             </div>

--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -31,7 +31,7 @@
       {foreach from=$block.states item=state key=key}
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
         <li class="{if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}">
-          <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
+          <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
         </li>
       {/foreach}
     </ul>

--- a/views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl
@@ -148,7 +148,7 @@
                                         <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
                                     </form>
                                     <div class="text-center mt-3">
-                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}" title="{l s='Create account' mod='everblock'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
                                 </div>
                             </div>

--- a/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl
@@ -54,10 +54,10 @@
                 <div class="mb-3">{$state.summary nofilter}</div>
               {/if}
               {if $page_link}
-                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="stretched-link"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
+                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="stretched-link" title="{$page_title|default:$state.cta_text|escape:'htmlall':'UTF-8'}"{if $state.target_blank} target="_blank" rel="noopener"{/if}></a>
               {/if}
               {if $page_link && $state.cta_text}
-                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary"{if $state.target_blank} target="_blank" rel="noopener"{/if}>
+                <a href="{$page_link|escape:'htmlall':'UTF-8'}" class="btn btn-primary" title="{$state.cta_text|escape:'htmlall':'UTF-8'}"{if $state.target_blank} target="_blank" rel="noopener"{/if}>
                   {$state.cta_text|escape:'htmlall':'UTF-8'}
                 </a>
               {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl
@@ -45,7 +45,7 @@
             </ul>
           {/if}
           {if $state.cta_url && $state.cta_label}
-            <a href="{$state.cta_url|escape:'htmlall'}" class="btn btn-primary">{$state.cta_label|escape:'htmlall'}</a>
+            <a href="{$state.cta_url|escape:'htmlall'}" class="btn btn-primary" title="{$state.cta_label|escape:'htmlall'}">{$state.cta_label|escape:'htmlall'}</a>
           {/if}
         </div>
       </div>

--- a/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_product_highlight.tpl
@@ -58,7 +58,7 @@
           {$block.settings.custom_text nofilter}
         </p>
 
-        <a href="{$product.url}" class="btn btn-warning text-dark border-0 fw-bold rounded-pill px-4 py-2">
+        <a href="{$product.url}" class="btn btn-warning text-dark border-0 fw-bold rounded-pill px-4 py-2" title="{l s='See the product' mod='everblock'}">
           {l s='See the product' mod='everblock'}
         </a>
       </div>

--- a/views/templates/hook/prettyblocks/prettyblock_scratch_card.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_scratch_card.tpl
@@ -108,7 +108,7 @@
                                         <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
                                     </form>
                                     <div class="text-center mt-3">
-                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}" title="{l s='Create account' mod='everblock'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
                                 </div>
                             </div>

--- a/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl
@@ -39,7 +39,7 @@
             <div class="everblock-scroll-video-content">
                 {if isset($state.title) && $state.title}<h3>{$state.title|escape:'htmlall':'UTF-8'}</h3>{/if}
                 {if isset($state.content) && $state.content}<p>{$state.content|escape:'htmlall':'UTF-8'}</p>{/if}
-                {if isset($state.button_label) && $state.button_label && isset($state.button_url) && $state.button_url}<a href="{$state.button_url|escape:'htmlall':'UTF-8'}" class="btn btn-primary">{$state.button_label|escape:'htmlall':'UTF-8'}</a>{/if}
+                {if isset($state.button_label) && $state.button_label && isset($state.button_url) && $state.button_url}<a href="{$state.button_url|escape:'htmlall':'UTF-8'}" class="btn btn-primary" title="{$state.button_label|escape:'htmlall':'UTF-8'}">{$state.button_label|escape:'htmlall':'UTF-8'}</a>{/if}
             </div>
         </div>
     {/foreach}

--- a/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
@@ -32,7 +32,7 @@
       <div class="everblock-sharer {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_spacing_style}">
         <!-- Bouton de partage Facebook -->
         <div class="social-share-button">
-          <a href="https://www.facebook.com/sharer/sharer.php?u={$urls.current_url nofilter}" target="_blank">
+          <a href="https://www.facebook.com/sharer/sharer.php?u={$urls.current_url nofilter}" target="_blank" title="{l s='Share on Facebook' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#1877f2" width="24" height="24">
               <path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h8v-7h-3v-3h3V9.364C11 6.364 12.79 5 15.5 5c1.77 0 3.25.66 3.5 1.5h2V8h-2c-.28 0-.5-.22-.5-.5V5h3l-.362 3H19v3h3l-.5 3h-2v7h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
             </svg>
@@ -41,7 +41,7 @@
 
         <!-- Bouton de partage Twitter -->
         <div class="social-share-button">
-          <a href="https://twitter.com/intent/tweet?url={$urls.current_url nofilter}" target="_blank">
+          <a href="https://twitter.com/intent/tweet?url={$urls.current_url nofilter}" target="_blank" title="{l s='Share on Twitter' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#1da1f2" width="24" height="24">
               <path d="M23.954 4.563c-.885.389-1.83.652-2.825.773 1.014-.611 1.795-1.574 2.164-2.723-.95.564-2.004.974-3.125 1.194-.894-.957-2.165-1.555-3.574-1.555-2.704 0-4.896 2.19-4.896 4.884 0 .383.043.756.127 1.117-4.068-.204-7.674-2.149-10.084-5.106-.42.724-.661 1.566-.661 2.465 0 1.7.865 3.195 2.174 4.075-.801-.025-1.553-.246-2.214-.612v.062c0 2.365 1.681 4.336 3.92 4.783-.41.11-.844.169-1.291.169-.314 0-.615-.03-.918-.086.622 1.92 2.429 3.32 4.572 3.357-1.675 1.311-3.787 2.09-6.077 2.09-.395 0-.787-.023-1.174-.068 2.163 1.387 4.73 2.198 7.5 2.198 9.001 0 13.92-7.464 13.92-13.926 0-.21-.005-.419-.014-.627.955-.692 1.794-1.557 2.458-2.542l-.047-.02z"/>
             </svg>
@@ -50,7 +50,7 @@
 
         <!-- Bouton de partage LinkedIn -->
         <div class="social-share-button">
-          <a href="https://www.linkedin.com/shareArticle?url={$urls.current_url nofilter}" target="_blank">
+          <a href="https://www.linkedin.com/shareArticle?url={$urls.current_url nofilter}" target="_blank" title="{l s='Share on LinkedIn' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#bd081c" width="24" height="24">
               <path d="M12 0c6.628 0 12 5.372 12 12 0 5.237-3.348 9.683-8 11.313-.117-1.001.238-2.663.557-3.981.063-.256.031-.332-.167-.523-.537-.532-1.043-1.28-1.043-2.211 0-1.718 1.235-3.001 2.764-3.001 1.307 0 1.938.982 1.938 2.162 0 1.318-.838 3.284-1.273 5.111-.361 1.517.765 2.742 2.266 2.742 2.718 0 4.548-3.559 4.548-7.891 0-3.325-2.338-5.68-5.634-5.68-4.093 0-6.524 3.078-6.524 6.27 0 1.273.52 2.66 1.16 3.394.129.152.147.213.1.389-.088.344-.289 1.084-.329 1.24-.045.165-.152.201-.334.12-1.08-.49-1.766-1.96-1.766-3.407 0-2.662 1.936-5.013 5.505-5.013 2.853 0 4.96 1.924 4.96 4.486 0 2.995-1.756 5.312-4.324 5.312-.845 0-1.639-.44-1.91-1.037 0 0-.443 1.688-.54 2.06-.203.769-.753 1.534-1.276 2.135-.942.962-2.234 1.726-3.582 1.958-.668.118-1.336.07-1.998-.102-.293-.069-.352-.16-.33-.453.027-.648.074-1.284.135-1.917.074-.803-1.354-14.07-1.354-14.07-.24-1.081.006-2.216.727-3.083.655-.808 1.503-1.3 2.412-1.393 2.062-.18 4.105-.154 6.158-.156z"/>
             </svg>

--- a/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl
@@ -26,7 +26,7 @@
   {/if}
 {prettyblocks_zone zone_name="block-shoppingcart-{$block.id_prettyblocks}-before"}
 <div id="_desktop_cart" class="ever-shopping-cart dropdown"  style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
-  <a rel="nofollow" aria-label="{l s='Shopping cart link containing nbProducts product(s)' sprintf=['nbProducts' => $cart.products_count] mod='everblock'}" href="{$urls.pages.cart}" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown">
+  <a rel="nofollow" aria-label="{l s='Shopping cart link containing nbProducts product(s)' sprintf=['nbProducts' => $cart.products_count] mod='everblock'}" href="{$urls.pages.cart}" class="btn btn-outline-primary dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" title="{l s='View cart' mod='everblock'}">
     <i class="material-icons shopping-cart" aria-hidden="true">shopping_cart</i>
     <span class="hidden-sm-down">{l s='Cart' mod='everblock'}</span>
     <span class="cart-products-count">({$cart.products_count})</span>
@@ -53,7 +53,7 @@
       <span class="total-label">{l s='Total' mod='everblock'}</span>
       <span class="total-value">{$cart.totals.total.value}</span>
     </div>
-    <a href="{$urls.pages.cart}" class="btn btn-primary btn-block w-100 text-white">{l s='View Cart' mod='everblock'}</a>
+    <a href="{$urls.pages.cart}" class="btn btn-primary btn-block w-100 text-white" title="{l s='View Cart' mod='everblock'}">{l s='View Cart' mod='everblock'}</a>
   </div>
 </div>
 {prettyblocks_zone zone_name="block-shoppingcart-{$block.id_prettyblocks}-after"}

--- a/views/templates/hook/prettyblocks/prettyblock_slot_machine.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_slot_machine.tpl
@@ -130,7 +130,7 @@
                                         <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
                                     </form>
                                     <div class="text-center mt-3">
-                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}" title="{l s='Create account' mod='everblock'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
                                 </div>
                             </div>

--- a/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_special_event.tpl
@@ -32,7 +32,7 @@
             <h2 class="mb-3" style="{if $state.text_color}color:{$state.text_color}!important;{/if}">{$state.title nofilter}</h2>
           {/if}
           {if $state.cta_link && $state.cta_text}
-            <a href="{$state.cta_link|escape:'htmlall'}" class="btn btn-primary mb-3">{$state.cta_text nofilter}</a>
+            <a href="{$state.cta_link|escape:'htmlall'}" class="btn btn-primary mb-3" title="{$state.cta_text|strip_tags|escape:'htmlall'}">{$state.cta_text nofilter}</a>
           {/if}
           {if $state.target_date}
             <div class="everblock-countdown d-flex justify-content-center" data-target="{$state.target_date|escape:'htmlall'}">

--- a/views/templates/hook/prettyblocks/prettyblock_tab.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_tab.tpl
@@ -34,7 +34,7 @@
             <ul class="nav nav-tabs" role="tablist">
                 {foreach from=$block.states item=state key=key}
                     <li class="nav-item">
-                        <a class="nav-link {if $key == 0}active{/if}" data-toggle="tab" data-bs-toggle="tab" href="#tab-{$block.id_prettyblocks}-{$key}" role="tab" aria-controls="tab-{$block.id_prettyblocks}-{$key}" aria-selected="{if $key == 0}true{else}false{/if}">
+                        <a class="nav-link {if $key == 0}active{/if}" data-toggle="tab" data-bs-toggle="tab" href="#tab-{$block.id_prettyblocks}-{$key}" role="tab" aria-controls="tab-{$block.id_prettyblocks}-{$key}" aria-selected="{if $key == 0}true{else}false{/if}" title="{$state.name|escape:'htmlall'}">
                             {$state.name}
                         </a>
                     </li>

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
@@ -49,11 +49,11 @@
                 </div>
             {/foreach}
         </div>
-        <a class="carousel-control-prev" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="prev" data-bs-slide="prev">
+        <a class="carousel-control-prev" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="prev" data-bs-slide="prev" title="{l s='Previous' mod='everblock'}">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
             <span class="sr-only visually-hidden">Previous</span>
         </a>
-        <a class="carousel-control-next" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="next" data-bs-slide="next">
+        <a class="carousel-control-next" href="#testimonialCarousel-{$block.id_prettyblocks}" role="button" data-slide="next" data-bs-slide="next" title="{l s='Next' mod='everblock'}">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="sr-only visually-hidden">Next</span>
         </a>

--- a/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_wheel_of_fortune.tpl
@@ -106,7 +106,7 @@
                                         <button class="btn btn-primary btn-block" type="submit">{l s='Sign in' mod='everblock'}</button>
                                     </form>
                                     <div class="text-center mt-3">
-                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}">{l s='Create account' mod='everblock'}</a>
+                                        <a href="{$link->getPageLink('authentication', true)|escape:'htmlall':'UTF-8'}?create_account=1&back={$urls.current_url|escape:'htmlall':'UTF-8'}" title="{l s='Create account' mod='everblock'}">{l s='Create account' mod='everblock'}</a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
### Motivation
- Improve accessibility and consistent hover text by ensuring all interactive links inside Prettyblock templates include a `title` attribute.
- Avoid missing descriptive metadata for screen readers and improve UX for controls like carousels and CTA buttons.

### Description
- Added `title` attributes to `<a>` elements across Prettyblock templates (about 27 files changed) including carousels, CTAs, guide links, sharer buttons, shopping cart, login/create-account links and more.
- Where appropriate the `title` uses existing labels or localized strings (e.g. `{l s='Previous' mod='everblock'}`, state/CTA labels or `{$state.title}`) and uses `strip_tags`/`escape` to sanitize content.
- Minor markup updates to ensure stretched links and icon links also receive `title` attributes for consistent behavior.
- Files touched include `prettyblock_img.tpl`, `prettyblock_img_slider.tpl`, `prettyblock_sharer.tpl`, `prettyblock_link_list.tpl`, `prettyblock_downloads.tpl`, `prettyblock_cover.tpl`, `prettyblock_cta.tpl`, `prettyblock_pricing_table.tpl`, `prettyblock_latest_guides.tpl`, `prettyblock_shopping_cart.tpl`, `prettyblock_slot_machine.tpl`, `prettyblock_scratch_card.tpl`, `prettyblock_faq.tpl`, `prettyblock_tab.tpl`, `prettyblock_category_tabs.tpl`, `prettyblock_button.tpl`, `prettyblock_scroll_video.tpl`, `prettyblock_testimonial_slider.tpl`, `prettyblock_wheel_of_fortune.tpl` and other Prettyblock templates (27 files total).

### Testing
- Ran automated scans using `rg`/a small `python` script to locate `<a` tags missing a `title` attribute and iteratively fixed reported occurrences, confirming updated templates no longer lacked `title` in the reviewed locations. (scan + verification completed)
- Inspected modified templates with line-aware listing (`nl -ba`) to verify the `title` attributes were added in expected places.
- Committed the changes with `git commit` after verification, showing `27 files changed` in the working tree.
- No unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b5b9859083228e0fca439ecc46f5)