### PR TITLE
Move Prettyblock Title background to heading

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -18,7 +18,7 @@
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color} style="background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
   {elseif $block.settings.default.container}
@@ -35,6 +35,9 @@
         {/if}
         {if isset($block.settings.title_alignment) && $block.settings.title_alignment}
           {assign var='heading_styles' value="{$heading_styles}text-align:{$block.settings.title_alignment|escape:'htmlall':'UTF-8'};"}
+        {/if}
+        {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
+          {assign var='heading_styles' value="{$heading_styles}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"}
         {/if}
         <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
     {if $block.settings.default.container}


### PR DESCRIPTION
### Motivation
- Ensure the Prettyblock Title background color is applied to the heading element itself instead of the outer wrapper so the background only covers the title.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_heading.tpl` to remove the inline `background-color` from the outer wrapper and add the `background-color` into the `heading_styles` so it is applied on the generated heading element.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967901fb5d08322b9865e56640ecba5)