### PR TITLE
Fix FAQ selector search visibility in product BO

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -119,6 +119,7 @@
     border-radius: .75rem;
     min-height: 56px;
     padding: .35rem;
+    background-color: #ffffff;
     transition: box-shadow .2s ease, border-color .2s ease;
 }
 
@@ -133,10 +134,20 @@
     padding: .4rem;
     font-size: 1rem;
     color: #0f172a;
+    min-width: 100%;
+    width: 100% !important;
 }
 
 #everblock .everblock-faq-selector-wrapper .select2-container--default.select2-container--focus .select2-selection--multiple {
     box-shadow: 0 0 0 .2rem rgba(79, 70, 229, 0.2);
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-container {
+    width: 100% !important;
+}
+
+#everblock .everblock-faq-selector-wrapper .select2-search--inline {
+    width: 100%;
 }
 
 #everblock .everblock-faq-selector-wrapper .select2-search--inline .select2-search__field::placeholder {


### PR DESCRIPTION
### Motivation
- The FAQ selector search input in the product back office was not visible/fully stretched, making it hard to find and use the search field when selecting FAQs.

### Description
- Updated `views/css/ever.css` to force the Select2 container and search field sizing so the search input is full-width and visible by adding `width: 100%` rules.
- Added a white `background-color` to the `.select2-selection--multiple` area to improve contrast and ensure the input is readable.
- Ensured the container and inline search wrapper `.select2-container` and `.select2-search--inline` are set to `width: 100% !important` so Select2 respects the form layout.

### Testing
- No automated tests were executed for this change; changes are purely presentational CSS and were committed without running test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b20529d88322b9447ffd56f49fcc)