### PR TITLE
Ensure EverblockPage is autoloaded for PrettyBlocks selector

### DIFF
--- a/classes/EverblockPage.php
+++ b/classes/EverblockPage.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once dirname(__FILE__) . '/../models/EverblockPage.php';

--- a/classes/index.php
+++ b/classes/index.php
@@ -1,0 +1,5 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}

--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -29,6 +29,8 @@ return [
     'README.md',
     'composer.json',
     'composer.lock',
+    'classes/EverblockPage.php',
+    'classes/index.php',
     'config/allowed_files.php',
     'config/index.php',
     'config/services.yml',


### PR DESCRIPTION
### Motivation

- The `selector` field using `'collection' => 'EverblockPage'` did not work because the `EverblockPage` model was not being autoloaded from `models/` when used by PrettyBlocks selectors. 
- PrestaShop module file listing needs explicit entries for files loaded from the `classes/` directory to be allowed by the module distribution checks. 

### Description

- Add `classes/EverblockPage.php` which requires the original model at `models/EverblockPage.php` to expose the class via the module `classes` autoload location. 
- Add `classes/index.php` as a minimal guard file for the `classes/` directory. 
- Update `config/allowed_files.php` to include `classes/EverblockPage.php` and `classes/index.php` so the new files are permitted by the module allowed-files list. 

### Testing

- No automated tests were run for this change. 
- Changes were validated locally by adding the files and updating `config/allowed_files.php` (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651034090483228e3d8e5a6a00c351)