### PR TITLE
Add ordering options to Category Tabs repeater

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5284,9 +5284,24 @@ class Everblock extends Module
                 if ($limit <= 0) {
                     $limit = (int) Configuration::get('PS_PRODUCTS_PER_PAGE');
                 }
+                $orderBy = isset($state['order_by']) ? (string) $state['order_by'] : 'id_product';
+                if ($orderBy === 'id') {
+                    $orderBy = 'id_product';
+                }
+                $allowedOrderBy = ['id_product', 'date_add', 'price'];
+                if (!in_array($orderBy, $allowedOrderBy, true)) {
+                    $orderBy = 'id_product';
+                }
+                $orderWay = isset($state['order_way']) ? strtoupper((string) $state['order_way']) : 'ASC';
+                $allowedOrderWay = ['ASC', 'DESC'];
+                if (!in_array($orderWay, $allowedOrderWay, true)) {
+                    $orderWay = 'ASC';
+                }
                 $rawProducts = EverblockTools::getProductsByCategoryId(
                     (int) $state['id_categories']['id'],
-                    $limit
+                    $limit,
+                    $orderBy,
+                    $orderWay
                 );
                 $presented = EverblockTools::everPresentProducts(
                     array_column($rawProducts, 'id_product'),

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2633,6 +2633,25 @@ class EverblockPrettyBlocks
                             'multiple' => true,
                             'default' => [],
                         ],
+                        'order_by' => [
+                            'type' => 'select',
+                            'label' => $module->l('Order by'),
+                            'choices' => [
+                                'id_product' => $module->l('ID'),
+                                'date_add' => $module->l('Date added'),
+                                'price' => $module->l('Price'),
+                            ],
+                            'default' => 'id_product',
+                        ],
+                        'order_way' => [
+                            'type' => 'select',
+                            'label' => $module->l('Order way'),
+                            'choices' => [
+                                'ASC' => $module->l('Ascending'),
+                                'DESC' => $module->l('Descending'),
+                            ],
+                            'default' => 'ASC',
+                        ],
                         'nb_products' => [
                             'type' => 'text',
                             'label' => $module->l('Number of products to display (0 for default)'),


### PR DESCRIPTION
### Motivation
- Provide configurable ordering for the PrettyBlocks "Category tabs" repeater so editors can sort products per tab. 
- Support common ordering fields requested: ID, date added and price. 
- Allow choosing ascending or descending order per repeater entry. 

### Description
- Added `order_by` and `order_way` select fields to the Category Tabs repeater configuration in `src/Service/EverblockPrettyBlocks.php` with choices and sensible defaults. 
- When rendering Category Tabs, the hook `hookBeforeRenderingEverblockCategoryTabs` in `everblock.php` reads `order_by`/`order_way`, normalizes `id` to `id_product`, validates allowed values (`id_product`, `date_add`, `price` and `ASC`/`DESC`), and passes them to `EverblockTools::getProductsByCategoryId`. 
- Defaults and validation ensure existing behavior remains unchanged when no ordering is configured. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were committed and the diff includes updates to `everblock.php` and `src/Service/EverblockPrettyBlocks.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966341d34088322bc8d6a051c6c500e)