### PR TITLE
Per-product modal trigger: add button image/label support and DB self‑heal checks

### DIFF
--- a/models/EverblockModal.php
+++ b/models/EverblockModal.php
@@ -35,8 +35,14 @@ class EverblockModal extends ObjectModel
     /** @var string */
     public $file;
 
+    /** @var string */
+    public $button_file;
+
     /** @var array */
     public $content;
+
+    /** @var array */
+    public $button_label;
 
     public static $definition = [
         'table' => 'everblock_modal',
@@ -58,7 +64,17 @@ class EverblockModal extends ObjectModel
                 'validate' => 'isString',
                 'required' => false,
             ],
+            'button_file' => [
+                'type' => self::TYPE_STRING,
+                'validate' => 'isString',
+                'required' => false,
+            ],
             'content' => [
+                'type' => self::TYPE_HTML,
+                'lang' => true,
+                'validate' => 'isCleanHtml',
+            ],
+            'button_label' => [
                 'type' => self::TYPE_HTML,
                 'lang' => true,
                 'validate' => 'isCleanHtml',
@@ -81,4 +97,3 @@ class EverblockModal extends ObjectModel
         return $modal;
     }
 }
-

--- a/sql/install.php
+++ b/sql/install.php
@@ -151,6 +151,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_modal` (
         `id_product` int(10) unsigned NOT NULL,
         `id_shop` int(10) unsigned NOT NULL,
         `file` varchar(255) DEFAULT NULL,
+        `button_file` varchar(255) DEFAULT NULL,
         PRIMARY KEY (`id_everblock_modal`))
         ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 
@@ -158,6 +159,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_modal_lang` (
         `id_everblock_modal` int(10) unsigned NOT NULL,
         `id_lang` int(10) unsigned NOT NULL,
         `content` text DEFAULT NULL,
+        `button_label` text DEFAULT NULL,
         PRIMARY KEY (`id_everblock_modal`, `id_lang`))
         ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4750,6 +4750,7 @@ class EverblockTools extends ObjectModel
             'id_product' => 'int(10) unsigned NOT NULL',
             'id_shop' => 'int(10) unsigned NOT NULL',
             'file' => 'varchar(255) DEFAULT NULL',
+            'button_file' => 'varchar(255) DEFAULT NULL',
         ];
         foreach ($columnsToAdd as $columnName => $columnDefinition) {
             $columnExists = $db->ExecuteS('DESCRIBE `' . _DB_PREFIX_ . 'everblock_modal` `' . pSQL($columnName) . '`');
@@ -4767,6 +4768,7 @@ class EverblockTools extends ObjectModel
             'id_everblock_modal' => 'int(10) unsigned NOT NULL',
             'id_lang' => 'int(10) unsigned NOT NULL',
             'content' => 'text DEFAULT NULL',
+            'button_label' => 'text DEFAULT NULL',
         ];
         foreach ($columnsToAdd as $columnName => $columnDefinition) {
             $columnExists = $db->ExecuteS('DESCRIBE `' . _DB_PREFIX_ . 'everblock_modal_lang` `' . pSQL($columnName) . '`');

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -457,6 +457,16 @@
     height: auto;
     max-height: 80vh;
 }
+
+.everblock-modal-button--image {
+    background: transparent;
+}
+
+.everblock-modal-button-image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
 .ever-model-product.card {
     border: 1px solid #dee2e6; /* même valeur que Bootstrap 4 */
     border-radius: 0.25rem;

--- a/views/js/product-modal.js
+++ b/views/js/product-modal.js
@@ -34,259 +34,296 @@
       return;
     }
 
-    var fileInput = container.querySelector('#everblock_modal_file');
-    var deleteCheckbox = container.querySelector('input[name="everblock_modal_file_delete"]');
-    var payloadInput = container.querySelector('#everblock_modal_file_payload');
-    var nameInput = container.querySelector('#everblock_modal_file_name');
-    var feedback = container.querySelector('.everblock-modal-feedback');
-    var fileWrapper = container.querySelector('.everblock-modal-file-wrapper');
-    var deleteWrapper = container.querySelector('.everblock-modal-delete-wrapper');
-    var previewContainer = container.querySelector('.everblock-modal-preview-container');
-    var previewWrapper = container.querySelector('.everblock-modal-preview-wrapper');
-    var previewImage = container.querySelector('.everblock-modal-preview-image');
-    var previewEmpty = container.querySelector('.everblock-modal-preview-empty');
-    var previewEmptyText = container.getAttribute('data-ever-preview-empty-text')
-      || (previewContainer && previewContainer.getAttribute('data-ever-preview-empty-text'))
-      || '';
-    var isProcessing = false;
+    function initUploader(options) {
+      var fileInput = container.querySelector(options.fileInputSelector);
+      var deleteCheckbox = container.querySelector(options.deleteCheckboxSelector);
+      var payloadInput = container.querySelector(options.payloadInputSelector);
+      var nameInput = container.querySelector(options.nameInputSelector);
+      var feedback = container.querySelector(options.feedbackSelector);
+      var fileWrapper = container.querySelector(options.fileWrapperSelector);
+      var deleteWrapper = container.querySelector(options.deleteWrapperSelector);
+      var previewContainer = container.querySelector(options.previewContainerSelector);
+      var previewWrapper = container.querySelector(options.previewWrapperSelector);
+      var previewImage = container.querySelector(options.previewImageSelector);
+      var previewEmpty = container.querySelector(options.previewEmptySelector);
+      var previewEmptyText = container.getAttribute('data-ever-preview-empty-text')
+        || (previewContainer && previewContainer.getAttribute('data-ever-preview-empty-text'))
+        || '';
+      var isProcessing = false;
 
-    if (!fileInput) {
-      return;
-    }
-
-    function resetPayload() {
-      if (payloadInput) {
-        payloadInput.value = '';
-      }
-      if (nameInput) {
-        nameInput.value = '';
-      }
-    }
-
-    function setProcessing(state) {
-      isProcessing = state;
-      fileInput.disabled = state;
-      if (deleteCheckbox) {
-        deleteCheckbox.disabled = state;
-      }
-    }
-
-    function showFeedback(type, message) {
-      if (!feedback) {
+      if (!fileInput) {
         return;
       }
 
-      feedback.classList.remove('alert-success', 'alert-danger', 'd-none');
-
-      if (!message) {
-        feedback.classList.add('d-none');
-        feedback.textContent = '';
-        return;
-      }
-
-      feedback.textContent = message;
-
-      if (type === 'success') {
-        feedback.classList.add('alert-success');
-        feedback.classList.remove('alert-danger');
-      } else {
-        feedback.classList.add('alert-danger');
-        feedback.classList.remove('alert-success');
-      }
-    }
-
-    function buildPreviewUrl(url, timestamp) {
-      if (!url) {
-        return '';
-      }
-
-      var separator = url.indexOf('?') === -1 ? '?' : '&';
-      var safeTimestamp = typeof timestamp === 'number' && !isNaN(timestamp) ? timestamp : Date.now();
-
-      return url + separator + 't=' + safeTimestamp;
-    }
-
-    function updateFileDisplay(url, name, options) {
-      options = options || {};
-      if (!fileWrapper) {
-        return;
-      }
-
-      var current = fileWrapper.querySelector('.everblock-modal-current-file');
-      if (!current) {
-        current = document.createElement('p');
-        current.className = 'everblock-modal-current-file';
-        fileWrapper.appendChild(current);
-      }
-
-      current.innerHTML = '';
-
-      if (url) {
-        current.classList.remove('text-muted');
-        var link = document.createElement('a');
-        link.href = url;
-        link.target = '_blank';
-        link.className = 'everblock-modal-file-link';
-        var linkLabel = name || url;
-        link.textContent = linkLabel;
-        current.appendChild(link);
-      } else {
-        current.classList.add('text-muted');
-        current.textContent = noFileText;
-      }
-
-      if (previewContainer) {
-        if (url) {
-          previewContainer.classList.remove('d-none');
-        } else {
-          previewContainer.classList.add('d-none');
+      function resetPayload() {
+        if (payloadInput) {
+          payloadInput.value = '';
+        }
+        if (nameInput) {
+          nameInput.value = '';
         }
       }
 
-      var hasPreview = !!(url && options.isImage);
-      var previewUrl = options.previewUrl || buildPreviewUrl(url, options.timestamp);
-
-      if (previewWrapper) {
-        if (hasPreview) {
-          previewWrapper.classList.remove('d-none');
-          if (previewImage) {
-            previewImage.style.display = '';
-            previewImage.src = previewUrl || url;
-            previewImage.alt = name || '';
-          }
-        } else {
-          previewWrapper.classList.add('d-none');
-          if (previewImage) {
-            previewImage.removeAttribute('src');
-            previewImage.alt = '';
-          }
+      function setProcessing(state) {
+        isProcessing = state;
+        fileInput.disabled = state;
+        if (deleteCheckbox) {
+          deleteCheckbox.disabled = state;
         }
       }
 
-      if (previewEmpty) {
-        if (!url) {
-          previewEmpty.classList.add('d-none');
-        } else if (hasPreview) {
-          previewEmpty.classList.add('d-none');
-        } else {
-          previewEmpty.classList.remove('d-none');
-          if (previewEmptyText) {
-            previewEmpty.textContent = previewEmptyText;
-          }
-        }
-      }
-    }
-
-    function toggleDeleteWrapper(visible) {
-      if (!deleteWrapper) {
-        return;
-      }
-
-      deleteWrapper.style.display = visible ? '' : 'none';
-
-      if (deleteCheckbox) {
-        deleteCheckbox.checked = false;
-      }
-    }
-
-    function buildFormData() {
-      var formData = new FormData();
-      formData.append('ajax', '1');
-      formData.append('action', 'EverblockProductModalFile');
-      formData.append('configure', 'everblock');
-      formData.append('id_product', productId);
-      return formData;
-    }
-
-    function handleResponse(data, context) {
-      setProcessing(false);
-
-      var success = !!(data && data.success);
-      var message = data && data.message ? data.message : (defaultErrorMessage || '');
-
-      showFeedback(success ? 'success' : 'error', message);
-
-      if (success) {
-        var hasFile = data && data.file_url ? data.file_url.length > 0 : false;
-        var displayName = data && (data.file_display_name || data.file_name) ? (data.file_display_name || data.file_name) : '';
-        updateFileDisplay(
-          hasFile ? data.file_url : '',
-          displayName,
-          {
-            isImage: !!(data && data.is_image),
-            previewUrl: data && data.file_preview_url ? data.file_preview_url : '',
-            timestamp: data && typeof data.file_timestamp !== 'undefined' ? data.file_timestamp : null,
-          }
-        );
-        toggleDeleteWrapper(hasFile);
-        resetPayload();
-      } else if (context === 'delete' && deleteCheckbox) {
-        deleteCheckbox.checked = false;
-      }
-    }
-
-    function sendRequest(formData, context) {
-      if (isProcessing) {
-        return;
-      }
-
-      setProcessing(true);
-      showFeedback(null, '');
-
-      var xhr = new XMLHttpRequest();
-      xhr.open('POST', ajaxUrl, true);
-      xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-
-      xhr.onreadystatechange = function () {
-        if (xhr.readyState !== 4) {
+      function showFeedback(type, message) {
+        if (!feedback) {
           return;
         }
 
-        var data = null;
+        feedback.classList.remove('alert-success', 'alert-danger', 'd-none');
 
-        if (xhr.status >= 200 && xhr.status < 300) {
-          try {
-            data = JSON.parse(xhr.responseText);
-          } catch (error) {
-            data = null;
+        if (!message) {
+          feedback.classList.add('d-none');
+          feedback.textContent = '';
+          return;
+        }
+
+        feedback.textContent = message;
+
+        if (type === 'success') {
+          feedback.classList.add('alert-success');
+          feedback.classList.remove('alert-danger');
+        } else {
+          feedback.classList.add('alert-danger');
+          feedback.classList.remove('alert-success');
+        }
+      }
+
+      function buildPreviewUrl(url, timestamp) {
+        if (!url) {
+          return '';
+        }
+
+        var separator = url.indexOf('?') === -1 ? '?' : '&';
+        var safeTimestamp = typeof timestamp === 'number' && !isNaN(timestamp) ? timestamp : Date.now();
+
+        return url + separator + 't=' + safeTimestamp;
+      }
+
+      function updateFileDisplay(url, name, updateOptions) {
+        updateOptions = updateOptions || {};
+        if (!fileWrapper) {
+          return;
+        }
+
+        var current = fileWrapper.querySelector('.everblock-modal-current-file');
+        if (!current) {
+          current = document.createElement('p');
+          current.className = 'everblock-modal-current-file';
+          fileWrapper.appendChild(current);
+        }
+
+        current.innerHTML = '';
+
+        if (url) {
+          current.classList.remove('text-muted');
+          var link = document.createElement('a');
+          link.href = url;
+          link.target = '_blank';
+          link.className = 'everblock-modal-file-link';
+          var linkLabel = name || url;
+          link.textContent = linkLabel;
+          current.appendChild(link);
+        } else {
+          current.classList.add('text-muted');
+          current.textContent = noFileText;
+        }
+
+        if (previewContainer) {
+          if (url) {
+            previewContainer.classList.remove('d-none');
+          } else {
+            previewContainer.classList.add('d-none');
           }
         }
 
-        handleResponse(data, context);
-      };
+        var hasPreview = !!(url && updateOptions.isImage);
+        var previewUrl = updateOptions.previewUrl || buildPreviewUrl(url, updateOptions.timestamp);
 
-      xhr.onerror = function () {
-        handleResponse(null, context);
-      };
+        if (previewWrapper) {
+          if (hasPreview) {
+            previewWrapper.classList.remove('d-none');
+            if (previewImage) {
+              previewImage.style.display = '';
+              previewImage.src = previewUrl || url;
+              previewImage.alt = name || '';
+            }
+          } else {
+            previewWrapper.classList.add('d-none');
+            if (previewImage) {
+              previewImage.removeAttribute('src');
+              previewImage.alt = '';
+            }
+          }
+        }
 
-      xhr.send(formData);
-    }
-
-    fileInput.addEventListener('change', function () {
-      if (!fileInput.files || fileInput.files.length === 0) {
-        resetPayload();
-        return;
+        if (previewEmpty) {
+          if (!url) {
+            previewEmpty.classList.add('d-none');
+          } else if (hasPreview) {
+            previewEmpty.classList.add('d-none');
+          } else {
+            previewEmpty.classList.remove('d-none');
+            if (previewEmptyText) {
+              previewEmpty.textContent = previewEmptyText;
+            }
+          }
+        }
       }
 
-      var formData = buildFormData();
-      formData.append('everblock_modal_file', fileInput.files[0]);
+      function toggleDeleteWrapper(visible) {
+        if (!deleteWrapper) {
+          return;
+        }
 
-      resetPayload();
-      sendRequest(formData, 'upload');
-      fileInput.value = '';
-    });
+        deleteWrapper.style.display = visible ? '' : 'none';
 
-    if (deleteCheckbox) {
-      deleteCheckbox.addEventListener('change', function () {
-        if (!deleteCheckbox.checked) {
+        if (deleteCheckbox) {
+          deleteCheckbox.checked = false;
+        }
+      }
+
+      function buildFormData() {
+        var formData = new FormData();
+        formData.append('ajax', '1');
+        formData.append('action', 'EverblockProductModalFile');
+        formData.append('configure', 'everblock');
+        formData.append('id_product', productId);
+        if (options.target) {
+          formData.append('target', options.target);
+        }
+        return formData;
+      }
+
+      function handleResponse(data, context) {
+        setProcessing(false);
+
+        var success = !!(data && data.success);
+        var message = data && data.message ? data.message : (defaultErrorMessage || '');
+
+        showFeedback(success ? 'success' : 'error', message);
+
+        if (success) {
+          var hasFile = data && data.file_url ? data.file_url.length > 0 : false;
+          var displayName = data && (data.file_display_name || data.file_name) ? (data.file_display_name || data.file_name) : '';
+          updateFileDisplay(
+            hasFile ? data.file_url : '',
+            displayName,
+            {
+              isImage: !!(data && data.is_image),
+              previewUrl: data && data.file_preview_url ? data.file_preview_url : '',
+              timestamp: data && typeof data.file_timestamp !== 'undefined' ? data.file_timestamp : null,
+            }
+          );
+          toggleDeleteWrapper(hasFile);
+          resetPayload();
+        } else if (context === 'delete' && deleteCheckbox) {
+          deleteCheckbox.checked = false;
+        }
+      }
+
+      function sendRequest(formData, context) {
+        if (isProcessing) {
+          return;
+        }
+
+        setProcessing(true);
+        showFeedback(null, '');
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', ajaxUrl, true);
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
+        xhr.onreadystatechange = function () {
+          if (xhr.readyState !== 4) {
+            return;
+          }
+
+          var data = null;
+
+          if (xhr.status >= 200 && xhr.status < 300) {
+            try {
+              data = JSON.parse(xhr.responseText);
+            } catch (error) {
+              data = null;
+            }
+          }
+
+          handleResponse(data, context);
+        };
+
+        xhr.onerror = function () {
+          handleResponse(null, context);
+        };
+
+        xhr.send(formData);
+      }
+
+      fileInput.addEventListener('change', function () {
+        if (!fileInput.files || fileInput.files.length === 0) {
+          resetPayload();
           return;
         }
 
         var formData = buildFormData();
-        formData.append('delete', '1');
-        sendRequest(formData, 'delete');
+        formData.append(options.fileField, fileInput.files[0]);
+
+        resetPayload();
+        sendRequest(formData, 'upload');
+        fileInput.value = '';
       });
+
+      if (deleteCheckbox) {
+        deleteCheckbox.addEventListener('change', function () {
+          if (!deleteCheckbox.checked) {
+            return;
+          }
+
+          var formData = buildFormData();
+          formData.append('delete', '1');
+          sendRequest(formData, 'delete');
+        });
+      }
     }
+
+    initUploader({
+      target: 'modal',
+      fileField: 'everblock_modal_file',
+      fileInputSelector: '#everblock_modal_file',
+      deleteCheckboxSelector: 'input[name="everblock_modal_file_delete"]',
+      payloadInputSelector: '#everblock_modal_file_payload',
+      nameInputSelector: '#everblock_modal_file_name',
+      feedbackSelector: '.everblock-modal-feedback',
+      fileWrapperSelector: '.everblock-modal-file-wrapper',
+      deleteWrapperSelector: '.everblock-modal-delete-wrapper',
+      previewContainerSelector: '.everblock-modal-preview-container',
+      previewWrapperSelector: '.everblock-modal-preview-wrapper',
+      previewImageSelector: '.everblock-modal-preview-image',
+      previewEmptySelector: '.everblock-modal-preview-empty',
+    });
+
+    initUploader({
+      target: 'button',
+      fileField: 'everblock_modal_button_file',
+      fileInputSelector: '#everblock_modal_button_file',
+      deleteCheckboxSelector: 'input[name="everblock_modal_button_file_delete"]',
+      payloadInputSelector: '#everblock_modal_button_file_payload',
+      nameInputSelector: '#everblock_modal_button_file_name',
+      feedbackSelector: '.everblock-modal-button-feedback',
+      fileWrapperSelector: '.everblock-modal-button-file-wrapper',
+      deleteWrapperSelector: '.everblock-modal-button-delete-wrapper',
+      previewContainerSelector: '.everblock-modal-button-preview-container',
+      previewWrapperSelector: '.everblock-modal-button-preview-wrapper',
+      previewImageSelector: '.everblock-modal-button-preview-image',
+      previewEmptySelector: '.everblock-modal-button-preview-empty',
+    });
   }
 
   if (document.readyState === 'loading') {

--- a/views/templates/admin/productModal.tpl
+++ b/views/templates/admin/productModal.tpl
@@ -26,6 +26,10 @@
                     <label for="everblock_modal_content_{$language.id_lang|escape:'htmlall':'UTF-8'}">{l s='Modal content' mod='everblock'} {$language.iso_code|escape:'htmlall':'UTF-8'}</label>
                     <textarea id="everblock_modal_content_{$language.id_lang|escape:'htmlall':'UTF-8'}" name="everblock_modal_content_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="form-control autoload_rte">{if isset($modal->content[$language.id_lang])}{$modal->content[$language.id_lang]|escape:'htmlall':'UTF-8'}{/if}</textarea>
                 </div>
+                <div class="form-group">
+                    <label for="everblock_modal_button_label_{$language.id_lang|escape:'htmlall':'UTF-8'}">{l s='Button label' mod='everblock'} {$language.iso_code|escape:'htmlall':'UTF-8'}</label>
+                    <input type="text" id="everblock_modal_button_label_{$language.id_lang|escape:'htmlall':'UTF-8'}" name="everblock_modal_button_label_{$language.id_lang|escape:'htmlall':'UTF-8'}" class="form-control" value="{if isset($modal->button_label[$language.id_lang])}{$modal->button_label[$language.id_lang]|escape:'htmlall':'UTF-8'}{/if}" />
+                </div>
             {/foreach}
         </div>
         <div class="form-group">
@@ -60,6 +64,39 @@
             <input type="hidden" name="everblock_modal_file_payload" id="everblock_modal_file_payload" value="" />
             <input type="hidden" name="everblock_modal_file_name" id="everblock_modal_file_name" value="" />
             <div class="everblock-modal-feedback alert d-none" role="alert"></div>
+        </div>
+        <div class="form-group">
+            <label for="everblock_modal_button_file">{l s='Button file' mod='everblock'}</label>
+            <div class="everblock-modal-button-file-wrapper">
+                {if $modal_button_file_url}
+                    <p class="everblock-modal-current-file">
+                        <a href="{$modal_button_file_url|escape:'htmlall':'UTF-8'}" target="_blank" class="everblock-modal-file-link">{$modal_button_file_name|escape:'htmlall':'UTF-8'}</a>
+                    </p>
+                {else}
+                    <p class="everblock-modal-current-file text-muted">{l s='No file uploaded yet.' mod='everblock'}</p>
+                {/if}
+            </div>
+            <div class="everblock-modal-button-delete-wrapper"{if !$modal_button_file_url} style="display:none;"{/if}>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="everblock_modal_button_file_delete" value="1" />
+                        {l s='Delete file' mod='everblock'}
+                    </label>
+                </div>
+            </div>
+            <div class="everblock-modal-button-preview-container mt-3{if !$modal_button_file_url} d-none{/if}" data-ever-preview-empty-text="{l s='Preview not available for this file.' mod='everblock'|escape:'htmlall':'UTF-8'}">
+                <label class="form-label d-block">{l s='Preview' mod='everblock'}</label>
+                <div class="everblock-modal-button-preview-wrapper{if !$modal_button_file_url || !$modal_button_file_is_image} d-none{/if}">
+                    <img class="everblock-modal-button-preview-image img-thumbnail" alt="{$modal_button_file_name|escape:'htmlall':'UTF-8'}"{if $modal_button_file_url && $modal_button_file_is_image} src="{$modal_button_file_preview_url|escape:'htmlall':'UTF-8'}" loading="lazy"{/if} />
+                </div>
+                <p class="everblock-modal-button-preview-empty text-muted{if $modal_button_file_url && $modal_button_file_is_image} d-none{/if}">
+                    {l s='Preview not available for this file.' mod='everblock'}
+                </p>
+            </div>
+            <input type="file" name="everblock_modal_button_file" id="everblock_modal_button_file" class="form-control" />
+            <input type="hidden" name="everblock_modal_button_file_payload" id="everblock_modal_button_file_payload" value="" />
+            <input type="hidden" name="everblock_modal_button_file_name" id="everblock_modal_button_file_name" value="" />
+            <div class="everblock-modal-button-feedback alert d-none" role="alert"></div>
         </div>
     </div>
 </div>

--- a/views/templates/hook/modal.tpl
+++ b/views/templates/hook/modal.tpl
@@ -16,8 +16,18 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php Academic Free License (AFL 3.0)
 *}
 {if isset($everblock_modal_id) && $everblock_modal_id}
-<button type="button" class="btn btn-secondary everblock-modal-button" data-evermodal="{$everblock_modal_id|escape:'htmlall':'UTF-8'}">
-    {l s='Show modal' mod='everblock'}
+    {assign var='everblockModalButtonLabel' value=$everblock_modal_button_label|default:''}
+    {assign var='everblockModalButtonFileUrl' value=$everblock_modal_button_file_url|default:''}
+<button type="button" class="btn everblock-modal-button{if $everblockModalButtonFileUrl} btn-link p-0 border-0 everblock-modal-button--image{else} btn-secondary{/if}" data-evermodal="{$everblock_modal_id|escape:'htmlall':'UTF-8'}">
+    {if $everblockModalButtonFileUrl}
+        <img src="{$everblockModalButtonFileUrl|escape:'htmlall':'UTF-8'}" alt="{$everblockModalButtonLabel|strip_tags|escape:'htmlall':'UTF-8'}" class="everblock-modal-button-image" loading="lazy" />
+        {if $everblockModalButtonLabel}
+            <span class="visually-hidden">{$everblockModalButtonLabel|strip_tags|escape:'htmlall':'UTF-8'}</span>
+        {/if}
+    {elseif $everblockModalButtonLabel}
+        {$everblockModalButtonLabel|escape:'htmlall':'UTF-8'}
+    {else}
+        {l s='Show modal' mod='everblock'}
+    {/if}
 </button>
 {/if}
-


### PR DESCRIPTION
### Motivation
- Enable merchants to customize the product modal trigger per product by using a button image or custom label instead of the default trigger.
- Ensure the module self-heals databases by adding checks for the newly introduced modal button columns so upgrades/installations add missing fields automatically.

### Description
- Add persistent fields for the per-product trigger by introducing `button_file` and `button_label` columns in `sql/install.php` and model properties in `models/EverblockModal.php` with multilingual support via `button_label`.
- Extend the admin product UI in `views/templates/admin/productModal.tpl` to accept a `Button label` and a `Button file` with preview and delete controls, and expose related Smarty variables from the module backend.
- Refactor the admin uploader script `views/js/product-modal.js` to support two upload targets (modal and button) and send a `target` parameter for uploads/deletes.
- Update backend handlers in `everblock.php` to accept the `target` parameter in `ajaxProcessProductModalFile`, handle upload/delete for both `file` and `button_file`, and persist transfer payloads from product save logic (including deletion handling and file cleanup).
- Render the custom trigger in the front office via `views/templates/hook/modal.tpl` to show an image (with `views/css/everblock.css` styles) when `button_file` exists or fallback to `button_label` text, preserving existing modal behavior.
- Add schema self-heal checks in `src/Service/EverblockTools.php::checkAndFixDatabase()` to add missing `button_file` to `everblock_modal` and `button_label` to `everblock_modal_lang` when needed.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696751fc015c8322844da027e2b4264a)