### PR TITLE
Fix PrettyBlocks export hook detection and align admin action buttons

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -2238,10 +2238,11 @@ class Everblock extends Module
                 'type' => 'html',
                 'name' => 'submitUploadSvgButton',
                 'html_content' => sprintf(
-                    '<button type="submit" name="%s" class="btn btn-default pull-right"><i class="process-icon-download"></i> %s</button>',
+                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button></div>',
                     'submitUploadSvg',
                     htmlspecialchars($this->l('Upload SVG'), ENT_QUOTES, 'UTF-8')
                 ),
+                'form_group_class' => 'everblock-prettyblocks-action',
                 'tab' => 'prettyblock',
             ];
 
@@ -2249,10 +2250,11 @@ class Everblock extends Module
                 'type' => 'html',
                 'name' => 'submitExportPrettyblocksButton',
                 'html_content' => sprintf(
-                    '<button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button>',
+                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button></div>',
                     'submitExportPrettyblocks',
                     htmlspecialchars($this->l('Export PrettyBlocks JSON'), ENT_QUOTES, 'UTF-8')
                 ),
+                'form_group_class' => 'everblock-prettyblocks-action',
                 'tab' => 'prettyblock',
             ];
 
@@ -2260,10 +2262,11 @@ class Everblock extends Module
                 'type' => 'html',
                 'name' => 'submitImportPrettyblocksButton',
                 'html_content' => sprintf(
-                    '<button type="submit" name="%s" class="btn btn-default pull-right"><i class="process-icon-upload"></i> %s</button>',
+                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-upload"></i> %s</button></div>',
                     'submitImportPrettyblocks',
                     htmlspecialchars($this->l('Import PrettyBlocks JSON'), ENT_QUOTES, 'UTF-8')
                 ),
+                'form_group_class' => 'everblock-prettyblocks-action',
                 'tab' => 'prettyblock',
             ];
         }

--- a/src/Service/EverblockPrettyBlocksImportExport.php
+++ b/src/Service/EverblockPrettyBlocksImportExport.php
@@ -223,10 +223,34 @@ class EverblockPrettyBlocksImportExport
     private function resolvePrettyblocksHookField(): ?string
     {
         $columns = $this->getPrettyblocksTableColumns();
-        if (in_array('id_hook', $columns, true)) {
+        $hasIdHook = in_array('id_hook', $columns, true);
+        $hasHook = in_array('hook', $columns, true);
+        $db = Db::getInstance();
+
+        if ($hasIdHook) {
+            $idHookCount = (int) $db->getValue(
+                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'prettyblocks`'
+                . ' WHERE id_hook IS NOT NULL AND id_hook != 0'
+            );
+            if ($idHookCount > 0) {
+                return 'id_hook';
+            }
+        }
+
+        if ($hasHook) {
+            $hookCount = (int) $db->getValue(
+                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'prettyblocks`'
+                . ' WHERE hook IS NOT NULL AND hook != ""'
+            );
+            if ($hookCount > 0 || !$hasIdHook) {
+                return 'hook';
+            }
+        }
+
+        if ($hasIdHook) {
             return 'id_hook';
         }
-        if (in_array('hook', $columns, true)) {
+        if ($hasHook) {
             return 'hook';
         }
 

--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -461,6 +461,21 @@
     margin-bottom: 0;
 }
 
+#module_form .everblock-prettyblocks-action {
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    display: flex;
+    justify-content: flex-end;
+}
+
+#module_form .everblock-prettyblocks-action .everblock-prettyblocks-action__buttons {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
 #module_form label.control-label {
     font-size: 0.95rem;
     font-weight: 600;


### PR DESCRIPTION
### Motivation
- The PrettyBlocks export options could be empty when the module stored hook info in a different column, and admin action buttons in the PrettyBlocks config tab were misaligned and inconsistent.
- Ensure the export hook selection is built from the actual populated column and improve the UI layout for action buttons in the configuration form.

### Description
- Update `EverblockPrettyBlocksImportExport::resolvePrettyblocksHookField()` to detect whether `id_hook` or `hook` is actually populated by counting non-empty values in the `prettyblocks` table and prefer the populated column when present.
- Keep backward-compatible fallbacks so the method still returns a field name when only one column exists.
- Wrap the PrettyBlocks admin action buttons in a dedicated container and set a `form_group_class` for the form inputs in `everblock.php` to group the actions consistently in the UI.
- Add CSS rules in `views/css/ever.css` to style `.everblock-prettyblocks-action` and `.everblock-prettyblocks-action__buttons` to align and space the buttons.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a31aca608322be01eeed723216de)