### PR TITLE
Prettyblock: remove iframe extra height and hide scrollbars

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3042,6 +3042,17 @@
   border
 
 /* Prettyblock FAQ */
+.everblock-prettyblock-iframe {
+  display: block;
+  border: 0;
+  overflow: hidden;
+  max-width: 100%;
+  scrollbar-width: none;
+}
+
+.everblock-prettyblock-iframe::-webkit-scrollbar {
+  display: none;
+}
 .prettyblock-faq {
   gap: 1rem;
 }

--- a/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
@@ -30,12 +30,12 @@
     {/if}
       <div class="everblock {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
         {if isset($block.settings.iframe_src) && $block.settings.iframe_src}
-          <iframe src="{$block.settings.iframe_src|escape:'htmlall':'UTF-8'}"
+          <iframe class="everblock-prettyblock-iframe" src="{$block.settings.iframe_src|escape:'htmlall':'UTF-8'}"
                   width="{if isset($block.settings.iframe_width) && $block.settings.iframe_width}{$block.settings.iframe_width|escape:'htmlall':'UTF-8'}{else}100%{/if}"
                   height="{if isset($block.settings.iframe_height) && $block.settings.iframe_height}{$block.settings.iframe_height|escape:'htmlall':'UTF-8'}{else}400{/if}"
                   style="border:0;"
                   {if isset($block.settings.loading_behavior) && $block.settings.loading_behavior}loading="{$block.settings.loading_behavior|escape:'htmlall':'UTF-8'}"{/if}
-                  {if $block.settings.allow_fullscreen}allowfullscreen{/if}></iframe>
+                  {if $block.settings.allow_fullscreen}allowfullscreen{/if} scrolling="no"></iframe>
         {/if}
       </div>
     {if $block.settings.default.container}

--- a/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
@@ -31,13 +31,13 @@
 
           <div id="block-{$block.id_prettyblocks}-{$key}" class="everblock {$state.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_state_spacing_style}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
             {if $state.iframe_source == 'youtube'}
-            <iframe width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}315{/if}" src="{$state.iframe_link}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+            <iframe class="everblock-prettyblock-iframe" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}315{/if}" src="{$state.iframe_link}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'vimeo'}
-            <iframe src="https://player.vimeo.com/video/' . $matches[1] . '?color=ffffff&title=0&byline=0&portrait=0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+            <iframe class="everblock-prettyblock-iframe" src="https://player.vimeo.com/video/' . $matches[1] . '?color=ffffff&title=0&byline=0&portrait=0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'dailymotion'}
-            <iframe frameborder="0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}270{/if}" src="{$state.iframe_link}" allowfullscreen></iframe>
+            <iframe class="everblock-prettyblock-iframe" frameborder="0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}270{/if}" src="{$state.iframe_link}" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'vidyard'}
-            <iframe src="{$state.iframe_link}" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+            <iframe class="everblock-prettyblock-iframe" src="{$state.iframe_link}" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen scrolling="no"></iframe>
             {/if}
           </div>
       {/foreach}


### PR DESCRIPTION
### Motivation
- The Prettyblock iframe embeds showed an unwanted extra height and visible scrollbars causing layout issues.
- Add a consistent identifier to iframes to allow targeted styling and remove baseline gaps.
- Prevent scrollbars from appearing inside embedded videos/maps for a cleaner UI.
- Ensure both stock and custom iframe templates are covered.

### Description
- Added `everblock-prettyblock-iframe` class to `views/templates/hook/prettyblocks/prettyblock_iframe.tpl` and `views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl`.
- Added `scrolling="no"` attribute to Prettyblock iframes to suppress internal scrollbars.
- Added CSS rules in `views/css/everblock.css` to set `display: block`, `overflow: hidden`, `max-width: 100%`, and hide scrollbars using `scrollbar-width: none` and `::-webkit-scrollbar`.
- Applied the class to all iframe variants (YouTube, Vimeo, Dailymotion, Vidyard and custom iframe) to ensure consistent behavior.

### Testing
- Attempted an automated Playwright screenshot of `http://localhost/`, which failed with `net::ERR_EMPTY_RESPONSE`.
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661b604e848322905d83c7afdc011d)