### PR TITLE
Add option to hide Best Sellers button in Best Sales prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3567,6 +3567,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Items per slide on mobile'),
                             'default' => 1,
                         ],
+                        'show_best_sales_button' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Show best sellers button'),
+                            'default' => 1,
+                        ],
                         'button_url_override' => [
                             'type' => 'text',
                             'label' => $module->l('Override the best sellers button URL'),

--- a/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
@@ -39,6 +39,7 @@
 
   {assign var='desktopCarouselEnabled' value=$block.settings.slider_desktop|default:0}
   {assign var='mobileCarouselEnabled' value=$block.settings.slider_mobile|default:0}
+  {assign var='showBestSalesButton' value=$block.settings.show_best_sales_button|default:1}
   {assign var='bestSalesLink' value=$block.settings.button_url_override|default:''}
   {if !$bestSalesLink}
     {assign var='bestSalesLink' value=$block.extra.best_sales_url|default:''}
@@ -135,7 +136,7 @@
           {/if}
         </section>
 
-        {if $bestSalesLink}
+        {if $showBestSalesButton && $bestSalesLink}
           <div class="text-center mt-4">
             <a class="btn btn-primary" href="{$bestSalesLink|escape:'htmlall':'UTF-8'}">
               {l s='See best sellers' mod='everblock'}


### PR DESCRIPTION
### Motivation
- Allow editors to remove the CTA that links to the best sellers page from the Prettyblock Best Sales block.
- Provide a simple configuration toggle so the button can be shown or hidden per block.

### Description
- Add a `show_best_sales_button` checkbox field to the block configuration in `src/Service/EverblockPrettyBlocks.php` with a default value of `1`.
- Expose the setting inside the template as `showBestSalesButton` in `views/templates/hook/prettyblocks/prettyblock_best_sales.tpl`.
- Change the button rendering condition from `if $bestSalesLink` to `if $showBestSalesButton && $bestSalesLink` so the CTA is only output when the toggle is enabled.
- Modified files: `src/Service/EverblockPrettyBlocks.php` and `views/templates/hook/prettyblocks/prettyblock_best_sales.tpl`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696602fbcecc8322b8915495959a8f3c)