### PR TITLE
Add configurable all-brands button to Prettyblock Brands

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2511,6 +2511,16 @@ class EverblockPrettyBlocks
                                 '6' => '6',
                             ],
                         ],
+                        'show_all_brands_button' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Show "All brands" button'),
+                            'default' => 0,
+                        ],
+                        'all_brands_button_label' => [
+                            'type' => 'text',
+                            'label' => $module->l('All brands button text'),
+                            'default' => $module->l('Voir toutes les marques'),
+                        ],
                     ], $module),
                 ],
                 'repeater' => [

--- a/views/templates/hook/ever_brand.tpl
+++ b/views/templates/hook/ever_brand.tpl
@@ -18,6 +18,9 @@
 {if isset($brands) && $brands}
   {assign var="numBrandsPerSlide" value=$brandsPerSlide|default:4}
   {assign var="colWidth" value=12/$numBrandsPerSlide}
+  {if isset($showAllBrandsButton) && $showAllBrandsButton && $allBrandsButtonLabel}
+    {assign var="allBrandsUrl" value=$link->getPageLink('manufacturer')}
+  {/if}
   {if isset($carousel) && $carousel}
     {assign var="carouselId" value="ever-brand-carousel-"|cat:mt_rand(1000,999999)}
     <section class="featured-brands clearfix mt-3 d-none d-md-block">
@@ -79,6 +82,11 @@
         </div>
       </div>
     </section>
+    {if isset($allBrandsUrl)}
+      <div class="text-center mt-3">
+        <a href="{$allBrandsUrl|escape:'htmlall':'UTF-8'}" class="btn btn-primary">{$allBrandsButtonLabel|escape:'htmlall':'UTF-8'}</a>
+      </div>
+    {/if}
   {else}
     <section class="featured-brands clearfix mt-3">
       <div class="brands row">
@@ -98,6 +106,10 @@
         {/foreach}
       </div>
     </section>
+    {if isset($allBrandsUrl)}
+      <div class="text-center mt-3">
+        <a href="{$allBrandsUrl|escape:'htmlall':'UTF-8'}" class="btn btn-primary">{$allBrandsButtonLabel|escape:'htmlall':'UTF-8'}</a>
+      </div>
+    {/if}
   {/if}
 {/if}
-


### PR DESCRIPTION
### Motivation
- Provide an optional button at the bottom of the Prettyblock Brands block linking to the full brands/manufacturers listing page.
- Allow merchants to customize the button label from the block configuration.
- Ensure the button appears for both carousel and non-carousel renderings without changing existing brand display logic.

### Description
- Add `show_all_brands_button` (checkbox) and `all_brands_button_label` (text) fields to `src/Service/EverblockPrettyBlocks.php` to expose the option in block settings.
- Update `views/templates/hook/ever_brand.tpl` to compute `allBrandsUrl` via `$link->getPageLink('manufacturer')` when enabled and render a centered button using `{$allBrandsButtonLabel}` below the brand list.
- Use proper Smarty escaping for the URL and label and keep the feature opt-in with a default label of `Voir toutes les marques`.
- The change only affects template rendering and block configuration, leaving existing brand collection logic untouched.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965208d049083229c34244872981cc9)