### PR TITLE
Add background image/color support to heading prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -418,6 +418,20 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Text color'),
                             'default' => '',
                         ],
+                        'background_image' => [
+                            'tab' => 'design',
+                            'type' => 'fileupload',
+                            'label' => $module->l('Background image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'background_color' => [
+                            'tab' => 'design',
+                            'type' => 'color',
+                            'default' => '',
+                            'label' => $module->l('Block background color'),
+                        ],
                     ], $module),
                 ],
             ];

--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -18,7 +18,22 @@
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+{capture name='prettyblock_heading_wrapper_style'}
+  {if isset($block.settings.background_image.url) && $block.settings.background_image.url}
+    background-image:url('{$block.settings.background_image.url|escape:'htmlall':'UTF-8'}');
+    background-size:cover;
+    background-position:center;
+    background-repeat:no-repeat;
+  {/if}
+  {if isset($block.settings.background_color) && $block.settings.background_color}
+    background-color:{$block.settings.background_color|escape:'htmlall':'UTF-8'};
+  {elseif isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+    background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};
+  {/if}
+{/capture}
+{assign var='prettyblock_heading_wrapper_style' value=$smarty.capture.prettyblock_heading_wrapper_style|trim}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_heading_wrapper_style} style="{$prettyblock_heading_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}


### PR DESCRIPTION
### Motivation
- Allow the Heading (`everblock_heading`) Prettyblock to have a visual background so editors can upload a background image or set a block background color for Hn/title blocks.
- Provide a design-tab UI for background settings and render them in the front-end wrapper for consistent spacing and visibility handling.

### Description
- Add `background_image` (type `fileupload`) and `background_color` (type `color`) fields to the `everblock_heading` block configuration in `src/Service/EverblockPrettyBlocks.php` so backgrounds can be configured from the editor.
- Update the heading template `views/templates/hook/prettyblocks/prettyblock_heading.tpl` to build a wrapper inline style that applies `background-image`, `background-size`, `background-position`, `background-repeat`, and `background-color`, falling back to the existing `default.bg_color` when appropriate.
- Preserve existing spacing and visibility behavior by leveraging the existing `_partials/spacing_style.tpl` and `_partials/visibility_class.tpl` includes and applying the computed wrapper style to the outer block `<div>`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676835505483229c43ff89244d569e)