### PR TITLE
Add optional category filter to Prettyblock Best Sales

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5557,7 +5557,16 @@ class Everblock extends Module
             $limit = 10;
         }
 
-        $productIds = EverblockTools::getBestSellingProductIdsForPrettyblock($limit);
+        $categoryId = 0;
+        if (!empty($settings['best_sales_category']['id'])) {
+            $categoryId = (int) $settings['best_sales_category']['id'];
+        }
+
+        if ($categoryId > 0) {
+            $productIds = EverblockTools::getBestSellingProductIdsForCategoryPrettyblock($categoryId, $limit);
+        } else {
+            $productIds = EverblockTools::getBestSellingProductIdsForPrettyblock($limit);
+        }
         $presentedProducts = [];
         if (!empty($productIds)) {
             $presentedProducts = EverblockTools::everPresentProducts($productIds, $this->context);

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -3557,6 +3557,13 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Number of best sellers to display'),
                             'default' => 10,
                         ],
+                        'best_sales_category' => [
+                            'type' => 'selector',
+                            'label' => $module->l('Optional category for best sellers'),
+                            'collection' => 'Category',
+                            'selector' => '{id} - {name}',
+                            'default' => '',
+                        ],
                         'items_per_slide_desktop' => [
                             'type' => 'text',
                             'label' => $module->l('Items per slide on desktop'),

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2057,6 +2057,16 @@ class EverblockTools extends ObjectModel
         return static::getBestSellingProductIds($limit, $orderBy, $orderWay, $days);
     }
 
+    public static function getBestSellingProductIdsForCategoryPrettyblock(
+        int $categoryId,
+        int $limit,
+        string $orderBy = 'total_quantity',
+        string $orderWay = 'DESC',
+        ?int $days = null
+    ): array {
+        return static::getBestSellingProductIdsByCategory($categoryId, $limit, $orderBy, $orderWay, $days);
+    }
+
     protected static function getBestSellingProductIds(int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();


### PR DESCRIPTION
### Motivation
- Permettre au bloc Prettyblock « Best Sales » de cibler facultativement une catégorie pour afficher ses meilleures ventes.
- Conserver le comportement existant en affichant les meilleures ventes globales de la boutique si aucune catégorie n’est renseignée.
- Exposer une méthode utilitaire pour récupérer les meilleures ventes filtrées par catégorie afin de garder la logique séparée.

### Description
- Ajout du champ de configuration `best_sales_category` dans `src/Service/EverblockPrettyBlocks.php` pour permettre la sélection optionnelle d’une catégorie via un `selector`.
- Ajout de la méthode publique `getBestSellingProductIdsForCategoryPrettyblock` dans `src/Service/EverblockTools.php` qui délègue à `getBestSellingProductIdsByCategory`.
- Mise à jour de `hookBeforeRenderingEverblockBestSales` dans `everblock.php` pour lire `best_sales_category` et utiliser la recherche par catégorie si un `id` est fourni, sinon utiliser la recherche globale.

### Testing
- No automated tests were run for this change.
- Manual/functional verification is recommended to ensure the selected category filter returns expected products and that fallback behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696608fde5608322b73a62495b6c829a)