### PR TITLE
Make carousels infinite and pad slides to avoid gaps

### DIFF
--- a/views/templates/hook/ever_img_carousel.tpl
+++ b/views/templates/hook/ever_img_carousel.tpl
@@ -1,5 +1,5 @@
 {if isset($images) && $images}
-  <div id="{$carousel_id}" class="carousel slide" data-bs-ride="carousel">
+  <div id="{$carousel_id}" class="carousel slide" data-bs-ride="carousel" data-bs-wrap="true">
     
     {* ✅ Dots (indicateurs) *}
     <div class="carousel-indicators">

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -89,7 +89,7 @@
   <section class="ever-featured-products featured-products mx-2 d-block d-md-none">
     {assign var="mobileCarouselId" value="ever-presented-carousel-mobile-"|cat:mt_rand(1000,999999)}
     {assign var="mobileNumProductsPerSlide" value=$mobileItems}
-    <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1">
+    <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1" data-ever-infinite-carousel="1">
       <div class="carousel-inner products">
         {hook h='displayBeforeProductMiniature' products=$everPresentProducts origin=$shortcodeClass|default:'' page_name=$page.page_name}
         {foreach from=$everPresentProducts item=product name=mobileProducts}

--- a/views/templates/hook/linkedproducts_carousel.tpl
+++ b/views/templates/hook/linkedproducts_carousel.tpl
@@ -16,7 +16,7 @@
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($everPresentProducts) && $everPresentProducts}
-  <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel">
+  <div id="{$carousel_id}" class="carousel slide" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true" data-ever-infinite-carousel="1">
     <div class="carousel-inner">
       {assign var="numProductsPerSlide" value=4}
       {foreach from=$everPresentProducts item=product name=products}

--- a/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
@@ -97,7 +97,7 @@
           {if $mobileCarouselEnabled}
             {assign var="mobileCarouselId" value="ever-best-sales-carousel-mobile-"|cat:mt_rand(1000,999999)}
             {assign var="mobileNumProductsPerSlide" value=$mobileItems}
-            <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1">
+            <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1" data-ever-infinite-carousel="1">
               <div class="carousel-inner products">
                 {hook h='displayBeforeProductMiniature' products=$block.extra.products origin='best-sales' page_name=$page.page_name}
                 {foreach from=$block.extra.products item=product name=mobileProducts}

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -52,7 +52,8 @@
          data-items="1"
          data-layout="cover"
          data-controls="true"
-         data-indicators="true">
+         data-indicators="true"
+         data-infinite="1">
       {foreach from=$block.states item=state key=key}
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
         {capture name='prettyblock_cover_state_style'}

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -54,7 +54,7 @@
          data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}"
          data-items-mobile="1"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
-         data-infinite="{if isset($block.settings.slider_infinite) && $block.settings.slider_infinite}1{else}0{/if}"
+         data-infinite="1"
          data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}"
          data-row-class="row g-3 justify-content-center"
          data-controls="true"

--- a/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_testimonial_slider.tpl
@@ -30,7 +30,7 @@
         <div class="row">
     {/if}
     {if isset($block.states) && $block.states}
-    <div id="testimonialCarousel-{$block.id_prettyblocks}" class="carousel slide everblock-testimonial" data-ride="carousel" data-bs-ride="carousel">
+    <div id="testimonialCarousel-{$block.id_prettyblocks}" class="carousel slide everblock-testimonial" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true">
         <div class="carousel-inner">
             {foreach from=$block.states item=state}
                 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}


### PR DESCRIPTION
### Motivation
- Ensure all sliders/carousels loop infinitely and do not leave empty slots on the last slide for multi‑item carousels.
- Provide consistent Bootstrap carousel behavior across desktop and mobile so sliding never shows holes when looping.

### Description
- Change carousel initialization logic in `views/js/everblock.js` to default `data-infinite` to enabled, pad multi‑item carousels by cloning items so the last slide is full, and add a helper `padEverblockCarouselSlides` used for already-rendered carousels.
- Make the builder use `paddedItems` when chunking slides so slides are evenly filled and set `wrap`/`data-bs-wrap` to allow looping in the carousel config (`wrap: !!infinite`).
- Enable infinite/wrap on relevant templates by adding `data-bs-wrap="true"` and `data-ever-infinite-carousel="1"` where appropriate, including `linkedproducts_carousel.tpl`, `ever_img_carousel.tpl`, `prettyblock_testimonial_slider.tpl`, `ever_presented_products.tpl` (mobile), `prettyblock_best_sales.tpl` (mobile), `prettyblock_cover.tpl`, and `prettyblock_img.tpl`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69660262438c8322a3b8e2de83225aa4)