### PR TITLE
Allow elements with `data-everclickmodal` to trigger Everblock modal

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -354,7 +354,7 @@ $(document).ready(function(){
         });
     });
 
-    $(document).on('click', '.everblock-modal-button', function(e) {
+    $(document).on('click', '.everblock-modal-button, [data-everclickmodal]', function(e) {
         e.preventDefault();
         let blockId = $(this).data('everclickmodal');
         let cmsId = $(this).data('evercms');


### PR DESCRIPTION
### Motivation
- The click handler only reacted to elements with the `.everblock-modal-button` class, preventing elements that only have the `data-everclickmodal` attribute from opening the modal.
- Make it possible to trigger the Everblock modal from any element that declares `data-everclickmodal` without requiring a specific CSS class.

### Description
- Changed the delegated click selector in `views/js/everblock.js` from `'.everblock-modal-button'` to `'.everblock-modal-button, [data-everclickmodal]'`.
- The existing modal data handling (`data-everclickmodal`, `data-evercms`, `data-evermodal`) and AJAX flow are left unchanged to preserve current behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ba1732e08322a6507c2982a41d15)