### PR TITLE
Remove PrettyBlocks missing hook warning

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -138,7 +138,6 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->appendJoin('LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` = a.`zone_name`)');
             $this->hookField = 'hook_name';
             $this->hookFilterKey = 'a!zone_name';
-            $this->notifyMissingHooksForZoneName();
         }
 
         if ($this->hasShopColumn) {
@@ -202,23 +201,6 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
         }
 
         return null;
-    }
-
-    private function notifyMissingHooksForZoneName(): void
-    {
-        try {
-            $missingCount = (int) Db::getInstance()->getValue(
-                'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'prettyblocks` a'
-                . ' LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` = a.`zone_name`)'
-                . ' WHERE a.`zone_name` IS NOT NULL AND a.`zone_name` != "" AND h.`id_hook` IS NULL'
-            );
-        } catch (Exception $e) {
-            $missingCount = 0;
-        }
-
-        if ($missingCount > 0) {
-            $this->errors[] = $this->l('Some PrettyBlocks are linked to missing hooks.');
-        }
     }
 
     private function configurePrettyblocksList(): void


### PR DESCRIPTION
### Motivation
- The admin controller displayed an unclear warning about PrettyBlocks linked to missing hooks and performed an extra lookup to detect it, which is being removed to avoid confusing messages and unnecessary queries.

### Description
- Removed the call to `notifyMissingHooksForZoneName()` from `controllers/admin/AdminEverBlockPrettyblockController.php`.
- Deleted the `notifyMissingHooksForZoneName()` method, which performed a SQL count join against the `hook` table and appended the error `Some PrettyBlocks are linked to missing hooks.` to `$this->errors`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eec96aa083229a02a18736da6f87)