### PR TITLE
Fix guide selection rewrite handling

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl
@@ -47,7 +47,8 @@
           {/if}
           {assign var='guide_link' value=''}
           {if $guide_object instanceof EverblockPage}
-            {assign var='guide_link' value=Context::getContext()->link->getModuleLink('everblock', 'page', ['id_everblock_page' => $guide_object->id, 'rewrite' => $guide_object->link_rewrite[Context::getContext()->language->id] ?? ''])}
+            {assign var='guide_rewrite' value=$guide_object->link_rewrite[Context::getContext()->language->id]|default:''}
+            {assign var='guide_link' value=Context::getContext()->link->getModuleLink('everblock', 'page', ['id_everblock_page' => $guide_object->id, 'rewrite' => $guide_rewrite])}
             {assign var='cover_image_data' value=$guide_object->getCoverImageData(Context::getContext())}
           {/if}
           {assign var='guide_title' value=$state.title|default:''}


### PR DESCRIPTION
### Motivation
- A Smarty syntax error occurred when the template used a PHP-style null-coalescing expression inside an `{assign}` which Smarty cannot parse. 
- The change aims to avoid the unsupported expression and reliably build module links for guide pages. 
- This prevents the fatal template compilation error triggered when rendering the guides selection block. 

### Description
- Replaced the inline null-coalescing expression with a separate Smarty assignment: `guide_rewrite` is set using the `|default:''` modifier. 
- Updated the `guide_link` assignment to use the new `guide_rewrite` variable. 
- Modified file `views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl` to apply the fix. 

### Testing
- No automated tests were run for this change (template-only change). 
- There are no template-specific automated tests executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650e7c5d788322bcb600bb97a91e05)