### PR TITLE
Reassurance prettyblock: optional slider with per-device settings

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -663,6 +663,44 @@ class EverblockPrettyBlocks
                             ],
                             'default' => '3',
                         ],
+                        'slider' => [
+                            'type' => 'switch',
+                            'label' => $module->l('Enable slider'),
+                            'default' => false,
+                        ],
+                        'slider_devices' => [
+                            'type' => 'select',
+                            'label' => $module->l('Enable slider on'),
+                            'choices' => [
+                                'desktop' => $module->l('Desktop only'),
+                                'mobile' => $module->l('Mobile only'),
+                                'both' => $module->l('Desktop and mobile'),
+                            ],
+                            'default' => 'both',
+                        ],
+                        'slider_items_desktop' => [
+                            'type' => 'select',
+                            'label' => $module->l('Items per slide (desktop)'),
+                            'choices' => [
+                                '1' => $module->l('1 item'),
+                                '2' => $module->l('2 items'),
+                                '3' => $module->l('3 items'),
+                                '4' => $module->l('4 items'),
+                                '5' => $module->l('5 items'),
+                                '6' => $module->l('6 items'),
+                            ],
+                            'default' => '3',
+                        ],
+                        'slider_items_mobile' => [
+                            'type' => 'select',
+                            'label' => $module->l('Items per slide (mobile)'),
+                            'choices' => [
+                                '1' => $module->l('1 item'),
+                                '2' => $module->l('2 items'),
+                                '3' => $module->l('3 items'),
+                            ],
+                            'default' => '1',
+                        ],
                     ],
                 ],
                 'repeater' => [

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -171,14 +171,25 @@ $(document).ready(function(){
     if ($.fn.slick) {
         $('.ever-slick-carousel:not(.slick-initialised)').each(function(){
             var $carousel = $(this);
-            var slides = parseInt($carousel.data('items')) || 4;
-            $carousel.slick({
-                infinite: true,
-                arrows: false,
-                dots: true,
-                slidesToShow: slides,
-                slidesToScroll: 1,
-                responsive: [{
+            var slidesDesktop = parseInt($carousel.data('itemsDesktop'), 10);
+            if (isNaN(slidesDesktop) || slidesDesktop <= 0) {
+                slidesDesktop = parseInt($carousel.data('items'), 10) || 4;
+            }
+            var slidesMobile = parseInt($carousel.data('itemsMobile'), 10);
+            var hasCustomMobile = !isNaN(slidesMobile) && slidesMobile > 0;
+            var slides = slidesDesktop;
+            var responsiveSettings = [];
+            if (hasCustomMobile) {
+                responsiveSettings = [{
+                    breakpoint: 768,
+                    settings: {
+                        slidesToShow: slidesMobile,
+                        slidesToScroll: 1,
+                        dots: true
+                    }
+                }];
+            } else {
+                responsiveSettings = [{
                     breakpoint: 1024,
                     settings: {
                         slidesToShow: Math.min(slides,3),
@@ -200,7 +211,15 @@ $(document).ready(function(){
                         slidesToScroll: 1,
                         dots: true
                     }
-                }]
+                }];
+            }
+            $carousel.slick({
+                infinite: true,
+                arrows: false,
+                dots: true,
+                slidesToShow: slides,
+                slidesToScroll: 1,
+                responsive: responsiveSettings
             });
             $carousel.on('setPosition', function(event, slick) {
                 $(slick.$slider).find('.slick-track').addClass('row');

--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -19,12 +19,18 @@
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 
 {assign var='reassuranceColumns' value=$block.settings.items_per_row|default:$block.settings.default.items_per_row|default:$block.settings.columns|default:$block.settings.default.columns|default:3|intval}
+{assign var='useSlider' value=(isset($block.settings.slider) && $block.settings.slider && $block.states|@count > 1)}
+{assign var='sliderDevices' value=$block.settings.slider_devices|default:'both'}
+{assign var='useDesktopSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'desktop'))}
+{assign var='useMobileSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'mobile'))}
 {assign var='reassuranceColumnClass' value=''}
-{if $reassuranceColumns > 0}
+{if $reassuranceColumns > 0 && !$useSlider}
   {math assign="reassuranceColumnWidth" equation="12 / x" x=$reassuranceColumns format="%.0f"}
   {assign var='reassuranceColumnClass' value="col-12 col-md-"|cat:$reassuranceColumnWidth|cat:' '}
-{elseif $block.settings.default.display_inline}
+{elseif $block.settings.default.display_inline && !$useSlider}
   {assign var='reassuranceColumnClass' value='col '}
+{elseif $useSlider}
+  {assign var='reassuranceColumnClass' value='col-12 '}
 {/if}
 
 {assign var='containerClass' value=''}
@@ -35,7 +41,7 @@
 {/if}
 {assign var='wrapperClasses' value=$containerClass|cat:' '|cat:$prettyblock_visibility_class|trim}
 
-{assign var='shouldRenderRow' value=$block.settings.default.force_full_width || $block.settings.default.container || $block.settings.default.display_inline || $reassuranceColumns > 0}
+{assign var='shouldRenderRow' value=$block.settings.default.force_full_width || $block.settings.default.container || $block.settings.default.display_inline || $reassuranceColumns > 0 || $useSlider}
 {assign var='rowClass' value=''}
 {if $shouldRenderRow}
   {if $block.settings.default.force_full_width}
@@ -46,54 +52,256 @@
 {/if}
 
 <div id="block-{$block.id_prettyblocks}" class="{$wrapperClasses}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
-  {if $shouldRenderRow}
-    <div class="{$rowClass}">
-  {/if}
-
   {if isset($block.states) && $block.states}
-    {foreach from=$block.states item=state key=key}
-      {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+    {assign var='sliderItemsDesktop' value=$block.settings.slider_items_desktop|default:3|intval}
+    {assign var='sliderItemsMobile' value=$block.settings.slider_items_mobile|default:1|intval}
 
-      {assign var="icon_url" value=false}
-      {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
-        {assign var="icon_url" value=$state.image.url}
-      {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
-        {assign var="icon_url" value=$state.icon.url}
-      {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
-        {if $state.icon|substr:-4 != '.svg'}
-          {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
-        {else}
-          {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
-        {/if}
-      {/if}
+    {if $useSlider}
+      {assign var='sliderRowClass' value=$rowClass|cat:' ever-slick-carousel'|trim}
 
-      <div id="block-{$block.id_prettyblocks}-{$key}" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
-        {if $icon_url}
-          <div class="mb-2">
-            {if $icon_url|substr:-4 == '.svg'}
-              <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
-            {else}
-              <picture>
-                <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
-                <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
-                <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
-              </picture>
+      {if $useDesktopSlider && !$useMobileSlider}
+        <div class="{$sliderRowClass} d-none d-md-flex"
+             data-items-desktop="{$sliderItemsDesktop}"
+             data-items-mobile="{$sliderItemsMobile}">
+          {foreach from=$block.states item=state key=key}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+            {assign var="icon_url" value=false}
+            {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+              {assign var="icon_url" value=$state.image.url}
+            {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+              {if $state.icon|substr:-4 != '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {/if}
             {/if}
-          </div>
+            <div id="block-{$block.id_prettyblocks}-{$key}" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+              {if $icon_url}
+                <div class="mb-2">
+                  {if $icon_url|substr:-4 == '.svg'}
+                    <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                  {else}
+                    <picture>
+                      <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                      <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                      <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                    </picture>
+                  {/if}
+                </div>
+              {/if}
+              {if $state.title}
+                <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+              {/if}
+              {if $state.text}
+                <p class="small m-0">{$state.text nofilter}</p>
+              {/if}
+            </div>
+          {/foreach}
+        </div>
+        <div class="{$rowClass} d-flex d-md-none">
+          {foreach from=$block.states item=state key=key}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+            {assign var="icon_url" value=false}
+            {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+              {assign var="icon_url" value=$state.image.url}
+            {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+              {if $state.icon|substr:-4 != '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {/if}
+            {/if}
+            <div id="block-{$block.id_prettyblocks}-{$key}-mobile" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+              {if $icon_url}
+                <div class="mb-2">
+                  {if $icon_url|substr:-4 == '.svg'}
+                    <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                  {else}
+                    <picture>
+                      <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                      <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                      <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                    </picture>
+                  {/if}
+                </div>
+              {/if}
+              {if $state.title}
+                <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+              {/if}
+              {if $state.text}
+                <p class="small m-0">{$state.text nofilter}</p>
+              {/if}
+            </div>
+          {/foreach}
+        </div>
+      {elseif $useMobileSlider && !$useDesktopSlider}
+        <div class="{$rowClass} d-none d-md-flex">
+          {foreach from=$block.states item=state key=key}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+            {assign var="icon_url" value=false}
+            {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+              {assign var="icon_url" value=$state.image.url}
+            {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+              {if $state.icon|substr:-4 != '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {/if}
+            {/if}
+            <div id="block-{$block.id_prettyblocks}-{$key}-desktop" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+              {if $icon_url}
+                <div class="mb-2">
+                  {if $icon_url|substr:-4 == '.svg'}
+                    <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                  {else}
+                    <picture>
+                      <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                      <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                      <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                    </picture>
+                  {/if}
+                </div>
+              {/if}
+              {if $state.title}
+                <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+              {/if}
+              {if $state.text}
+                <p class="small m-0">{$state.text nofilter}</p>
+              {/if}
+            </div>
+          {/foreach}
+        </div>
+        <div class="{$sliderRowClass} d-flex d-md-none"
+             data-items-desktop="{$sliderItemsDesktop}"
+             data-items-mobile="{$sliderItemsMobile}">
+          {foreach from=$block.states item=state key=key}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+            {assign var="icon_url" value=false}
+            {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+              {assign var="icon_url" value=$state.image.url}
+            {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+              {if $state.icon|substr:-4 != '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {/if}
+            {/if}
+            <div id="block-{$block.id_prettyblocks}-{$key}-slider" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+              {if $icon_url}
+                <div class="mb-2">
+                  {if $icon_url|substr:-4 == '.svg'}
+                    <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                  {else}
+                    <picture>
+                      <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                      <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                      <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                    </picture>
+                  {/if}
+                </div>
+              {/if}
+              {if $state.title}
+                <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+              {/if}
+              {if $state.text}
+                <p class="small m-0">{$state.text nofilter}</p>
+              {/if}
+            </div>
+          {/foreach}
+        </div>
+      {else}
+        <div class="{$sliderRowClass}"
+             data-items-desktop="{$sliderItemsDesktop}"
+             data-items-mobile="{$sliderItemsMobile}">
+          {foreach from=$block.states item=state key=key}
+            {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+            {assign var="icon_url" value=false}
+            {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+              {assign var="icon_url" value=$state.image.url}
+            {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+              {assign var="icon_url" value=$state.icon.url}
+            {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+              {if $state.icon|substr:-4 != '.svg'}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+              {else}
+                {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+              {/if}
+            {/if}
+            <div id="block-{$block.id_prettyblocks}-{$key}-all" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+              {if $icon_url}
+                <div class="mb-2">
+                  {if $icon_url|substr:-4 == '.svg'}
+                    <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                  {else}
+                    <picture>
+                      <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                      <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                      <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                    </picture>
+                  {/if}
+                </div>
+              {/if}
+              {if $state.title}
+                <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+              {/if}
+              {if $state.text}
+                <p class="small m-0">{$state.text nofilter}</p>
+              {/if}
+            </div>
+          {/foreach}
+        </div>
+      {/if}
+    {else}
+      {if $shouldRenderRow}
+        <div class="{$rowClass}">
+      {/if}
+      {foreach from=$block.states item=state key=key}
+        {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+        {assign var="icon_url" value=false}
+        {if (is_array($state.image) || is_object($state.image)) && isset($state.image.url) && $state.image.url}
+          {assign var="icon_url" value=$state.image.url}
+        {elseif (is_array($state.icon) || is_object($state.icon)) && isset($state.icon.url) && $state.icon.url}
+          {assign var="icon_url" value=$state.icon.url}
+        {elseif isset($state.icon) && is_string($state.icon) && $state.icon|trim != ''}
+          {if $state.icon|substr:-4 != '.svg'}
+            {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
+          {else}
+            {assign var="icon_url" value=$smarty.const._MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon}
+          {/if}
         {/if}
-
-        {if $state.title}
-          <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
-        {/if}
-
-        {if $state.text}
-          <p class="small m-0">{$state.text nofilter}</p>
-        {/if}
-      </div>
-    {/foreach}
-  {/if}
-
-  {if $shouldRenderRow}
-    </div>
+        <div id="block-{$block.id_prettyblocks}-{$key}" class="{$reassuranceColumnClass}text-center{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}{if $state.background_color}background-color:{$state.background_color};{/if}{if $state.text_color}color:{$state.text_color};{/if}">
+          {if $icon_url}
+            <div class="mb-2">
+              {if $icon_url|substr:-4 == '.svg'}
+                <img src="{$icon_url|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+              {else}
+                <picture>
+                  <source srcset="{$icon_url|escape:'htmlall'}" type="image/webp">
+                  <source srcset="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" type="image/jpeg">
+                  <img src="{$icon_url|replace:'.webp':'.jpg'|escape:'htmlall'}" alt="{$state.title|escape:'htmlall'}" loading="lazy" class="img-fluid" width="45" height="45">
+                </picture>
+              {/if}
+            </div>
+          {/if}
+          {if $state.title}
+            <p class="h6 fw-bold mb-1">{$state.title|escape:'htmlall'}</p>
+          {/if}
+          {if $state.text}
+            <p class="small m-0">{$state.text nofilter}</p>
+          {/if}
+        </div>
+      {/foreach}
+      {if $shouldRenderRow}
+        </div>
+      {/if}
+    {/if}
   {/if}
 </div>


### PR DESCRIPTION
### Motivation
- Allow the Reassurance prettyblock repeaters to be displayed as an optional slider instead of a static grid.
- Give administrators control to enable the slider on `desktop`, `mobile` or `both` and to set different items-per-slide counts for desktop and mobile.

### Description
- Added new block configuration fields in `src/Service/EverblockPrettyBlocks.php`: `slider`, `slider_devices`, `slider_items_desktop`, and `slider_items_mobile`.
- Updated the template `views/templates/hook/prettyblocks/prettyblock_reassurance.tpl` to conditionally render grid or slider layouts, add `ever-slick-carousel` classes and emit `data-items-desktop`/`data-items-mobile` attributes used by the carousel.
- Enhanced `views/js/everblock.js` to read `data-items-desktop` and `data-items-mobile` and build Slick `responsive` settings so desktop/mobile slide counts can be applied independently.
- Changes implement conditional desktop/mobile rendering (separate markup/CSS classes) so the slider can be restricted to one device type or enabled on both.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610b044e988322a484e3ff4e924bdf)