### PR TITLE
Add HTML intro content for Category Tabs prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2563,6 +2563,11 @@ class EverblockPrettyBlocks
                             'label' => 'Tab title',
                             'default' => Configuration::get('PS_SHOP_NAME'),
                         ],
+                        'html_before_products' => [
+                            'type' => 'editor',
+                            'label' => $module->l('HTML content before products'),
+                            'default' => '',
+                        ],
                         'id_categories' => [
                             'type' => 'selector',
                             'label' => $module->l('Categories'),

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -82,6 +82,11 @@
                     {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-lg-"|cat:$desktopColumnWidth}
                     {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-xl-"|cat:$desktopColumnWidth}
                     <div class="tab-pane {if $smarty.foreach.categorytabs.first}show active{/if}{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" id="{$tabId}" role="tabpanel" aria-labelledby="{$tabId}-tab"style="{$prettyblock_state_spacing_style}{if isset($state.background_color) && $state.background_color}background-color:{$state.background_color|escape:'htmlall':'UTF-8'};{/if}{if isset($state.text_color) && $state.text_color}color:{$state.text_color|escape:'htmlall':'UTF-8'};{/if}">
+                        {if isset($state.html_before_products) && $state.html_before_products}
+                            <div class="prettyblock-category-tabs__intro">
+                                {$state.html_before_products nofilter}
+                            </div>
+                        {/if}
                         {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                         {if $useDesktopSlider || $useMobileSlider}
                             {if $useDesktopSlider}


### PR DESCRIPTION
### Motivation

- Allow editors to add custom HTML content that appears before the product list in each tab of the Category Tabs prettyblock.

### Description

- Add a new per-tab editor field `html_before_products` to the Category repeater in `src/Service/EverblockPrettyBlocks.php`.
- Render the optional HTML content inside `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` before the products listing using `{$state.html_before_products nofilter}`.
- Keep the output unescaped so rich HTML entered in the editor is rendered as-is inside the tab content.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696510d21ce88322a1935cf312faad13)