### PR TITLE
Fix FAQ selector in product admin

### DIFF
--- a/models/EverblockFaq.php
+++ b/models/EverblockFaq.php
@@ -213,6 +213,16 @@ class EverblockFaq extends ObjectModel
         return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
     }
 
+    public static function countAll(int $shopId): int
+    {
+        $sql = new DbQuery();
+        $sql->select('COUNT(*)');
+        $sql->from(self::$definition['table']);
+        $sql->where('id_shop = ' . (int) $shopId);
+
+        return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
     public static function getFirstActiveTagName(?int $shopId = null): ?string
     {
         $shopId = self::resolveShopId($shopId);


### PR DESCRIPTION
### Motivation
- The product edit page was loading a FAQ selector UI that relied on an AJAX script which was not enqueued on the product admin page. 
- The selector was shown even when there were no FAQ entries, producing an unusable control. 
- Several admin functions used inconsistent shop id arguments when building FAQ-related data.

### Description
- Load the product FAQ front-end script on the product admin page by adding the `product-faq.js` include in `hookActionAdminControllerSetMedia` (`everblock.php`).
- Add `EverblockFaq::countAll` in `models/EverblockFaq.php` to return the total number of FAQs for a shop and use it to decide whether to display the selector.
- Pass a single `$shopId` variable through `hookDisplayAdminProductsExtra` and use it when fetching tabs, flags and FAQ data to avoid mixed shop id usage (`everblock.php`).
- Only assign `everblock_faq_selector` to the template when `countAll($shopId) > 0`, and otherwise omit the selector so the UI is not offered when there are no FAQs (`everblock.php`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967635a7a74832289b3bd9bf583acce)