### PR TITLE
Fix host comparison and use Tools::file_get_contents for image downloads

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -6117,10 +6117,13 @@ class EverblockTools extends ObjectModel
     {
         // Parse the current domain and the image URL
         $parsedUrl = parse_url($url);
-        $currentDomain = Tools::getHttpHost(true) . __PS_BASE_URI__;
+        $currentHost = parse_url(Tools::getHttpHost(true), PHP_URL_HOST);
+        if (!$currentHost) {
+            $currentHost = Tools::getHttpHost(false);
+        }
 
         // Check if the image is hosted on a different domain
-        if (isset($parsedUrl['host']) && $parsedUrl['host'] !== $currentDomain) {
+        if (isset($parsedUrl['host']) && $currentHost && $parsedUrl['host'] !== $currentHost) {
             // Download the image and return the local file path
             return self::downloadImage($url);
         } else {
@@ -6142,7 +6145,7 @@ class EverblockTools extends ObjectModel
             $localPath = _PS_ROOT_DIR_ . '/img/cms/' . $fileName;
 
             // Download the image
-            $imageContents = file_get_contents($url);
+            $imageContents = Tools::file_get_contents($url);
             if ($imageContents === false) {
                 return false; // Return false if the download failed
             }


### PR DESCRIPTION
### Motivation
- The webp conversion attempted remote downloads for same-host images due to an incorrect domain comparison, which produced HTTP failures and console errors.
- Using raw `file_get_contents` produced PHP warnings when remote fetches failed during image downloads.
- Resolving same-host URLs to local file paths avoids unnecessary network requests and potential service errors.
- Using the framework helper for fetching improves error handling and suppresses noisy warnings.

### Description
- Extract the current host with `parse_url(Tools::getHttpHost(true), PHP_URL_HOST)` and fall back to `Tools::getHttpHost(false)` when necessary.
- Update the host comparison in `urlToFilePath` to compare `parsedUrl['host']` against the extracted `currentHost` so same-host URLs are treated as local.
- Replace `file_get_contents($url)` with `Tools::file_get_contents($url)` in `downloadImage` to use the framework’s safer fetch helper.
- Ensure `urlToFilePath` returns a local filesystem path for same-host images and `downloadImage` returns false on download failure.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fac1d9248322a710bcf87ff3c207)