### PR TITLE
Remove simple image highlight text fields

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1514,16 +1514,6 @@ class EverblockPrettyBlocks
                             'label' => $module->l('End date (YYYY-MM-DD HH:MM:SS)'),
                             'default' => '',
                         ],
-                        'text_highlight_1' => [
-                            'type' => 'editor',
-                            'label' => $module->l('Highlight text 1'),
-                            'default' => '',
-                        ],
-                        'text_highlight_2' => [
-                            'type' => 'editor',
-                            'label' => $module->l('Highlight text 2'),
-                            'default' => '',
-                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),


### PR DESCRIPTION
### Motivation
- The Simple image prettyblock should not expose the extra highlight text editor fields, so remove them from its configuration to simplify the block options.

### Description
- Remove the `text_highlight_1` and `text_highlight_2` editor fields from the Simple image prettyblock configuration in `src/Service/EverblockPrettyBlocks.php`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e6ca1eb88322bdea51156645efdd)