### PR TITLE
Improve Prettyblock Google Reviews layout

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3156,3 +3156,197 @@
 .prettyblock-faq-cta {
   min-width: 240px;
 }
+
+/* Prettyblock Google reviews */
+.everblock-google-reviews__layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.everblock-google-reviews__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.everblock-google-reviews__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+  color: #111827;
+}
+
+.everblock-google-reviews__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.everblock-google-reviews__score {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.everblock-google-reviews__rating {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.everblock-google-reviews__stars {
+  display: inline-flex;
+  gap: 2px;
+  font-size: 1.1rem;
+}
+
+.everblock-google-reviews__star {
+  color: #d1d5db;
+}
+
+.everblock-google-reviews__star.is-filled {
+  color: #f59e0b;
+}
+
+.everblock-google-reviews__total {
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.everblock-google-reviews__provider {
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.everblock-google-reviews__logo-letter.is-blue {
+  color: #4285f4;
+}
+
+.everblock-google-reviews__logo-letter.is-red {
+  color: #ea4335;
+}
+
+.everblock-google-reviews__logo-letter.is-yellow {
+  color: #fbbc05;
+}
+
+.everblock-google-reviews__logo-letter.is-green {
+  color: #34a853;
+}
+
+.everblock-google-reviews__cta .btn {
+  background-color: #6b7280;
+  border-color: #6b7280;
+  color: #fff;
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.everblock-google-reviews__cta .btn:hover,
+.everblock-google-reviews__cta .btn:focus {
+  background-color: #4b5563;
+  border-color: #4b5563;
+  color: #fff;
+}
+
+.everblock-google-reviews__list {
+  margin: 0;
+}
+
+.everblock-google-reviews__card {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  background: #f3f4f6;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.everblock-google-reviews__avatar {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.everblock-google-reviews__avatar.is-placeholder {
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.everblock-google-reviews__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.everblock-google-reviews__author {
+  margin: 0;
+  font-weight: 600;
+  color: #111827;
+}
+
+.everblock-google-reviews__author a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.everblock-google-reviews__author a:hover {
+  text-decoration: underline;
+}
+
+.everblock-google-reviews__time {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.everblock-google-reviews__text {
+  margin: 0;
+  color: #374151;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  max-height: 7.5rem;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.everblock-google-reviews__text::-webkit-scrollbar {
+  width: 6px;
+}
+
+.everblock-google-reviews__text::-webkit-scrollbar-thumb {
+  background: #9ca3af;
+  border-radius: 999px;
+}
+
+.everblock-google-reviews__text::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@media (max-width: 991px) {
+  .everblock-google-reviews__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .everblock-google-reviews__aside {
+    align-items: center;
+    text-align: center;
+  }
+}

--- a/views/templates/hook/_partials/google_reviews.tpl
+++ b/views/templates/hook/_partials/google_reviews.tpl
@@ -21,80 +21,98 @@
 {if $columns < 1}{assign var=columns value=1}{/if}
 {if $columns > 6}{assign var=columns value=6}{/if}
 <div class="everblock-google-reviews{if $googleReviewsOptions.css_class} {$googleReviewsOptions.css_class|escape:'htmlall':'UTF-8'}{/if}"{if isset($googleReviewsOptions.place_id) && $googleReviewsOptions.place_id} data-place-id="{$googleReviewsOptions.place_id|escape:'htmlall':'UTF-8'}"{/if}>
-  {if $googleReviewsHeading}
-    <h3 class="everblock-google-reviews__title">{$googleReviewsHeading|escape:'htmlall':'UTF-8'}</h3>
-  {/if}
-  {if $googleReviewsIntro}
-    <div class="everblock-google-reviews__intro">{$googleReviewsIntro nofilter}</div>
-  {/if}
-  {if $googleReviewsOptions.show_rating && $googleReviewsData.rating}
-    <div class="everblock-google-reviews__summary">
-      <div class="everblock-google-reviews__score">
-        <span class="everblock-google-reviews__rating">{$googleReviewsData.rating|number_format:1}</span>
-        <span class="everblock-google-reviews__stars" aria-hidden="true">
-          {section name=globalStar loop=5}
-            {assign var=position value=$smarty.section.globalStar.index+1}
-            <span class="everblock-google-reviews__star{if $googleReviewsData.rating >= $position} is-filled{/if}">★</span>
-          {/section}
-        </span>
-        <span class="sr-only">{l s='%1$s out of %2$s' sprintf=[$googleReviewsData.rating|number_format:1, 5] mod='everblock'}</span>
-      </div>
-      {if $googleReviewsData.user_ratings_total}
-        <div class="everblock-google-reviews__total">
-          {l s='%s reviews' sprintf=[$googleReviewsData.user_ratings_total] mod='everblock'}
+  <div class="everblock-google-reviews__layout">
+    <aside class="everblock-google-reviews__aside">
+      {if $googleReviewsHeading}
+        <h3 class="everblock-google-reviews__title">{$googleReviewsHeading|escape:'htmlall':'UTF-8'}</h3>
+      {/if}
+      {if $googleReviewsIntro}
+        <div class="everblock-google-reviews__intro">{$googleReviewsIntro nofilter}</div>
+      {/if}
+      {if $googleReviewsOptions.show_rating && $googleReviewsData.rating}
+        <div class="everblock-google-reviews__summary">
+          <div class="everblock-google-reviews__score">
+            <span class="everblock-google-reviews__rating">{$googleReviewsData.rating|number_format:1}</span>
+            <span class="everblock-google-reviews__stars" aria-hidden="true">
+              {section name=globalStar loop=5}
+                {assign var=position value=$smarty.section.globalStar.index+1}
+                <span class="everblock-google-reviews__star{if $googleReviewsData.rating >= $position} is-filled{/if}">★</span>
+              {/section}
+            </span>
+            <span class="sr-only">{l s='%1$s out of %2$s' sprintf=[$googleReviewsData.rating|number_format:1, 5] mod='everblock'}</span>
+          </div>
+          {if $googleReviewsData.user_ratings_total}
+            <div class="everblock-google-reviews__total">
+              {l s='Based on %s reviews' sprintf=[$googleReviewsData.user_ratings_total] mod='everblock'}
+            </div>
+          {/if}
         </div>
       {/if}
-    </div>
-  {/if}
-  {if $reviews}
-    <div class="everblock-google-reviews__list row row-cols-1 row-cols-md-{$columns} g-3">
-      {foreach from=$reviews item=review}
-        <div class="col">
-          <article class="everblock-google-reviews__card h-100">
-            {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
-              <div class="everblock-google-reviews__avatar">
-                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="64" height="64">
-              </div>
-            {/if}
-            <div class="everblock-google-reviews__body">
-              <header class="everblock-google-reviews__header">
-                {if $review.author_name}
-                  <p class="everblock-google-reviews__author">
-                    {if $review.author_url}
-                      <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
-                    {else}
-                      {$review.author_name|escape:'htmlall':'UTF-8'}
-                    {/if}
-                  </p>
-                {/if}
-                {if $review.rating}
-                  <div class="everblock-google-reviews__rating" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
-                    {section name=item loop=5}
-                      {assign var=position value=$smarty.section.item.index+1}
-                      <span class="everblock-google-reviews__star{if $review.rating >= $position} is-filled{/if}">★</span>
-                    {/section}
+      <div class="everblock-google-reviews__provider" aria-label="Google">
+        <span class="everblock-google-reviews__logo-letter is-blue">G</span>
+        <span class="everblock-google-reviews__logo-letter is-red">o</span>
+        <span class="everblock-google-reviews__logo-letter is-yellow">o</span>
+        <span class="everblock-google-reviews__logo-letter is-blue">g</span>
+        <span class="everblock-google-reviews__logo-letter is-green">l</span>
+        <span class="everblock-google-reviews__logo-letter is-red">e</span>
+      </div>
+      {if $googleReviewsOptions.show_cta && $googleReviewsOptions.cta_url}
+        <div class="everblock-google-reviews__cta">
+          <a class="btn btn-primary" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow">
+            {if $googleReviewsOptions.cta_label}{$googleReviewsOptions.cta_label|escape:'htmlall':'UTF-8'}{else}{l s='Read all reviews on Google' mod='everblock'}{/if}
+          </a>
+        </div>
+      {/if}
+    </aside>
+    <div class="everblock-google-reviews__content">
+      {if $reviews}
+        <div class="everblock-google-reviews__list row row-cols-1 row-cols-md-{$columns} g-3">
+          {foreach from=$reviews item=review}
+            <div class="col">
+              <article class="everblock-google-reviews__card h-100">
+                {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
+                  <div class="everblock-google-reviews__avatar">
+                    <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="64" height="64">
+                  </div>
+                {elseif $googleReviewsOptions.show_avatar}
+                  <div class="everblock-google-reviews__avatar is-placeholder" aria-hidden="true">
+                    <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
                   </div>
                 {/if}
-                {if $review.relative_time_description}
-                  <p class="everblock-google-reviews__time">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
-                {/if}
-              </header>
-              {if $review.text}
-                <p class="everblock-google-reviews__text">{$review.text|escape:'htmlall':'UTF-8'}</p>
-              {/if}
+                <div class="everblock-google-reviews__body">
+                  <header class="everblock-google-reviews__header">
+                    {if $review.author_name}
+                      <p class="everblock-google-reviews__author">
+                        {if $review.author_url}
+                          <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
+                        {else}
+                          {$review.author_name|escape:'htmlall':'UTF-8'}
+                        {/if}
+                      </p>
+                    {/if}
+                    {if $review.rating}
+                      <div class="everblock-google-reviews__rating" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
+                        {section name=item loop=5}
+                          {assign var=position value=$smarty.section.item.index+1}
+                          <span class="everblock-google-reviews__star{if $review.rating >= $position} is-filled{/if}">★</span>
+                        {/section}
+                      </div>
+                    {/if}
+                    {if $review.relative_time_description}
+                      <p class="everblock-google-reviews__time">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
+                    {/if}
+                  </header>
+                  {if $review.text}
+                    <p class="everblock-google-reviews__text">{$review.text|escape:'htmlall':'UTF-8'}</p>
+                  {/if}
+                </div>
+              </article>
             </div>
-          </article>
+          {/foreach}
         </div>
-      {/foreach}
+      {elseif $googleReviewsOptions.is_configured}
+        <p class="everblock-google-reviews__empty">{l s='No Google reviews available yet.' mod='everblock'}</p>
+      {/if}
     </div>
-  {elseif $googleReviewsOptions.is_configured}
-    <p class="everblock-google-reviews__empty">{l s='No Google reviews available yet.' mod='everblock'}</p>
-  {/if}
-  {if $googleReviewsOptions.show_cta && $googleReviewsOptions.cta_url}
-    <div class="everblock-google-reviews__cta mt-3">
-      <a class="btn btn-primary" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow">
-        {if $googleReviewsOptions.cta_label}{$googleReviewsOptions.cta_label|escape:'htmlall':'UTF-8'}{else}{l s='Read all reviews on Google' mod='everblock'}{/if}
-      </a>
-    </div>
-  {/if}
+  </div>
 </div>


### PR DESCRIPTION
### Motivation
- Update the Prettyblock Google Reviews block to match the provided mockup with a clearer summary/sidebar and improved card presentation.
- Provide stronger provider branding and a prominent CTA while handling missing avatars gracefully.

### Description
- Restructured the reviews template in `views/templates/hook/_partials/google_reviews.tpl` to add a two-column layout with an `aside` summary area and a main content area. 
- Moved the CTA and provider branding into the summary area and changed the reviews total label to `Based on %s reviews` for clearer copy. 
- Added avatar placeholder support when `profile_photo_url` is missing and adjusted markup for review cards and header elements. 
- Added comprehensive styling in `views/css/everblock.css` to implement the grid layout, sidebar typography, card appearance, avatar placeholders, star colors, scrollable review text, and a responsive media query.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968f2f914d4832282e9b660efc98c7e)