### PR TITLE
Add prettyblock_custom_iframe to allowed files

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -311,6 +311,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_counters.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cover.tpl',
     'views/templates/hook/prettyblocks/prettyblock_cta.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl',
     'views/templates/hook/prettyblocks/prettyblock_divider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_downloads.tpl',
     'views/templates/hook/prettyblocks/prettyblock_everblock.tpl',


### PR DESCRIPTION
### Motivation
- Allow the PrettyBlocks custom iframe template to be included in the module's allowed files so it can be loaded when referenced by the PrettyBlocks service.
- Avoid file-access or packaging issues when `EverblockPrettyBlocks` references a `prettyblock_custom_iframe.tpl` template.

### Description
- Added `views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl` to the allowed files array in `config/allowed_files.php`.
- No other code changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69661cd7c38c8322963439814568a694)