### PR TITLE
Style Prettyblock category tabs as buttons

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -365,6 +365,31 @@
 .nav-tabs .nav-item {
     list-style-type: none;
 }
+.prettyblock-category-tabs__nav.nav-tabs {
+    border-bottom: 0;
+    gap: 0.5rem;
+}
+.prettyblock-category-tabs__nav .nav-item {
+    margin-bottom: 0;
+}
+.prettyblock-category-tabs__tab-link {
+    border: 1px solid var(--bs-primary, #0d6efd);
+    border-radius: 999px;
+    color: var(--bs-primary, #0d6efd);
+    font-weight: 600;
+    padding: 0.5rem 1.5rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.prettyblock-category-tabs__tab-link:hover,
+.prettyblock-category-tabs__tab-link:focus {
+    border-color: var(--bs-primary, #0d6efd);
+    color: var(--bs-primary, #0d6efd);
+}
+.prettyblock-category-tabs__tab-link.active {
+    background-color: var(--bs-primary, #0d6efd);
+    border-color: var(--bs-primary, #0d6efd);
+    color: #fff;
+}
 #everblockModal button.close {
     float: right;
     padding: 0;

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -31,11 +31,11 @@
     {if isset($block.states) && $block.states}
     <div class="mt-2 col-12 d-flex justify-content-center text-center">
         <div class="tab-container">
-            <ul class="nav nav-tabs justify-content-center" role="tablist">
+            <ul class="nav nav-tabs justify-content-center prettyblock-category-tabs__nav" role="tablist">
                 {foreach from=$block.states item=state key=key name=categorytabs}
                     {assign var='tabId' value="tab-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key}
                     <li class="nav-item">
-                        <a class="nav-link {if $smarty.foreach.categorytabs.first}active{/if}" id="{$tabId}-tab" data-toggle="tab" data-bs-toggle="tab" data-bs-target="#{$tabId}" href="#{$tabId}" role="tab" aria-controls="{$tabId}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}" title="{$state.name|escape:'htmlall'}">
+                        <a class="nav-link prettyblock-category-tabs__tab-link {if $smarty.foreach.categorytabs.first}active{/if}" id="{$tabId}-tab" data-toggle="tab" data-bs-toggle="tab" data-bs-target="#{$tabId}" href="#{$tabId}" role="tab" aria-controls="{$tabId}" aria-selected="{if $smarty.foreach.categorytabs.first}true{else}false{/if}" title="{$state.name|escape:'htmlall'}">
                             {$state.name}
                         </a>
                     </li>


### PR DESCRIPTION
### Motivation
- Make the Prettyblock Category Tabs visually appear as pill buttons for clearer affordance and better visual integration with the theme.
- Provide dedicated CSS hooks so the tab appearance can be adjusted without altering markup elsewhere.

### Description
- Add `prettyblock-category-tabs__nav` to the tab list and `prettyblock-category-tabs__tab-link` to each tab link in `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to expose styling hooks.
- Add styles in `views/css/everblock.css` to render tab links as rounded pill buttons with bordered, hover and active states using `--bs-primary` as the color source.
- Remove the default tab bottom border for the styled tab list and add spacing between pill buttons.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966327df0208322a803c17ae915aefb)