### PR TITLE
Refactor Google Reviews block layout and styling (Bootstrap 5)

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3166,17 +3166,10 @@
   box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
 }
 
-.everblock-google-reviews__layout {
-  display: grid;
-  grid-template-columns: minmax(220px, 260px) 1fr;
-  gap: 32px;
-  align-items: start;
-}
-
 .everblock-google-reviews__aside {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
   align-items: flex-start;
 }
 
@@ -3197,8 +3190,7 @@
 .everblock-google-reviews__summary {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
+  gap: 6px;
   border-radius: 16px;
   background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
   border: 1px solid #e0e7ff;
@@ -3207,7 +3199,7 @@
 .everblock-google-reviews__score {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .everblock-google-reviews__rating {
@@ -3268,7 +3260,7 @@
   background-color: #111827;
   border-color: #111827;
   color: #fff;
-  padding: 0.6rem 1.4rem;
+  padding: 0.7rem 1.6rem;
   border-radius: 999px;
   font-weight: 700;
   box-shadow: 0 10px 20px rgba(17, 24, 39, 0.2);
@@ -3289,11 +3281,7 @@
 }
 
 .everblock-google-reviews__card {
-  display: flex;
-  gap: 16px;
-  padding: 18px;
   border-radius: 18px;
-  background: #ffffff;
   border: 1px solid #e5e7eb;
   box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
@@ -3306,9 +3294,9 @@
 }
 
 .everblock-google-reviews__avatar {
-  width: 52px;
-  height: 52px;
-  flex: 0 0 52px;
+  width: 56px;
+  height: 56px;
+  flex: 0 0 56px;
   border-radius: 50%;
   overflow: hidden;
   display: flex;
@@ -3328,8 +3316,8 @@
 .everblock-google-reviews__header {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 6px;
+  gap: 4px;
+  margin-bottom: 8px;
 }
 
 .everblock-google-reviews__author {
@@ -3358,31 +3346,15 @@
   color: #374151;
   font-size: 0.95rem;
   line-height: 1.6;
-  max-height: 8rem;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-
-.everblock-google-reviews__text::-webkit-scrollbar {
-  width: 6px;
-}
-
-.everblock-google-reviews__text::-webkit-scrollbar-thumb {
-  background: #9ca3af;
-  border-radius: 999px;
-}
-
-.everblock-google-reviews__text::-webkit-scrollbar-track {
-  background: transparent;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 @media (max-width: 991px) {
   .everblock-google-reviews {
     padding: 22px;
-  }
-
-  .everblock-google-reviews__layout {
-    grid-template-columns: 1fr;
   }
 
   .everblock-google-reviews__aside {

--- a/views/templates/hook/_partials/google_reviews.tpl
+++ b/views/templates/hook/_partials/google_reviews.tpl
@@ -21,18 +21,20 @@
 {if $columns < 1}{assign var=columns value=1}{/if}
 {if $columns > 6}{assign var=columns value=6}{/if}
 <div class="everblock-google-reviews{if $googleReviewsOptions.css_class} {$googleReviewsOptions.css_class|escape:'htmlall':'UTF-8'}{/if}"{if isset($googleReviewsOptions.place_id) && $googleReviewsOptions.place_id} data-place-id="{$googleReviewsOptions.place_id|escape:'htmlall':'UTF-8'}"{/if}>
-  <div class="everblock-google-reviews__layout">
-    <aside class="everblock-google-reviews__aside">
-      {if $googleReviewsHeading}
-        <h3 class="everblock-google-reviews__title">{$googleReviewsHeading|escape:'htmlall':'UTF-8'}</h3>
-      {/if}
-      {if $googleReviewsIntro}
-        <div class="everblock-google-reviews__intro">{$googleReviewsIntro nofilter}</div>
-      {/if}
+  <div class="d-flex flex-column flex-lg-row gap-4 gap-lg-5">
+    <aside class="everblock-google-reviews__aside flex-shrink-0">
+      <header class="d-flex flex-column gap-2">
+        {if $googleReviewsHeading}
+          <h3 class="everblock-google-reviews__title h4 mb-0">{$googleReviewsHeading|escape:'htmlall':'UTF-8'}</h3>
+        {/if}
+        {if $googleReviewsIntro}
+          <div class="everblock-google-reviews__intro text-muted">{$googleReviewsIntro nofilter}</div>
+        {/if}
+      </header>
       {if $googleReviewsOptions.show_rating && $googleReviewsData.rating}
-        <div class="everblock-google-reviews__summary">
-          <div class="everblock-google-reviews__score">
-            <span class="everblock-google-reviews__rating">{$googleReviewsData.rating|number_format:1}</span>
+        <div class="everblock-google-reviews__summary border rounded-4 p-3 d-flex flex-column gap-2">
+          <div class="d-flex align-items-center gap-2 flex-wrap">
+            <span class="everblock-google-reviews__rating fs-3 fw-bold">{$googleReviewsData.rating|number_format:1}</span>
             <span class="everblock-google-reviews__stars" aria-hidden="true">
               {section name=globalStar loop=5}
                 {assign var=position value=$smarty.section.globalStar.index+1}
@@ -42,13 +44,13 @@
             <span class="sr-only">{l s='%1$s out of %2$s' sprintf=[$googleReviewsData.rating|number_format:1, 5] mod='everblock'}</span>
           </div>
           {if $googleReviewsData.user_ratings_total}
-            <div class="everblock-google-reviews__total">
+            <p class="everblock-google-reviews__total mb-0 text-muted">
               {l s='Based on %s reviews' sprintf=[$googleReviewsData.user_ratings_total] mod='everblock'}
-            </div>
+            </p>
           {/if}
         </div>
       {/if}
-      <div class="everblock-google-reviews__provider" aria-label="Google">
+      <div class="everblock-google-reviews__provider d-inline-flex align-items-center gap-1" aria-label="Google">
         <span class="everblock-google-reviews__logo-letter is-blue">G</span>
         <span class="everblock-google-reviews__logo-letter is-red">o</span>
         <span class="everblock-google-reviews__logo-letter is-yellow">o</span>
@@ -58,60 +60,64 @@
       </div>
       {if $googleReviewsOptions.show_cta && $googleReviewsOptions.cta_url}
         <div class="everblock-google-reviews__cta">
-          <a class="btn btn-primary" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow">
+          <a class="btn btn-primary btn-lg" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow" aria-label="{l s='Read all reviews on Google' mod='everblock'}">
             {if $googleReviewsOptions.cta_label}{$googleReviewsOptions.cta_label|escape:'htmlall':'UTF-8'}{else}{l s='Read all reviews on Google' mod='everblock'}{/if}
           </a>
         </div>
       {/if}
     </aside>
-    <div class="everblock-google-reviews__content">
+    <div class="everblock-google-reviews__content flex-grow-1">
       {if $reviews}
-        <div class="everblock-google-reviews__list row row-cols-1 row-cols-md-{$columns} g-3">
+        <div class="everblock-google-reviews__list row row-cols-1 row-cols-md-2 row-cols-lg-{$columns} g-4">
           {foreach from=$reviews item=review}
             <div class="col">
-              <article class="everblock-google-reviews__card h-100">
-                {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
-                  <div class="everblock-google-reviews__avatar">
-                    <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="64" height="64">
-                  </div>
-                {elseif $googleReviewsOptions.show_avatar}
-                  <div class="everblock-google-reviews__avatar is-placeholder" aria-hidden="true">
-                    <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
-                  </div>
-                {/if}
-                <div class="everblock-google-reviews__body">
-                  <header class="everblock-google-reviews__header">
-                    {if $review.author_name}
-                      <p class="everblock-google-reviews__author">
-                        {if $review.author_url}
-                          <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
-                        {else}
-                          {$review.author_name|escape:'htmlall':'UTF-8'}
-                        {/if}
-                      </p>
-                    {/if}
-                    {if $review.rating}
-                      <div class="everblock-google-reviews__rating" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
-                        {section name=item loop=5}
-                          {assign var=position value=$smarty.section.item.index+1}
-                          <span class="everblock-google-reviews__star{if $review.rating >= $position} is-filled{/if}">★</span>
-                        {/section}
-                      </div>
-                    {/if}
-                    {if $review.relative_time_description}
-                      <p class="everblock-google-reviews__time">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
-                    {/if}
-                  </header>
-                  {if $review.text}
-                    <p class="everblock-google-reviews__text">{$review.text|escape:'htmlall':'UTF-8'}</p>
+              <article class="card h-100 border-0 shadow-sm everblock-google-reviews__card">
+                <div class="card-body d-flex gap-3">
+                  {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
+                    <div class="everblock-google-reviews__avatar flex-shrink-0">
+                      <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                    </div>
+                  {elseif $googleReviewsOptions.show_avatar}
+                    <div class="everblock-google-reviews__avatar is-placeholder flex-shrink-0" aria-hidden="true">
+                      <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
+                    </div>
                   {/if}
+                  <div class="everblock-google-reviews__body flex-grow-1">
+                    <header class="everblock-google-reviews__header d-flex flex-column gap-1 mb-2">
+                      {if $review.author_name}
+                        <p class="everblock-google-reviews__author mb-0">
+                          {if $review.author_url}
+                            <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
+                          {else}
+                            {$review.author_name|escape:'htmlall':'UTF-8'}
+                          {/if}
+                        </p>
+                      {/if}
+                      <div class="d-flex align-items-center gap-2 flex-wrap">
+                        {if $review.rating}
+                          <div class="everblock-google-reviews__rating" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
+                            {section name=item loop=5}
+                              {assign var=position value=$smarty.section.item.index+1}
+                              <span class="everblock-google-reviews__star{if $review.rating >= $position} is-filled{/if}">★</span>
+                            {/section}
+                          </div>
+                        {/if}
+                        {if $review.relative_time_description}
+                          <p class="everblock-google-reviews__time mb-0">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
+                        {/if}
+                      </div>
+                    </header>
+                    {if $review.text}
+                      <p class="everblock-google-reviews__text mb-0">{$review.text|escape:'htmlall':'UTF-8'}</p>
+                    {/if}
+                  </div>
                 </div>
               </article>
             </div>
           {/foreach}
         </div>
       {elseif $googleReviewsOptions.is_configured}
-        <p class="everblock-google-reviews__empty">{l s='No Google reviews available yet.' mod='everblock'}</p>
+        <p class="everblock-google-reviews__empty text-muted mb-0">{l s='No Google reviews available yet.' mod='everblock'}</p>
       {/if}
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Modernize the visual rendering and HTML structure of the existing Google Reviews Prettyblocks block to a cleaner, more e-commerce friendly layout while keeping all data, schema and logic unchanged.

### Description
- Reworked the Smarty template `views/templates/hook/_partials/google_reviews.tpl` to use Bootstrap 5 layout and utility classes, semantic header markup, accessible CTA and responsive card grid (`row-cols-1 row-cols-md-2 row-cols-lg-{$columns}`) while preserving all Smarty variables and conditional logic.
- Converted each review into a Bootstrap `card`, improved avatar sizing and placeholder, aligned author/date/rating, and kept star rendering intact (no change in business logic or data fields).
- Updated `views/css/everblock.css` to refine spacing, card shadows/borders, avatar size, CTA sizing, rating visuals and replaced scrollable review text with a cross-browser clamp using `-webkit-line-clamp` for uniform card heights.
- Ensured there is no change to data retrieval, schema, or added dependencies and avoided inline CSS/JS and server-side HTML generation.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fc91a114832285a55f082aaf90d8)