### PR TITLE
Add front-office 'View on front' action for Everblock pages

### DIFF
--- a/controllers/admin/AdminEverBlockPageController.php
+++ b/controllers/admin/AdminEverBlockPageController.php
@@ -160,6 +160,7 @@ class AdminEverBlockPageController extends ModuleAdminController
     {
         $this->addRowAction('edit');
         $this->addRowAction('delete');
+        $this->addRowAction('viewfront');
 
         if (Tools::getValue('clearcache')) {
             Tools::clearAllCache();
@@ -201,6 +202,47 @@ class AdminEverBlockPageController extends ModuleAdminController
         );
 
         return $content;
+    }
+
+    public function displayViewfrontLink($token, $id, $name = null)
+    {
+        $pageId = (int) $id;
+        if ($pageId <= 0) {
+            return '';
+        }
+
+        $page = new $this->className($pageId, (int) $this->context->language->id);
+        if (!$page->active) {
+            return '';
+        }
+
+        $rewrite = trim((string) $page->link_rewrite);
+        if ($rewrite === '') {
+            return '';
+        }
+
+        $link = $this->context->link->getModuleLink(
+            $this->module->name,
+            'page',
+            [
+                'id_everblock_page' => (int) $page->id,
+                'rewrite' => $rewrite,
+            ]
+        );
+
+        $title = sprintf(
+            $this->l('View "%s" guide on front office'),
+            $page->title ?: $page->name
+        );
+
+        return sprintf(
+            '<a class="btn btn-default" href="%s" title="%s" target="_blank">'
+            . '<i class="icon-search"></i> %s'
+            . '</a>',
+            Tools::safeOutput($link),
+            Tools::safeOutput($title),
+            $this->l('View on front')
+        );
     }
 
     public function renderForm()


### PR DESCRIPTION
### Motivation
- Provide a quick admin action to open an Everblock guide page in the front office from the pages list when the page is active.
- Match existing behavior in other Everblock admin controllers that expose a `viewfront` action for front links.
- Avoid showing the action for inactive pages or when the page has no `link_rewrite` to prevent broken links.

### Description
- Added a `viewfront` row action in `AdminEverBlockPageController::renderList` to show the new button in the list.
- Implemented `displayViewfrontLink($token, $id, $name = null)` in `controllers/admin/AdminEverBlockPageController.php` which loads the page, returns empty when invalid/inactive or missing `link_rewrite`, and builds the front URL via `getModuleLink`.
- The method renders an HTML button link with an icon, `target="_blank"`, uses `Tools::safeOutput` for safety, and localizes the title with `$this->l`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651431d1e08322bdbf1f427a1ce7e6)