### PR TITLE
Fix collation mismatch in PrettyBlocks hook join

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -135,7 +135,10 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->hookFilterKey = 'a!hook';
         } elseif ($this->hasColumn('zone_name')) {
             $this->appendSelect('COALESCE(h.name, a.zone_name) AS hook_name');
-            $this->appendJoin('LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` = a.`zone_name`)');
+            $this->appendJoin(
+                'LEFT JOIN `' . _DB_PREFIX_ . 'hook` h ON (h.`name` COLLATE utf8mb4_unicode_ci ='
+                . ' a.`zone_name` COLLATE utf8mb4_unicode_ci)'
+            );
             $this->hookField = 'hook_name';
             $this->hookFilterKey = 'a!zone_name';
         }


### PR DESCRIPTION
### Motivation
- Prevent SQL errors caused by mixed collations when joining the `hook.name` column with the `prettyblocks.zone_name` column in the admin PrettyBlocks list by making the join use a consistent `utf8mb4_unicode_ci` collation.

### Description
- Update `controllers/admin/AdminEverBlockPrettyblockController.php` to use an explicit `COLLATE utf8mb4_unicode_ci` on both sides of the `LEFT JOIN` between `h.name` and `a.zone_name` so the comparison is performed with the same collation.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968fd45af4c8322a7afedc701b5c369)