### PR TITLE
Refine FAQ front layout with Bootstrap utilities

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1168,7 +1168,7 @@
 .everblock-faqs-list {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
 }
 
 .everblock-faqs-hero {
@@ -1176,38 +1176,27 @@
     justify-content: space-between;
     align-items: flex-start;
     gap: 1.5rem;
-    padding: 1.5rem;
-    border-radius: 1rem;
-    background: linear-gradient(120deg, rgba(13, 110, 253, 0.08), rgba(111, 66, 193, 0.08));
-    border: 1px solid rgba(13, 110, 253, 0.15);
 }
 
 .everblock-faqs-meta {
     display: flex;
     gap: 1rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .everblock-faqs-meta__item {
     min-width: 120px;
-    background: #ffffff;
-    border: 1px solid #e9ecef;
-    border-radius: 0.75rem;
-    padding: 0.75rem 1rem;
-    text-align: center;
-    box-shadow: 0 8px 30px rgba(33, 37, 41, 0.05);
 }
 
 .everblock-faqs-meta__label {
     display: block;
     font-size: 0.875rem;
-    color: #6c757d;
 }
 
 .everblock-faqs-meta__value {
     display: block;
     font-size: 1.35rem;
-    color: #0d6efd;
 }
 
 .everblock-faqs-tag {
@@ -1215,55 +1204,8 @@
     letter-spacing: 0.01em;
 }
 
-.faq-accordion .card-header,
-.faq-accordion .accordion-header {
-    background-color: #f9fbff;
-    border: none;
-}
-
 .everblock-faq-accordion {
-    gap: 1rem;
-}
-
-.everblock-faq-item {
-    border: 1px solid #e9ecef;
-    border-radius: 0.85rem;
-    overflow: hidden;
-    box-shadow: 0 12px 34px rgba(15, 23, 42, 0.05);
-}
-
-.everblock-faq-item + .everblock-faq-item {
-    margin-top: 0.5rem;
-}
-
-.faq-question .everblock-faq-icon {
-    width: 1.25rem;
-    height: 1.25rem;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: #e9f2ff;
-    position: relative;
-    transition: transform 0.3s ease, background-color 0.2s ease;
-}
-
-.faq-question .everblock-faq-icon::before,
-.faq-question .everblock-faq-icon::after {
-    content: "";
-    position: absolute;
-    background-color: #0d6efd;
-    transition: transform 0.3s ease;
-}
-
-.faq-question .everblock-faq-icon::before {
-    width: 2px;
-    height: 10px;
-}
-
-.faq-question .everblock-faq-icon::after {
-    width: 10px;
-    height: 2px;
+    gap: 0;
 }
 
 .faq-accordion .accordion-button {
@@ -1272,25 +1214,24 @@
     font-weight: 600;
 }
 
-.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon {
-    background-color: #0d6efd;
-    transform: rotate(45deg);
+.faq-accordion .accordion-button::after {
+    display: none;
 }
 
-.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon::before,
-.faq-accordion .accordion-button:not(.collapsed) .everblock-faq-icon::after {
-    background-color: #ffffff;
+.faq-chevron {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.75rem;
+    line-height: 1;
+    transition: transform 0.2s ease;
 }
 
-.faq-accordion .accordion-button:focus {
-    border-color: rgba(13, 110, 253, 0.35);
-    box-shadow: 0 0 0 0.1rem rgba(13, 110, 253, 0.2);
+.faq-accordion .accordion-button:not(.collapsed) .faq-chevron {
+    transform: rotate(180deg);
 }
 
 .faq-answer,
 .faq-accordion .accordion-body {
-    padding: 16px 20px 20px;
-    background: #ffffff;
     line-height: 1.7;
 }
 

--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -5,9 +5,9 @@
 {/block}
 
 {block name='page_content'}
-  <section class="everblock-faqs-list" aria-label="{l s='Frequently asked questions' mod='everblock' d='Modules.Everblock.Front'}">
-    <header class="mb-4">
-      <div class="everblock-faqs-hero">
+  <section class="everblock-faqs-list d-flex flex-column gap-4" aria-label="{l s='Frequently asked questions' mod='everblock' d='Modules.Everblock.Front'}">
+    <header>
+      <div class="everblock-faqs-hero rounded-4 border bg-light p-4 p-md-5 d-flex flex-column flex-md-row justify-content-between gap-3">
         <div>
           {if $everblock_is_all_faqs_page}
             <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
@@ -15,22 +15,22 @@
           {else}
             <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
               <h1 class="h2 mb-0">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
-              <span class="badge bg-primary everblock-faqs-tag" aria-label="{l s='Current FAQ tag' mod='everblock' d='Modules.Everblock.Front'}">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</span>
+              <span class="badge text-bg-primary text-lowercase everblock-faqs-tag" aria-label="{l s='Current FAQ tag' mod='everblock' d='Modules.Everblock.Front'}">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</span>
             </div>
             <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>
           {/if}
         </div>
 
         {if $everblock_faqs|@count}
-          <div class="everblock-faqs-meta">
-            <div class="everblock-faqs-meta__item">
-              <span class="everblock-faqs-meta__label">{l s='Questions' mod='everblock' d='Modules.Everblock.Front'}</span>
-              <strong class="everblock-faqs-meta__value">{$everblock_faqs|@count}</strong>
+          <div class="everblock-faqs-meta d-flex flex-wrap gap-3">
+            <div class="everblock-faqs-meta__item bg-white border rounded-3 px-3 py-2 text-center shadow-sm">
+              <span class="everblock-faqs-meta__label text-muted small">{l s='Questions' mod='everblock' d='Modules.Everblock.Front'}</span>
+              <strong class="everblock-faqs-meta__value d-block fs-5">{$everblock_faqs|@count}</strong>
             </div>
             {if !$everblock_is_all_faqs_page && isset($everblock_tag_name)}
-              <div class="everblock-faqs-meta__item">
-                <span class="everblock-faqs-meta__label">{l s='Group' mod='everblock' d='Modules.Everblock.Front'}</span>
-                <strong class="everblock-faqs-meta__value">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</strong>
+              <div class="everblock-faqs-meta__item bg-white border rounded-3 px-3 py-2 text-center shadow-sm">
+                <span class="everblock-faqs-meta__label text-muted small">{l s='Group' mod='everblock' d='Modules.Everblock.Front'}</span>
+                <strong class="everblock-faqs-meta__value d-block fs-5">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</strong>
               </div>
             {/if}
           </div>

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -17,32 +17,34 @@
 *}
 
 {if isset($everFaqs) && $everFaqs}
-  <div id="everblockFaq">
-    <div class="accordion faq-accordion everblock-faq-accordion" id="faqAccordion">
-      {foreach from=$everFaqs item=faq name=faqloop}
-        <article class="accordion-item card mb-4 everblock-faq-item" itemscope itemtype="https://schema.org/Question">
-          <div class="accordion-header card-header p-0 h2" id="headingEverFaq{$faq->id_everblock_faq}">
-            <div class="d-flex align-items-center gap-2 px-4 py-3">
-              <button class="accordion-button btn btn-link faq-question flex-grow-1 d-flex justify-content-between align-items-center w-100 text-body p-0 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
-                      aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}" itemprop="name">
-                <span>{$faq->title}</span>
-                <span class="everblock-faq-icon" aria-hidden="true"></span>
-              </button>
-              {if isset($faq->tag_link) && $faq->tag_link}
-                <a class="badge bg-secondary text-decoration-none everblock-faq-chip" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
-                  {$faq->tag_name|escape:'htmlall':'UTF-8'}
-                </a>
-              {/if}
+  <div id="everblockFaq" class="d-flex flex-column gap-3">
+    <div class="rounded-4 border bg-light p-2 p-md-3">
+      <div class="accordion accordion-flush faq-accordion everblock-faq-accordion" id="faqAccordion">
+        {foreach from=$everFaqs item=faq name=faqloop}
+          <article class="accordion-item bg-transparent border-0{if !$smarty.foreach.faqloop.last} border-bottom{/if}" itemscope itemtype="https://schema.org/Question">
+            <div class="accordion-header" id="headingEverFaq{$faq->id_everblock_faq}">
+              <div class="d-flex align-items-center gap-2 px-3 px-md-4 py-3">
+                <button class="accordion-button bg-transparent shadow-none px-0 py-0 text-body fw-semibold d-flex align-items-center justify-content-between gap-3 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
+                        aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}" itemprop="name">
+                  <span class="text-start flex-grow-1">{$faq->title}</span>
+                  <span class="faq-chevron rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center flex-shrink-0" aria-hidden="true">⌄</span>
+                </button>
+                {if isset($faq->tag_link) && $faq->tag_link}
+                  <a class="badge text-bg-secondary text-decoration-none everblock-faq-chip flex-shrink-0" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
+                    {$faq->tag_name|escape:'htmlall':'UTF-8'}
+                  </a>
+                {/if}
+              </div>
             </div>
-          </div>
-          <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
-               aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
-            <div class="accordion-body card-body faq-answer" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
-              <div itemprop="text">{$faq->content nofilter}</div>
+            <div id="collapse{$faq->id_everblock_faq}" class="accordion-collapse collapse {if $smarty.foreach.faqloop.first}show{/if}"
+                 aria-labelledby="headingEverFaq{$faq->id_everblock_faq}" data-parent="#faqAccordion" data-bs-parent="#faqAccordion">
+              <div class="accordion-body faq-answer bg-white border-top px-3 px-md-4 py-3" itemprop="acceptedAnswer" itemscope itemtype="https://schema.org/Answer">
+                <div itemprop="text">{$faq->content nofilter}</div>
+              </div>
             </div>
-          </div>
-        </article>
-      {/foreach}
+          </article>
+        {/foreach}
+      </div>
     </div>
   </div>
   {if empty($everblock_structured_data)}


### PR DESCRIPTION
### Motivation

- Align the FAQ front display with the provided mockup by reorganizing header, meta and accordion layout.  
- Replace bespoke color rules with Bootstrap 5 utility classes to rely on framework styling rather than hard-coded colors.  
- Improve spacing, responsive behavior and visual separation of FAQ items while keeping markup semantic.  

### Description

- Restyled the FAQ page header and meta block in `views/templates/front/faqs.tpl` to use Bootstrap utilities (`rounded-4`, `bg-light`, `text-bg-primary`, `d-flex`, `gap-*`, etc.) and updated the badge and meta card markup.  
- Reworked the accordion markup in `views/templates/hook/faq.tpl` to use `accordion-flush`, lighter container, per-item separators, and a custom chevron element (`.faq-chevron`) while keeping structured data output intact.  
- Simplified and trimmed FAQ CSS in `views/css/everblock.css` by removing many custom color rules and icon styles, hiding the default bootstrap chevron via `.faq-accordion .accordion-button::after { display: none; }`, adding `.faq-chevron` styling, and adjusting spacing and wrapping rules.  

### Testing

- No automated tests were executed for this change.  
- Visual/manual verification was expected but not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650ba13014832285f6163ad7eb5646)