### PR TITLE
Add Prettyblock admin controller to allowed files

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -37,6 +37,7 @@ return [
     'controllers/admin/AdminEverBlockFaqController.php',
     'controllers/admin/AdminEverBlockHookController.php',
     'controllers/admin/AdminEverBlockPageController.php',
+    'controllers/admin/AdminEverBlockPrettyblockController.php',
     'controllers/admin/AdminEverBlockShortcodeController.php',
     'controllers/admin/index.php',
     'controllers/front/advent.php',


### PR DESCRIPTION
### Motivation
- The Prettyblock admin controller file was present but not included in the module allowed files list, preventing it from being recognized by the system.
- Whitelisting the controller ensures it is packaged and available for admin use.

### Description
- Added `'controllers/admin/AdminEverBlockPrettyblockController.php'` to `config/allowed_files.php`.
- No other code changes were introduced in this PR.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f665343c8322858bc2208ed1514c)