### PR TITLE
Handle zone_name hooks in PrettyBlocks admin and import/export

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -133,6 +133,12 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->appendSelect('a.hook AS hook_name');
             $this->hookField = 'hook_name';
             $this->hookFilterKey = 'a!hook';
+        } elseif ($this->hasColumn('zone_name')) {
+            $this->appendSelect('COALESCE(h.name, a.zone_name) AS hook_name');
+            $this->appendJoin('LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` = a.`zone_name`)');
+            $this->hookField = 'hook_name';
+            $this->hookFilterKey = 'a!zone_name';
+            $this->notifyMissingHooksForZoneName();
         }
 
         if ($this->hasShopColumn) {
@@ -196,6 +202,23 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
         }
 
         return null;
+    }
+
+    private function notifyMissingHooksForZoneName(): void
+    {
+        try {
+            $missingCount = (int) Db::getInstance()->getValue(
+                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'prettyblocks` a'
+                . ' LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` = a.`zone_name`)'
+                . ' WHERE a.`zone_name` IS NOT NULL AND a.`zone_name` != "" AND h.`id_hook` IS NULL'
+            );
+        } catch (Exception $e) {
+            $missingCount = 0;
+        }
+
+        if ($missingCount > 0) {
+            $this->errors[] = $this->l('Some PrettyBlocks are linked to missing hooks.');
+        }
     }
 
     private function configurePrettyblocksList(): void


### PR DESCRIPTION
### Motivation
- The `prettyblocks` table may store hook identifiers in the `zone_name` column which represents hook names rather than numeric `id_hook` values. 
- Admin listing and import/export logic must therefore resolve `zone_name` against the `hook` table and warn or reject entries when the referenced hook does not exist. 
- This prevents showing incorrect hook information and avoids importing blocks bound to non-existent hooks.

### Description
- In `controllers/admin/AdminEverBlockPrettyblockController.php` add support for `zone_name` by selecting `COALESCE(h.name, a.zone_name) AS hook_name`, joining the `hook` table on `h.name = a.zone_name`, and setting the correct `hookFilterKey`, and add `notifyMissingHooksForZoneName()` to warn about missing hooks. 
- In `src/Service/EverblockPrettyBlocksImportExport.php` extend `resolvePrettyblocksHookField()` to detect `zone_name` and prefer populated `zone_name` values, and add `hookExistsByName()` helper. 
- Update `exportPrettyblocks()` to validate the selected hook exists and use a dynamic WHERE clause based on the resolved hook column, and update `getPrettyblocksHookOptions()` to only return hooks that exist in the `hook` table. 
- Update `importPrettyblocks()` to skip rows whose `hook`/`zone_name` value has no matching `hook` record and collect/report the list of skipped hook names.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968af1b8bf88322a37c47303319285a)