### PR TITLE
Remove parallax support from Prettyblocks

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -858,11 +858,6 @@ class EverblockPrettyBlocks
                                 'url' => '',
                             ],
                         ],
-                        'parallax' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Parallax mode'),
-                            'default' => false,
-                        ],
                         'background_color' => [
                             'tab' => 'design',
                             'type' => 'color',
@@ -1062,11 +1057,6 @@ class EverblockPrettyBlocks
                             'type' => 'text',
                             'label' => 'Image height (e.g., 100px)',
                             'default' => 'auto',
-                        ],
-                        'parallax' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Parallax mode'),
-                            'default' => false,
                         ],
                         'content' => [
                             'type' => 'editor',
@@ -1638,11 +1628,6 @@ class EverblockPrettyBlocks
                             'type' => 'text',
                             'label' => 'Image height (e.g., 100px)',
                             'default' => 'auto',
-                        ],
-                        'parallax' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Parallax mode'),
-                            'default' => false,
                         ],
                         'content' => [
                             'type' => 'editor',
@@ -2945,11 +2930,6 @@ class EverblockPrettyBlocks
                             'default' => [
                                 'url' => '',
                             ],
-                        ],
-                        'parallax' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Enable parallax effect'),
-                            'default' => false,
                         ],
                         'btn1_text' => [
                             'type' => 'text',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -298,30 +298,8 @@
     cursor: pointer;
 }
 .everblock-gallery-modal .modal-header,
-.everblock-testimonial .text-center,
-.everblock-parallax .text-center {
+.everblock-testimonial .text-center {
     text-align: center;
-}
-.everblock-parallax .parallax-container {
-    position: relative;
-    overflow: hidden;
-}
-.everblock-parallax .parallax-bg {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-size: cover;
-    background-position: center top;
-    background-repeat: no-repeat;
-    transform: translateZ(0);
-    z-index: 0;
-}
-.everblock-parallax .parallax-content {
-    position: relative;
-    z-index: 1;
-    padding: 20px;
 }
 .everblock-overlay .image-overlay-container {
     position: relative;
@@ -770,14 +748,6 @@
     overflow: hidden;
 }
 
-.prettyblock-cover-item--parallax {
-    background-attachment: fixed;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    min-height: 300px;
-}
-
 .prettyblock-cover-item img.prettyblock-cover-image,
 .prettyblock-cover-row > .col img.prettyblock-cover-image {
     width: 100%;
@@ -885,10 +855,6 @@
 }
 
 @media (max-width: 767px) {
-    .prettyblock-cover-item--parallax {
-        background-attachment: scroll;
-    }
-
     .prettyblock-cover-overlay.position-mobile-top {
         justify-content: flex-start;
         align-items: center;

--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -58,45 +58,22 @@
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
         {capture name='prettyblock_cover_state_style'}
           {$prettyblock_cover_state_spacing_style}
-          {if $state.parallax && isset($state.background_image.url) && $state.background_image.url}
-            background-image:url('{$state.background_image.url|escape:'htmlall'}');
-            background-size:cover;
-            background-position:center;
-            background-repeat:no-repeat;
-            background-attachment:fixed;
-            {if isset($state.background_image.height) && $state.background_image.height}
-              min-height:{$state.background_image.height|intval}px;
-            {/if}
-          {/if}
         {/capture}
         {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
         {assign var='prettyblock_cover_link' value=$state.cover_link|default:''}
         <div id="block-{$block.id_prettyblocks}-{$key}"
-             class="prettyblock-cover-item{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
+             class="prettyblock-cover-item"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
             {if isset($state.background_image.url) && $state.background_image.url}
-              {if $state.parallax}
+              <picture>
                 {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-                  <style>
-                    @media (max-width: 767px) {
-                      #block-{$block.id_prettyblocks}-{$key} {
-                        background-image:url('{$state.background_image_mobile.url|escape:'htmlall'}');
-                        {if isset($state.background_image_mobile.height) && $state.background_image_mobile.height}min-height:{$state.background_image_mobile.height|intval}px;{/if}
-                      }
-                    }
-                  </style>
+                  <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
                 {/if}
-              {else}
-                <picture>
-                  {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-                    <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
-                  {/if}
-                  <img src="{$state.background_image.url|escape:'htmlall'}"
-                       alt="{$state.title|escape:'htmlall'}"
-                       {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
-                       {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
-                       class="prettyblock-cover-image">
-                </picture>
-              {/if}
+                <img src="{$state.background_image.url|escape:'htmlall'}"
+                     alt="{$state.title|escape:'htmlall'}"
+                     {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
+                     {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
+                     class="prettyblock-cover-image">
+              </picture>
             {/if}
           <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|replace:' ':'-'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|replace:' ':'-'|escape:'htmlall'}">
             {if $state.title}
@@ -149,16 +126,6 @@
       {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_cover_state_spacing_style'}
       {capture name='prettyblock_cover_state_style'}
         {$prettyblock_cover_state_spacing_style}
-        {if $state.parallax && isset($state.background_image.url) && $state.background_image.url}
-          background-image:url('{$state.background_image.url|escape:'htmlall'}');
-          background-size:cover;
-          background-position:center;
-          background-repeat:no-repeat;
-          background-attachment:fixed;
-          {if isset($state.background_image.height) && $state.background_image.height}
-            min-height:{$state.background_image.height|intval}px;
-          {/if}
-        {/if}
       {/capture}
       {assign var='prettyblock_cover_state_style' value=$smarty.capture.prettyblock_cover_state_style|trim}
       {assign var='prettyblock_cover_link' value=$state.cover_link|default:''}
@@ -167,31 +134,18 @@
         {assign var='prettyblock_cover_item_base_class' value=$columns_item_classes}
       {/if}
       <div id="block-{$block.id_prettyblocks}-{$key}"
-           class="{$prettyblock_cover_item_base_class}{if $state.parallax} prettyblock-cover-item--parallax{/if}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
+           class="{$prettyblock_cover_item_base_class}"{if $prettyblock_cover_state_style} style="{$prettyblock_cover_state_style}"{/if}>
         {if isset($state.background_image.url) && $state.background_image.url}
-          {if $state.parallax}
+          <picture>
             {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-              <style>
-                @media (max-width: 767px) {
-                  #block-{$block.id_prettyblocks}-{$key} {
-                    background-image:url('{$state.background_image_mobile.url|escape:'htmlall'}');
-                    {if isset($state.background_image_mobile.height) && $state.background_image_mobile.height}min-height:{$state.background_image_mobile.height|intval}px;{/if}
-                  }
-                }
-              </style>
+              <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
             {/if}
-          {else}
-            <picture>
-              {if isset($state.background_image_mobile.url) && $state.background_image_mobile.url}
-                <source media="(max-width: 767px)" srcset="{$state.background_image_mobile.url|escape:'htmlall'}">
-              {/if}
-              <img src="{$state.background_image.url|escape:'htmlall'}"
-                   alt="{$state.title|escape:'htmlall'}"
-                   {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
-                   {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
-                   class="prettyblock-cover-image">
-            </picture>
-          {/if}
+            <img src="{$state.background_image.url|escape:'htmlall'}"
+                 alt="{$state.title|escape:'htmlall'}"
+                 {if isset($state.background_image.width)} width="{$state.background_image.width|escape:'htmlall'}"{/if}
+                 {if isset($state.background_image.height)} height="{$state.background_image.height|escape:'htmlall'}"{/if}
+                 class="prettyblock-cover-image">
+          </picture>
         {/if}
         <div class="prettyblock-cover-overlay position-desktop-{$state.content_position_desktop|default:'center'|lower|replace:' ':'-'|escape:'htmlall'} position-mobile-{$state.content_position_mobile|default:'center'|lower|replace:' ':'-'|escape:'htmlall'}">
           {if $state.title}

--- a/views/templates/hook/prettyblocks/prettyblock_cta.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cta.tpl
@@ -34,7 +34,6 @@
           background-image: url('{$state.background_image.url|escape:'htmlall'}');
           background-size: cover;
           background-position: center;
-          {if $state.parallax}background-attachment: fixed;{/if}
         {/if}
       ">
         <div class="d-flex flex-column align-items-center justify-content-center h-100 w-100 px-3" style="z-index: 1;">

--- a/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl
@@ -32,48 +32,25 @@
                 
                 {* IMAGE *}
                 <div class="col-md-6 mb-3 mb-md-0 text-center">
-                    {if $state.parallax}
-                        {if $state.image_mobile.url}
-                            <div class="d-block d-md-none" style="
-                                background-image:url('{$state.image_mobile.url|replace:'.webp':'.jpg'}');
-                                background-size:cover;
-                                background-position:center;
-                                background-repeat:no-repeat;
-                                background-attachment:fixed;
-                                {if $state.image_mobile.height > 0}min-height:{$state.image_mobile.height}px;{/if}">
-                            </div>
-                        {/if}
-                        {if $state.image.url}
-                            <div class="{if $state.image_mobile.url}d-none d-md-block{/if}" style="
-                                background-image:url('{$state.image.url|replace:'.webp':'.jpg'}');
-                                background-size:cover;
-                                background-position:center;
-                                background-repeat:no-repeat;
-                                background-attachment:fixed;
-                                {if $state.image.height > 0}min-height:{$state.image.height}px;{/if}">
-                            </div>
-                        {/if}
-                    {else}
-                        {if $state.image_mobile.url}
-                            <picture class="d-block d-md-none">
-                                <source srcset="{$state.image_mobile.url}" type="image/webp">
-                                <source srcset="{$state.image_mobile.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                                <img src="{$state.image_mobile.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
-                                     {if $state.image_mobile.width > 0} width="{$state.image_mobile.width}"{/if}
-                                     {if $state.image_mobile.height > 0} height="{$state.image_mobile.height}"{/if}
-                                     loading="lazy">
-                            </picture>
-                        {/if}
-                        {if $state.image.url}
-                            <picture class="{if $state.image_mobile.url}d-none d-md-block{/if}">
-                                <source srcset="{$state.image.url}" type="image/webp">
-                                <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                                <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
-                                     {if $state.image.width > 0} width="{$state.image.width}"{/if}
-                                     {if $state.image.height > 0} height="{$state.image.height}"{/if}
-                                     loading="lazy">
-                            </picture>
-                        {/if}
+                    {if $state.image_mobile.url}
+                        <picture class="d-block d-md-none">
+                            <source srcset="{$state.image_mobile.url}" type="image/webp">
+                            <source srcset="{$state.image_mobile.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                            <img src="{$state.image_mobile.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                                 {if $state.image_mobile.width > 0} width="{$state.image_mobile.width}"{/if}
+                                 {if $state.image_mobile.height > 0} height="{$state.image_mobile.height}"{/if}
+                                 loading="lazy">
+                        </picture>
+                    {/if}
+                    {if $state.image.url}
+                        <picture class="{if $state.image_mobile.url}d-none d-md-block{/if}">
+                            <source srcset="{$state.image.url}" type="image/webp">
+                            <source srcset="{$state.image.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                            <img src="{$state.image.url|replace:'.webp':'.jpg'}" alt="{$state.name}" title="{$state.name}" class="img img-fluid rounded mx-auto d-block lazyload"
+                                 {if $state.image.width > 0} width="{$state.image.width}"{/if}
+                                 {if $state.image.height > 0} height="{$state.image.height}"{/if}
+                                 loading="lazy">
+                        </picture>
                     {/if}
                 </div>
 


### PR DESCRIPTION
### Motivation
- Remove parallax support from all Prettyblock types to simplify block rendering and avoid use of `background-attachment: fixed` and parallax-specific markup and styles.

### Description
- Removed the `'parallax'` checkbox fields from Prettyblocks schema definitions in `src/Service/EverblockPrettyBlocks.php` so the option is no longer present in block settings.
- Simplified templates in `views/templates/hook/prettyblocks/prettyblock_cover.tpl`, `prettyblock_text_and_image.tpl`, and `prettyblock_cta.tpl` to stop emitting parallax-specific markup and to always render images using `<picture><img>` elements.
- Removed parallax-specific CSS rules from `views/css/everblock.css`, including `.everblock-parallax` blocks and `.prettyblock-cover-item--parallax` rules.
- Cleaned up conditional background-attachment and inline parallax styles in cover/CTA/templates to use standard background/image rendering.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e5292b8c83229e82071119897f67)