### PR TITLE
Fix category tabs sliders initialization

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -74,7 +74,7 @@
                             {if $useDesktopSlider}
                                 {assign var='carouselIdDesktop' value="category-tabs-carousel-desktop-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
                                 <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
-                                    <div id="{$carouselIdDesktop}" class="carousel slide prettyblocks-image-slider" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                    <div id="{$carouselIdDesktop}" class="carousel slide prettyblocks-image-slider" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true">
                                         <div class="carousel-inner products">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             {foreach from=$block.extra.products[$key] item=product name=desktopProducts}
@@ -114,7 +114,7 @@
                             {if $useMobileSlider}
                                 {assign var='carouselIdMobile' value="category-tabs-carousel-mobile-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
                                 <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-block d-md-none">
-                                    <div id="{$carouselIdMobile}" class="carousel slide prettyblocks-image-slider" data-ride="false" data-bs-ride="false" data-bs-wrap="true">
+                                    <div id="{$carouselIdMobile}" class="carousel slide prettyblocks-image-slider" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true">
                                         <div class="carousel-inner products">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             {foreach from=$block.extra.products[$key] item=product name=mobileProducts}


### PR DESCRIPTION
### Motivation
- Category tab sliders were not initializing because the carousel ride attributes were set to disable initialization.
- The template targets both desktop and mobile carousel instances that must be initialized by Bootstrap for navigation to work.

### Description
- Updated `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to enable carousel auto-initialization.
- Replaced `data-ride="false"` and `data-bs-ride="false"` with `data-ride="carousel"` and `data-bs-ride="carousel"` on both desktop and mobile carousel containers.
- This change ensures Bootstrap will recognize and activate the carousels rendered in the category tabs.

### Testing
- No automated tests were run for this change.
- Changes were committed locally and the template file was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d15de4548322b2468199e6de3b04)