### PR TITLE
Add configurable background image for WordPress latest posts section

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -1134,9 +1134,16 @@ class EverblockTools extends ObjectModel
             }
         }
 
+        $backgroundImage = Configuration::get('EVERWP_POSTS_BG_IMAGE');
+        $backgroundUrl = '';
+        if ($backgroundImage) {
+            $backgroundUrl = $context->link->getBaseLink(null, null)
+                . 'modules/' . $module->name . '/views/img/' . $backgroundImage;
+        }
         $context->smarty->assign([
             'everblock_wp_posts' => $storedPosts,
             'everblock_wp_blog_url' => Configuration::get('EVERWP_BLOG_URL') ?: '/blog',
+            'everblock_wp_background_image' => $backgroundUrl,
         ]);
 
         foreach ($matches as $match) {

--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -1,5 +1,5 @@
 {if isset($everblock_wp_posts) && $everblock_wp_posts|@count > 0}
-<section class="everblock-wp-section text-center my-5">
+<section class="everblock-wp-section text-center my-5"{if $everblock_wp_background_image} style="background-image:url('{$everblock_wp_background_image|escape:'htmlall':'UTF-8'}');background-size:cover;background-position:center;background-repeat:no-repeat;"{/if}>
   <div class="h2 section-title text-uppercase mb-4">
     <span>{l s='Latest news from our blog' mod='everblock'}</span>
   </div>


### PR DESCRIPTION
### Motivation
- Allow the home/latest WordPress posts section to use a configurable background image set from the module configuration. 
- Provide upload, delete and persistence for the background image so the shortcode-generated block can render it.

### Description
- Added a new configuration key `EVERWP_POSTS_BG_IMAGE` and default value during `install()` and removal during `uninstall()` in `everblock.php`.
- Exposed a new file field in the WordPress settings tab (`EVERWP_POSTS_BG_IMAGE`) with preview and delete URL, and added upload handling/validation and previous-file cleanup in `postProcess()` and delete handling in `getContent()` in `everblock.php`.
- Included the new config value in `getConfigFormValues()` and updated templates to display the configured image preview in the admin form via the `image` entry.
- Passed the background image URL to the posts shortcode via `EverblockTools::getWordpressPostsShortcode()` and updated `views/templates/hook/generated_wp_posts.tpl` to apply an inline `background-image` style when provided.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967925f82d88322b2b13c17f7b63fe0)