### PR TITLE
Align PrettyBlocks action buttons

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -2236,33 +2236,13 @@ class Everblock extends Module
 
             $form['form']['input'][] = [
                 'type' => 'html',
-                'name' => 'submitUploadSvgButton',
+                'name' => 'submitPrettyblocksActions',
                 'html_content' => sprintf(
-                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button></div>',
+                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-upload"></i> %s</button></div>',
                     'submitUploadSvg',
-                    htmlspecialchars($this->l('Upload SVG'), ENT_QUOTES, 'UTF-8')
-                ),
-                'form_group_class' => 'everblock-prettyblocks-action',
-                'tab' => 'prettyblock',
-            ];
-
-            $form['form']['input'][] = [
-                'type' => 'html',
-                'name' => 'submitExportPrettyblocksButton',
-                'html_content' => sprintf(
-                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-download"></i> %s</button></div>',
+                    htmlspecialchars($this->l('Upload SVG'), ENT_QUOTES, 'UTF-8'),
                     'submitExportPrettyblocks',
-                    htmlspecialchars($this->l('Export PrettyBlocks JSON'), ENT_QUOTES, 'UTF-8')
-                ),
-                'form_group_class' => 'everblock-prettyblocks-action',
-                'tab' => 'prettyblock',
-            ];
-
-            $form['form']['input'][] = [
-                'type' => 'html',
-                'name' => 'submitImportPrettyblocksButton',
-                'html_content' => sprintf(
-                    '<div class="everblock-prettyblocks-action__buttons"><button type="submit" name="%s" class="btn btn-default"><i class="process-icon-upload"></i> %s</button></div>',
+                    htmlspecialchars($this->l('Export PrettyBlocks JSON'), ENT_QUOTES, 'UTF-8'),
                     'submitImportPrettyblocks',
                     htmlspecialchars($this->l('Import PrettyBlocks JSON'), ENT_QUOTES, 'UTF-8')
                 ),


### PR DESCRIPTION
### Motivation
- Group the three PrettyBlocks actions into a single form group so their buttons appear side-by-side in the Prettyblock configuration tab.

### Description
- Replace three separate `html` form inputs with a single `html` input (`submitPrettyblocksActions`) that renders the `Upload SVG`, `Export PrettyBlocks JSON`, and `Import PrettyBlocks JSON` buttons together in `everblock.php`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b19e0eac8322826acb09675a3c96)