### PR TITLE
Add best-sellers Prettyblock

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -298,6 +298,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_accordeon.tpl',
     'views/templates/hook/prettyblocks/prettyblock_advent_calendar.tpl',
     'views/templates/hook/prettyblocks/prettyblock_alert.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_best_sales.tpl',
     'views/templates/hook/prettyblocks/prettyblock_brands.tpl',
     'views/templates/hook/prettyblocks/prettyblock_button.tpl',
     'views/templates/hook/prettyblocks/prettyblock_card.tpl',

--- a/everblock.php
+++ b/everblock.php
@@ -5544,6 +5544,30 @@ class Everblock extends Module
         return ['deals' => $presentedProducts];
     }
 
+    public function hookBeforeRenderingEverblockBestSales($params)
+    {
+        $settings = [];
+        if (!empty($params['block']['settings']) && is_array($params['block']['settings'])) {
+            $settings = $params['block']['settings'];
+        }
+
+        $limit = isset($settings['product_limit']) ? (int) $settings['product_limit'] : 10;
+        if ($limit <= 0) {
+            $limit = 10;
+        }
+
+        $productIds = EverblockTools::getBestSellingProductIdsForPrettyblock($limit);
+        $presentedProducts = [];
+        if (!empty($productIds)) {
+            $presentedProducts = EverblockTools::everPresentProducts($productIds, $this->context);
+        }
+
+        return [
+            'products' => $presentedProducts,
+            'best_sales_url' => $this->context->link->getPageLink('best-sales'),
+        ];
+    }
+
     public function hookBeforeRenderingEverblockGuidedSelector($params)
     {
         $states = $params['block']['states'] ?? [];

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -162,6 +162,7 @@ class EverblockPrettyBlocks
             $productSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_product_selector.tpl';
             $guidedSelectorTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl';
             $flashDealsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl';
+            $bestSalesTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl';
             $categoryProductsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_products.tpl';
             $countersTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_counters.tpl';
             $countdownTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_countdown.tpl';
@@ -3500,6 +3501,51 @@ class EverblockPrettyBlocks
                             'type' => 'text',
                             'label' => $module->l('Number of products to display'),
                             'default' => 8,
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Best sellers'),
+                'description' => $module->l('Display best-selling products with optional sliders'),
+                'code' => 'everblock_best_sales',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $bestSalesTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'slider_desktop' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable desktop slider'),
+                            'default' => 1,
+                        ],
+                        'slider_mobile' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable mobile slider'),
+                            'default' => 1,
+                        ],
+                        'product_limit' => [
+                            'type' => 'text',
+                            'label' => $module->l('Number of best sellers to display'),
+                            'default' => 10,
+                        ],
+                        'items_per_slide_desktop' => [
+                            'type' => 'text',
+                            'label' => $module->l('Items per slide on desktop'),
+                            'default' => 4,
+                        ],
+                        'items_per_slide_mobile' => [
+                            'type' => 'text',
+                            'label' => $module->l('Items per slide on mobile'),
+                            'default' => 1,
+                        ],
+                        'button_url_override' => [
+                            'type' => 'text',
+                            'label' => $module->l('Override the best sellers button URL'),
+                            'default' => '',
                         ],
                     ], $module),
                 ],

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2052,6 +2052,11 @@ class EverblockTools extends ObjectModel
         return EverblockCache::cacheRetrieve($cacheId);
     }
 
+    public static function getBestSellingProductIdsForPrettyblock(int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
+    {
+        return static::getBestSellingProductIds($limit, $orderBy, $orderWay, $days);
+    }
+
     protected static function getBestSellingProductIds(int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();

--- a/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
@@ -1,0 +1,150 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+
+{if isset($block.extra.products) && $block.extra.products}
+  {assign var='desktopItems' value=$block.settings.items_per_slide_desktop|default:4|intval}
+  {if $desktopItems < 1}
+    {assign var='desktopItems' value=1}
+  {/if}
+  {assign var='mobileItems' value=$block.settings.items_per_slide_mobile|default:1|intval}
+  {if $mobileItems < 1}
+    {assign var='mobileItems' value=1}
+  {/if}
+  {assign var='tabletItems' value=2}
+
+  {math equation="ceil(12 / x)" x=$mobileItems assign='mobileColumnWidth'}
+  {math equation="ceil(12 / x)" x=$tabletItems assign='tabletColumnWidth'}
+  {math equation="ceil(12 / x)" x=$desktopItems assign='desktopColumnWidth'}
+  {assign var='productColumnClasses' value="col-"|cat:$mobileColumnWidth}
+  {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-sm-"|cat:$tabletColumnWidth}
+  {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-lg-"|cat:$desktopColumnWidth}
+  {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-xl-"|cat:$desktopColumnWidth}
+
+  {assign var='desktopCarouselEnabled' value=$block.settings.slider_desktop|default:0}
+  {assign var='mobileCarouselEnabled' value=$block.settings.slider_mobile|default:0}
+  {assign var='bestSalesLink' value=$block.settings.button_url_override|default:''}
+  {if !$bestSalesLink}
+    {assign var='bestSalesLink' value=$block.extra.best_sales_url|default:''}
+  {/if}
+
+  <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
+    {if $block.settings.default.force_full_width}
+      <div class="row gx-0 no-gutters">
+    {elseif $block.settings.default.container}
+      <div class="row">
+    {/if}
+      <div class="mt-2{if $block.settings.default.container} container{/if}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+        <section class="ever-featured-products featured-products clearfix mx-5 d-none d-md-block best-sales">
+          {if $desktopCarouselEnabled}
+            {assign var="carouselId" value="ever-best-sales-carousel-"|cat:mt_rand(1000,999999)}
+            {assign var="numProductsPerSlide" value=$desktopItems}
+            <div id="{$carouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-infinite-carousel="1">
+              <div class="carousel-inner products">
+                {hook h='displayBeforeProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+                {foreach from=$block.extra.products item=product name=products}
+                  {if $product@index % $numProductsPerSlide == 0}
+                    <div class="carousel-item{if $product@first} active{/if}">
+                      <div class="row">
+                  {/if}
+                  {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                  {if ($product@index + 1) % $numProductsPerSlide == 0 || $product@last}
+                      </div>
+                    </div>
+                  {/if}
+                {/foreach}
+                {hook h='displayAfterProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+              </div>
+
+              <button class="carousel-control-prev" type="button" data-bs-target="#{$carouselId}" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+              </button>
+
+              <button class="carousel-control-next" type="button" data-bs-target="#{$carouselId}" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+              </button>
+            </div>
+          {else}
+            <div class="products row">
+              {hook h='displayBeforeProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+              {foreach from=$block.extra.products item=product}
+                {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+              {/foreach}
+              {hook h='displayAfterProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+            </div>
+          {/if}
+        </section>
+
+        <section class="ever-featured-products featured-products mx-2 d-block d-md-none">
+          {if $mobileCarouselEnabled}
+            {assign var="mobileCarouselId" value="ever-best-sales-carousel-mobile-"|cat:mt_rand(1000,999999)}
+            {assign var="mobileNumProductsPerSlide" value=$mobileItems}
+            <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1">
+              <div class="carousel-inner products">
+                {hook h='displayBeforeProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+                {foreach from=$block.extra.products item=product name=mobileProducts}
+                  {if $product@index % $mobileNumProductsPerSlide == 0}
+                    <div class="carousel-item{if $product@first} active{/if}">
+                      <div class="row">
+                  {/if}
+                  {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                  {if ($product@index + 1) % $mobileNumProductsPerSlide == 0 || $product@last}
+                      </div>
+                    </div>
+                  {/if}
+                {/foreach}
+                {hook h='displayAfterProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+              </div>
+
+              <button class="carousel-control-prev" type="button" data-bs-target="#{$mobileCarouselId}" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+              </button>
+
+              <button class="carousel-control-next" type="button" data-bs-target="#{$mobileCarouselId}" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+              </button>
+            </div>
+          {else}
+            <div class="products row">
+              {hook h='displayBeforeProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+              {foreach from=$block.extra.products item=product}
+                {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+              {/foreach}
+              {hook h='displayAfterProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
+            </div>
+          {/if}
+        </section>
+
+        {if $bestSalesLink}
+          <div class="text-center mt-4">
+            <a class="btn btn-primary" href="{$bestSalesLink|escape:'htmlall':'UTF-8'}">
+              {l s='See best sellers' mod='everblock'}
+            </a>
+          </div>
+        {/if}
+      </div>
+    {if $block.settings.default.force_full_width || $block.settings.default.container}
+      </div>
+    {/if}
+  </div>
+{/if}


### PR DESCRIPTION
### Motivation
- Provide a reusable Prettyblock to display store best-sellers with configurable sliders and CTA. 
- Allow editors to control desktop/mobile slider behavior, number of products, items per slide and the CTA URL (with an override). 
- Reuse existing best-sellers product query logic and present products via Everblock presentation helpers. 
- Keep template files discoverable by the module by updating the allowed files list.

### Description
- Add a new Prettyblock registration for `everblock_best_sales` with settings for `slider_desktop`, `slider_mobile`, `product_limit`, `items_per_slide_desktop`, `items_per_slide_mobile` and `button_url_override` in `src/Service/EverblockPrettyBlocks.php`.
- Add `hookBeforeRenderingEverblockBestSales` in `everblock.php` which loads best-seller product IDs, presents them with `EverblockTools::everPresentProducts` and exposes the default Prestashop best-sales page link via `link->getPageLink('best-sales')` to the template.
- Introduce `views/templates/hook/prettyblocks/prettyblock_best_sales.tpl` containing desktop/mobile grid or Bootstrap carousel rendering and a centered CTA button that uses the override URL when set.
- Expose a public helper `getBestSellingProductIdsForPrettyblock` in `src/Service/EverblockTools.php` (delegating to the existing protected query) and register the new template in `config/allowed_files.php`.

### Testing
- No automated tests were executed for this change.
- (No test failures reported because automated tests were not run.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fa14a4a48322bd6e4fd5fef76dc6)