### PR TITLE
Register PrettyBlocks beforeRendering hooks when PrettyBlocks is installed

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -842,6 +842,7 @@ class Everblock extends Module
         $this->secureModuleFolder();
         EverblockTools::checkAndFixDatabase();
         $this->checkHooks();
+        EverblockPrettyBlocks::ensureBeforeRenderingHooksRegistered($this);
         $this->html = '';
 
         if (Tools::isSubmit('deleteEVERBLOCK_MARKER_ICON')) {

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -39,10 +39,35 @@ if (!defined('_PS_VERSION_')) {
 class EverblockPrettyBlocks
 {
     private const MEDIA_PATH = '$/img/cms/prettyblocks/';
+    private const BEFORE_RENDERING_HOOKS = [
+        'beforeRenderingEverblockEverblock',
+        'beforeRenderingEverblockCategoryTabs',
+        'beforeRenderingEverblockCategoryPrice',
+        'beforeRenderingEverblockProductHighlight',
+        'beforeRenderingEverblockProductSelector',
+        'beforeRenderingEverblockVideoProducts',
+        'beforeRenderingEverblockSpecialEvent',
+        'beforeRenderingEverblockFlashDeals',
+        'beforeRenderingEverblockBestSales',
+        'beforeRenderingEverblockGuidedSelector',
+        'beforeRenderingEverblockLookbook',
+        'beforeRenderingEverblockCategoryProducts',
+    ];
 
     public function registerBlockToZone($zone_name, $code, $id_lang, $id_shop)
     {
         return PrettyBlocksModel::registerBlockToZone($zone_name, $code, $id_lang, $id_shop);
+    }
+
+    public static function ensureBeforeRenderingHooksRegistered(Module $module): void
+    {
+        if (!Module::isInstalled('prettyblocks')) {
+            return;
+        }
+
+        foreach (self::BEFORE_RENDERING_HOOKS as $hookName) {
+            $module->registerHook($hookName);
+        }
     }
 
     private static function appendSpacingFields(array $groups, Module $module): array


### PR DESCRIPTION
### Motivation
- Ensure Everblock exposes its `beforeRendering` hooks when the `prettyblocks` module is installed so PrettyBlocks can attach to them.
- Centralize the list of `beforeRendering` hooks and the registration logic in the PrettyBlocks helper service.
- Trigger hook registration during module configuration rendering to keep hooks in sync with module state.

### Description
- Add a `BEFORE_RENDERING_HOOKS` constant to `src/Service/EverblockPrettyBlocks.php` containing the list of hook names. 
- Implement `ensureBeforeRenderingHooksRegistered(Module $module)` in `EverblockPrettyBlocks` to register each hook when `prettyblocks` is installed. 
- Invoke `EverblockPrettyBlocks::ensureBeforeRenderingHooksRegistered($this)` from the module `getContent` method in `everblock.php` to run the registration during configuration rendering. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fff13d308322b73630a36cc8c316)