### PR TITLE
Category Tabs: move image slider left, add header and responsive layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -390,6 +390,37 @@
     border-color: var(--bs-primary, #0d6efd);
     color: #fff;
 }
+.prettyblock-category-tabs__layout {
+    align-items: flex-start;
+}
+.prettyblock-category-tabs__slider {
+    width: 100%;
+}
+.prettyblock-category-tabs__slider-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+}
+.prettyblock-category-tabs__slider-title {
+    flex: 1;
+    font-weight: 600;
+    text-align: center;
+}
+.prettyblock-category-tabs__slider .carousel-control-prev,
+.prettyblock-category-tabs__slider .carousel-control-next {
+    position: static;
+    width: 2rem;
+    height: 2rem;
+    margin: 0;
+    opacity: 1;
+}
+.prettyblock-category-tabs__slider .carousel-control-prev.disabled,
+.prettyblock-category-tabs__slider .carousel-control-next.disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
 #everblockModal button.close {
     float: right;
     padding: 0;

--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -49,6 +49,21 @@
                     {assign var='sliderDevices' value=$state.slider_devices|default:'both'}
                     {assign var='useDesktopSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'desktop'))}
                     {assign var='useMobileSlider' value=($useSlider && ($sliderDevices == 'both' || $sliderDevices == 'mobile'))}
+                    {assign var='sliderImages' value=[]}
+                    {if isset($state.slider_image_1.url) && $state.slider_image_1.url}
+                        {append var='sliderImages' value=$state.slider_image_1}
+                    {/if}
+                    {if isset($state.slider_image_2.url) && $state.slider_image_2.url}
+                        {append var='sliderImages' value=$state.slider_image_2}
+                    {/if}
+                    {if isset($state.slider_image_3.url) && $state.slider_image_3.url}
+                        {append var='sliderImages' value=$state.slider_image_3}
+                    {/if}
+                    {if isset($state.slider_image_4.url) && $state.slider_image_4.url}
+                        {append var='sliderImages' value=$state.slider_image_4}
+                    {/if}
+                    {assign var='sliderImagesCount' value=$sliderImages|@count}
+                    {assign var='hasSliderImages' value=($sliderImagesCount > 0)}
                     {assign var='productCount' value=0}
                     {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                         {assign var='productCount' value=$block.extra.products[$key]|@count}
@@ -56,6 +71,9 @@
                     {assign var='desktopItems' value=$state.products_per_slide_desktop|default:4|intval}
                     {if $desktopItems < 1}
                         {assign var='desktopItems' value=1}
+                    {/if}
+                    {if $sliderImagesCount > 0}
+                        {assign var='desktopItems' value=2}
                     {/if}
                     {if $productCount > 0 && $productCount < $desktopItems}
                         {assign var='desktopItems' value=$productCount}
@@ -87,55 +105,46 @@
                                 {$state.html_before_products nofilter}
                             </div>
                         {/if}
-                        {assign var='sliderImages' value=[]}
-                        {if isset($state.slider_image_1.url) && $state.slider_image_1.url}
-                            {append var='sliderImages' value=$state.slider_image_1}
-                        {/if}
-                        {if isset($state.slider_image_2.url) && $state.slider_image_2.url}
-                            {append var='sliderImages' value=$state.slider_image_2}
-                        {/if}
-                        {if isset($state.slider_image_3.url) && $state.slider_image_3.url}
-                            {append var='sliderImages' value=$state.slider_image_3}
-                        {/if}
-                        {if isset($state.slider_image_4.url) && $state.slider_image_4.url}
-                            {append var='sliderImages' value=$state.slider_image_4}
-                        {/if}
-                        {assign var='sliderImagesCount' value=$sliderImages|@count}
-                        {if $sliderImagesCount > 0}
-                            {assign var='carouselId' value="category-tabs-slider-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
-                            <div class="prettyblock-category-tabs__slider mt-3">
-                                <div id="{$carouselId}" class="prettyblocks-image-slider carousel slide" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true" data-autoplay="0" data-transition-speed="600">
-                                    {if $sliderImagesCount > 1}
-                                        <ol class="carousel-indicators">
-                                            {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
-                                                <li data-target="#{$carouselId}" data-slide-to="{$smarty.foreach.categorytabsimages.index}" data-bs-target="#{$carouselId}" data-bs-slide-to="{$smarty.foreach.categorytabsimages.index}" class="{if $smarty.foreach.categorytabsimages.first}active{/if}" aria-label="{$state.name|escape:'htmlall'}" aria-current="{if $smarty.foreach.categorytabsimages.first}true{else}false{/if}"></li>
-                                            {/foreach}
-                                        </ol>
-                                    {/if}
-                                    <div class="carousel-inner">
-                                        {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
-                                            <div class="carousel-item{if $smarty.foreach.categorytabsimages.first} active{/if}">
-                                                <div class="prettyblocks-slider-item-inner">
-                                                    <img src="{$sliderImage.url}" alt="{$state.name|escape:'htmlall'}" class="img img-fluid w-100 prettyblocks-slider-image lazyload" loading="lazy"{if isset($sliderImage.width) && $sliderImage.width} width="{$sliderImage.width|intval}"{/if}{if isset($sliderImage.height) && $sliderImage.height} height="{$sliderImage.height|intval}"{/if}>
-                                                </div>
+                        <div class="row prettyblock-category-tabs__layout{if $hasSliderImages} prettyblock-category-tabs__layout--with-slider{/if}">
+                            {if $hasSliderImages}
+                                {assign var='carouselId' value="category-tabs-slider-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
+                                <div class="col-12 col-lg-4">
+                                    <div class="prettyblock-category-tabs__slider mt-3">
+                                        <div id="{$carouselId}" class="prettyblocks-image-slider carousel slide" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true" data-autoplay="0" data-transition-speed="600">
+                                            <div class="prettyblock-category-tabs__slider-header">
+                                                <button class="carousel-control-prev{if $sliderImagesCount < 2} disabled{/if}" type="button" data-target="#{$carouselId}" data-slide="prev" data-bs-target="#{$carouselId}" data-bs-slide="prev" {if $sliderImagesCount < 2}tabindex="-1" aria-disabled="true"{/if}>
+                                                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                                    <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+                                                </button>
+                                                <span class="prettyblock-category-tabs__slider-title">{$state.name|escape:'htmlall'}</span>
+                                                <button class="carousel-control-next{if $sliderImagesCount < 2} disabled{/if}" type="button" data-target="#{$carouselId}" data-slide="next" data-bs-target="#{$carouselId}" data-bs-slide="next" {if $sliderImagesCount < 2}tabindex="-1" aria-disabled="true"{/if}>
+                                                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                                    <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+                                                </button>
                                             </div>
-                                        {/foreach}
+                                            {if $sliderImagesCount > 1}
+                                                <ol class="carousel-indicators">
+                                                    {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
+                                                        <li data-target="#{$carouselId}" data-slide-to="{$smarty.foreach.categorytabsimages.index}" data-bs-target="#{$carouselId}" data-bs-slide-to="{$smarty.foreach.categorytabsimages.index}" class="{if $smarty.foreach.categorytabsimages.first}active{/if}" aria-label="{$state.name|escape:'htmlall'}" aria-current="{if $smarty.foreach.categorytabsimages.first}true{else}false{/if}"></li>
+                                                    {/foreach}
+                                                </ol>
+                                            {/if}
+                                            <div class="carousel-inner">
+                                                {foreach from=$sliderImages item=sliderImage name=categorytabsimages}
+                                                    <div class="carousel-item{if $smarty.foreach.categorytabsimages.first} active{/if}">
+                                                        <div class="prettyblocks-slider-item-inner">
+                                                            <img src="{$sliderImage.url}" alt="{$state.name|escape:'htmlall'}" class="img img-fluid w-100 prettyblocks-slider-image lazyload" loading="lazy"{if isset($sliderImage.width) && $sliderImage.width} width="{$sliderImage.width|intval}"{/if}{if isset($sliderImage.height) && $sliderImage.height} height="{$sliderImage.height|intval}"{/if}>
+                                                        </div>
+                                                    </div>
+                                                {/foreach}
+                                            </div>
+                                        </div>
                                     </div>
-                                    {if $sliderImagesCount > 1}
-                                        <button class="carousel-control-prev" type="button" data-target="#{$carouselId}" data-slide="prev" data-bs-target="#{$carouselId}" data-bs-slide="prev">
-                                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                                            <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
-                                        </button>
-                                        <button class="carousel-control-next" type="button" data-target="#{$carouselId}" data-slide="next" data-bs-target="#{$carouselId}" data-bs-slide="next">
-                                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                                            <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
-                                        </button>
-                                    {/if}
                                 </div>
-                            </div>
-                        {/if}
-                        {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
-                        {if $useDesktopSlider || $useMobileSlider}
+                            {/if}
+                            {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
+                                <div class="col-12{if $hasSliderImages} col-lg-8{/if}">
+                                    {if $useDesktopSlider || $useMobileSlider}
                             {if $useDesktopSlider}
                                 {assign var='carouselIdDesktop' value="category-tabs-carousel-desktop-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
                                 <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
@@ -216,18 +225,20 @@
                                     </div>
                                 </section>
                             {/if}
-                        {else}
-                            <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
-                                <div class="products row">
-                                    {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
-                                    {foreach from=$block.extra.products[$key] item=product}
-                                        {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
-                                    {/foreach}
-                                    {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                    {else}
+                                        <section class="ever-featured-products featured-products clearfix mt-3 category_tabs">
+                                            <div class="products row">
+                                                {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                                {foreach from=$block.extra.products[$key] item=product}
+                                                    {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                                {/foreach}
+                                                {hook h='displayAfterProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
+                                            </div>
+                                        </section>
+                                    {/if}
                                 </div>
-                            </section>
-                        {/if}
-                        {/if}
+                            {/if}
+                        </div>
                     </div>
                 {/foreach}
             </div>


### PR DESCRIPTION
### Motivation
- Place the image slider to the left of the product list and show it on desktop when images exist so two products appear to its right as requested.
- Ensure the slider is full-width on mobile and the category/custom name is centered between the slider navigation arrows inside the slider header.
- Improve layout/spacing so remaining products wrap to the next line when two are shown beside the slider.

### Description
- Reworked the template in `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to collect `sliderImages` earlier and render the slider in a left column (`col-lg-4`) with products in a right column (`col-lg-8`).
- Added a slider header containing previous/next buttons and a centered category title inside the slider, with disabled state handling for single-image sliders.
- When slider images exist the desktop product count is forced to `2` by adjusting `desktopItems` so two products are shown beside the slider and others wrap to the next row.
- Added CSS rules in `views/css/everblock.css` to style `.prettyblock-category-tabs__layout`, `.prettyblock-category-tabs__slider`, the slider header and control states.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696638c24a148322be7d5632bd202c67)