### PR TITLE
Fix collation mismatch in PrettyBlocks hook lookup

### DIFF
--- a/src/Service/EverblockPrettyBlocksImportExport.php
+++ b/src/Service/EverblockPrettyBlocksImportExport.php
@@ -235,7 +235,8 @@ class EverblockPrettyBlocksImportExport
         return $db->executeS(
             'SELECT h.name AS id, h.name AS name, COUNT(*) AS total'
             . ' FROM `' . _DB_PREFIX_ . 'prettyblocks` a'
-            . ' INNER JOIN `' . _DB_PREFIX_ . 'hook` h ON h.name = a.' . $hookColumn
+            . ' INNER JOIN `' . _DB_PREFIX_ . 'hook` h ON h.name COLLATE utf8mb4_unicode_ci ='
+            . ' a.' . $hookColumn . ' COLLATE utf8mb4_unicode_ci'
             . ' WHERE a.' . $hookColumn . ' IS NOT NULL AND a.' . $hookColumn . ' != ""'
             . ' GROUP BY h.name'
             . ' HAVING total > 0'


### PR DESCRIPTION
### Motivation
- Prevent `SQLSTATE[HY000]: General error: 1267 Illegal mix of collations` when resolving PrettyBlocks hook options by ensuring the `hook` join comparison uses a consistent collation.

### Description
- Updated `src/Service/EverblockPrettyBlocksImportExport.php` to force the join comparison to use `COLLATE utf8mb4_unicode_ci` on both sides of the `ON` clause when joining `hook.name` with the PrettyBlocks hook column.
- This replaces the plain `ON h.name = a.<column>` with `ON h.name COLLATE utf8mb4_unicode_ci = a.<column> COLLATE utf8mb4_unicode_ci` in the non-`id_hook` branch.
- Change is limited to the `getPrettyblocksHookOptions()` method and affects only the hook-name join SQL string.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968bffca9088322aa7d6f7538b3d486)