### PR TITLE
Adjust FAQ headings, badge styling, and add chevron icon

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1277,6 +1277,12 @@
     transition: transform 0.2s ease;
 }
 
+.faq-chevron__icon {
+    width: 0.9rem;
+    height: 0.9rem;
+    display: block;
+}
+
 .faq-accordion .accordion-button:not(.collapsed) .faq-chevron {
     transform: rotate(180deg);
 }
@@ -1287,7 +1293,14 @@
 }
 
 .everblock-faq-chip {
+    color: #fff;
+    background-color: var(--bs-secondary);
     text-transform: lowercase;
+}
+
+.everblock-faq-chip:hover,
+.everblock-faq-chip:focus {
+    color: #fff;
 }
 
 @media (max-width: 767px) {

--- a/views/templates/front/faqs.tpl
+++ b/views/templates/front/faqs.tpl
@@ -10,11 +10,11 @@
       <div class="everblock-faqs-hero rounded-4 border bg-light p-4 p-md-5 d-flex flex-column flex-md-row justify-content-between gap-3">
         <div>
           {if $everblock_is_all_faqs_page}
-            <h1 class="h2 mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
+            <h1 class="mb-2">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
             <p class="text-muted mb-0">{l s='Browse every question and answer available across all groups.' mod='everblock' d='Modules.Everblock.Front'}</p>
           {else}
             <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
-              <h1 class="h2 mb-0">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
+              <h1 class="mb-0">{l s='FAQ' mod='everblock' d='Modules.Everblock.Front'}</h1>
               <span class="badge text-bg-primary text-lowercase everblock-faqs-tag" aria-label="{l s='Current FAQ tag' mod='everblock' d='Modules.Everblock.Front'}">{$everblock_tag_name|escape:'htmlall':'UTF-8'}</span>
             </div>
             <p class="text-muted mb-0">{l s='All frequently asked questions grouped by this tag.' mod='everblock' d='Modules.Everblock.Front'}</p>

--- a/views/templates/hook/faq.tpl
+++ b/views/templates/hook/faq.tpl
@@ -27,10 +27,14 @@
                 <button class="accordion-button bg-transparent shadow-none px-0 py-0 text-body fw-semibold d-flex align-items-center justify-content-between gap-3 {if !$smarty.foreach.faqloop.first}collapsed{/if}" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#collapse{$faq->id_everblock_faq}" data-bs-target="#collapse{$faq->id_everblock_faq}"
                         aria-expanded="{if $smarty.foreach.faqloop.first}true{else}false{/if}" aria-controls="collapse{$faq->id_everblock_faq}" itemprop="name">
                   <span class="text-start flex-grow-1">{$faq->title}</span>
-                  <span class="faq-chevron rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center flex-shrink-0" aria-hidden="true">⌄</span>
+                  <span class="faq-chevron rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center flex-shrink-0" aria-hidden="true">
+                    <svg class="faq-chevron__icon" viewBox="0 0 20 20" role="presentation" focusable="false" aria-hidden="true">
+                      <path d="M5.5 7.5L10 12l4.5-4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+                    </svg>
+                  </span>
                 </button>
                 {if isset($faq->tag_link) && $faq->tag_link}
-                  <a class="badge text-bg-secondary text-decoration-none everblock-faq-chip flex-shrink-0" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
+                  <a class="badge bg-secondary text-decoration-none everblock-faq-chip flex-shrink-0" href="{$faq->tag_link|escape:'htmlall':'UTF-8'}" title="{l s='View all questions from the %s group' sprintf=[$faq->tag_name] mod='everblock' d='Modules.Everblock.Front'}">
                     {$faq->tag_name|escape:'htmlall':'UTF-8'}
                   </a>
                 {/if}


### PR DESCRIPTION
### Motivation
- Normalize FAQ headings by removing the `h2` utility class to rely on semantic `h1` sizing and avoid double-sizing conflicts.
- Make FAQ tag chips visibly styled as secondary badges (not only visible on hover) so they are readable by default.
- Add a clear chevron icon to accordion headers to indicate the FAQ items are expandable and keep the rotation behavior when opened.

### Description
- Updated `views/templates/front/faqs.tpl` to remove the `h2` utility class from `h1` elements on the FAQ front page.
- Updated `views/templates/hook/faq.tpl` to replace the textual chevron with an inline SVG chevron and switched the tag badge class from `text-bg-secondary text-decoration-none` to `bg-secondary text-decoration-none` for consistent background usage.
- Updated `views/css/everblock.css` to add `.faq-chevron__icon` sizing rules, ensure `.everblock-faq-chip` uses a visible secondary background color and white text, and keep hover/focus color behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675c0d5854832294995ffc2e88377f)