### PR TITLE
Show hook name in Prettyblock admin listing

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -130,7 +130,8 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->hookField = 'hook_name';
             $this->hookFilterKey = 'h!name';
         } elseif ($this->hasColumn('hook')) {
-            $this->hookField = 'hook';
+            $this->appendSelect('a.hook AS hook_name');
+            $this->hookField = 'hook_name';
             $this->hookFilterKey = 'a!hook';
         }
 


### PR DESCRIPTION
### Motivation
- Ensure the admin PrettyBlocks listing shows the hook name for each block consistently by normalizing the column alias to `hook_name` whether the DB stores `id_hook` or `hook`.

### Description
- Update `controllers/admin/AdminEverBlockPrettyblockController.php` to `appendSelect('a.hook AS hook_name')` and set `hookField` to `hook_name` when the `prettyblocks` table contains a `hook` column so the list always exposes a `hook_name` column.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a4c7c6d08322807dcb21ef0b6645)