### PR TITLE
Fix best sales slider column sizing

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_best_sales.tpl
@@ -29,9 +29,18 @@
   {/if}
   {assign var='tabletItems' value=2}
 
-  {math equation="ceil(12 / x)" x=$mobileItems assign='mobileColumnWidth'}
-  {math equation="ceil(12 / x)" x=$tabletItems assign='tabletColumnWidth'}
-  {math equation="ceil(12 / x)" x=$desktopItems assign='desktopColumnWidth'}
+  {math equation="floor(12 / x)" x=$mobileItems assign='mobileColumnWidth'}
+  {math equation="floor(12 / x)" x=$tabletItems assign='tabletColumnWidth'}
+  {math equation="floor(12 / x)" x=$desktopItems assign='desktopColumnWidth'}
+  {if $mobileColumnWidth < 1}
+    {assign var='mobileColumnWidth' value=1}
+  {/if}
+  {if $tabletColumnWidth < 1}
+    {assign var='tabletColumnWidth' value=1}
+  {/if}
+  {if $desktopColumnWidth < 1}
+    {assign var='desktopColumnWidth' value=1}
+  {/if}
   {assign var='productColumnClasses' value="col-"|cat:$mobileColumnWidth}
   {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-sm-"|cat:$tabletColumnWidth}
   {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-lg-"|cat:$desktopColumnWidth}


### PR DESCRIPTION
### Motivation
- The last slide in the Prettyblock Best Sales slider could wrap into two rows instead of staying on a single carousel slide. 
- The column width calculation used `ceil(12 / x)`, which could produce column classes that make the total width exceed 12 and cause wrapping. 
- A minimum column width is required to avoid generating `col-0` classes when `items_per_slide` is greater than 12.

### Description
- Replace `{math equation="ceil(12 / x)" ...}` with `{math equation="floor(12 / x)" ...}` for mobile, tablet and desktop column width calculations in `views/templates/hook/prettyblocks/prettyblock_best_sales.tpl`.
- Add guards that set each computed column width to `1` when the result is less than `1` to prevent zero-width columns.
- The change updates how `productColumnClasses` are built so slides no longer overflow their row width.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696607988e708322bb5a4cbf5182d9ca)