### PR TITLE
Add 4-image slider to Category Tabs prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2620,6 +2620,38 @@ class EverblockPrettyBlocks
                             'label' => 'Tab title',
                             'default' => Configuration::get('PS_SHOP_NAME'),
                         ],
+                        'slider_image_1' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Slider image 1'),
+                            'accept' => 'image/svg+xml,image/webp,image/png,image/jpeg,image/gif',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'slider_image_2' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Slider image 2'),
+                            'accept' => 'image/svg+xml,image/webp,image/png,image/jpeg,image/gif',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'slider_image_3' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Slider image 3'),
+                            'accept' => 'image/svg+xml,image/webp,image/png,image/jpeg,image/gif',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'slider_image_4' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Slider image 4'),
+                            'accept' => 'image/svg+xml,image/webp,image/png,image/jpeg,image/gif',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'html_before_products' => [
                             'type' => 'editor',
                             'label' => $module->l('HTML content before products'),

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -87,6 +87,53 @@
                                 {$state.html_before_products nofilter}
                             </div>
                         {/if}
+                        {assign var='sliderImages' value=[]}
+                        {if isset($state.slider_image_1.url) && $state.slider_image_1.url}
+                            {append var='sliderImages' value=$state.slider_image_1}
+                        {/if}
+                        {if isset($state.slider_image_2.url) && $state.slider_image_2.url}
+                            {append var='sliderImages' value=$state.slider_image_2}
+                        {/if}
+                        {if isset($state.slider_image_3.url) && $state.slider_image_3.url}
+                            {append var='sliderImages' value=$state.slider_image_3}
+                        {/if}
+                        {if isset($state.slider_image_4.url) && $state.slider_image_4.url}
+                            {append var='sliderImages' value=$state.slider_image_4}
+                        {/if}
+                        {assign var='sliderImagesCount' value=$sliderImages|@count}
+                        {if $sliderImagesCount > 0}
+                            {assign var='carouselId' value="category-tabs-slider-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
+                            <div class="prettyblock-category-tabs__slider mt-3">
+                                <div id="{$carouselId}" class="prettyblocks-image-slider carousel slide" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true" data-autoplay="0" data-transition-speed="600">
+                                    {if $sliderImagesCount > 1}
+                                        <ol class="carousel-indicators">
+                                            {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
+                                                <li data-target="#{$carouselId}" data-slide-to="{$smarty.foreach.categorytabsimages.index}" data-bs-target="#{$carouselId}" data-bs-slide-to="{$smarty.foreach.categorytabsimages.index}" class="{if $smarty.foreach.categorytabsimages.first}active{/if}" aria-label="{$state.name|escape:'htmlall'}" aria-current="{if $smarty.foreach.categorytabsimages.first}true{else}false{/if}"></li>
+                                            {/foreach}
+                                        </ol>
+                                    {/if}
+                                    <div class="carousel-inner">
+                                        {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
+                                            <div class="carousel-item{if $smarty.foreach.categorytabsimages.first} active{/if}">
+                                                <div class="prettyblocks-slider-item-inner">
+                                                    <img src="{$sliderImage.url}" alt="{$state.name|escape:'htmlall'}" class="img img-fluid w-100 prettyblocks-slider-image lazyload" loading="lazy"{if isset($sliderImage.width) && $sliderImage.width} width="{$sliderImage.width|intval}"{/if}{if isset($sliderImage.height) && $sliderImage.height} height="{$sliderImage.height|intval}"{/if}>
+                                                </div>
+                                            </div>
+                                        {/foreach}
+                                    </div>
+                                    {if $sliderImagesCount > 1}
+                                        <button class="carousel-control-prev" type="button" data-target="#{$carouselId}" data-slide="prev" data-bs-target="#{$carouselId}" data-bs-slide="prev">
+                                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+                                        </button>
+                                        <button class="carousel-control-next" type="button" data-target="#{$carouselId}" data-slide="next" data-bs-target="#{$carouselId}" data-bs-slide="next">
+                                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                            <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+                                        </button>
+                                    {/if}
+                                </div>
+                            </div>
+                        {/if}
                         {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                         {if $useDesktopSlider || $useMobileSlider}
                             {if $useDesktopSlider}


### PR DESCRIPTION
### Motivation
- Allow editors to upload up to four images per Category Tabs tab and display them as a visual slider above the product grid, matching the provided mockup.
- Reuse the existing Prettyblocks carousel assets and behavior to keep consistent UI and interactions.
- Keep the feature optional so tabs without images are unchanged and existing slider/product logic remains intact.

### Description
- Added four `fileupload` fields (`slider_image_1`..`slider_image_4`) to the Category Tabs repeater in `src/Service/EverblockPrettyBlocks.php` so each tab can store up to four images. 
- Updated the tab template `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to collect any configured slider images and render a Bootstrap carousel (with indicators and prev/next controls) immediately before the products section when at least one image is present. 
- The new carousel uses existing `prettyblocks-image-slider` classes and lazy-loading attributes to integrate with current CSS/JS initializers and to ensure consistent appearance and behavior. 
- Changes are committed in two files: `src/Service/EverblockPrettyBlocks.php` and `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl`.

### Testing
- No automated tests were executed for this change in this rollout. 
- Template and PHP changes were saved and committed successfully to the local branch. 
- The carousel rendering relies on existing `prettyblocks-image-slider` JS/CSS initializers already present in the codebase and should work when served in a running frontend environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696635ab5e7c8322820ec6003a69cfe4)