### PR TITLE
Enable Bootstrap carousel for Google reviews

### DIFF
--- a/views/templates/hook/_partials/google_reviews.tpl
+++ b/views/templates/hook/_partials/google_reviews.tpl
@@ -64,57 +64,220 @@
     </aside>
     <div class="everblock-google-reviews__content col-12 col-lg-8 col-xl-9">
       {if $reviews}
-        <div class="everblock-google-reviews__list row g-4">
-          {foreach from=$reviews item=review}
-            <div class="col-12 col-md-6 col-lg-4">
-              <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
-                <div class="card-body d-flex flex-column gap-3">
-                  <header class="everblock-google-reviews__header d-flex gap-3">
-                    {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
-                      <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
-                        <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
-                      </div>
-                    {elseif $googleReviewsOptions.show_avatar}
-                      <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
-                        <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
-                      </div>
-                    {/if}
-                    <div class="everblock-google-reviews__body flex-grow-1">
-                      {if $review.author_name}
-                        <p class="mb-1 fw-semibold">
-                          {if $review.author_url}
-                            <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
-                          {else}
-                            {$review.author_name|escape:'htmlall':'UTF-8'}
+        {assign var=reviewCount value=$reviews|count}
+        {assign var=carouselSuffix value=$googleReviewsOptions.place_id|default:$smarty.now}
+
+        <div id="everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-lg" class="carousel slide d-none d-lg-block" data-bs-interval="false" data-bs-pause="hover" aria-label="{l s='Google reviews carousel' mod='everblock'}">
+          <div class="carousel-inner">
+            {foreach from=$reviews|@array_chunk:3 item=reviewGroup name=reviewsLg}
+              <div class="carousel-item{if $smarty.foreach.reviewsLg.first} active{/if}">
+                <div class="row g-4">
+                  {foreach from=$reviewGroup item=review}
+                    <div class="col-12 col-lg-4">
+                      <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
+                        <div class="card-body d-flex flex-column gap-3">
+                          <header class="everblock-google-reviews__header d-flex gap-3">
+                            {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                              </div>
+                            {elseif $googleReviewsOptions.show_avatar}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                                <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
+                              </div>
+                            {/if}
+                            <div class="everblock-google-reviews__body flex-grow-1">
+                              {if $review.author_name}
+                                <p class="mb-1 fw-semibold">
+                                  {if $review.author_url}
+                                    <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
+                                  {else}
+                                    {$review.author_name|escape:'htmlall':'UTF-8'}
+                                  {/if}
+                                </p>
+                              {/if}
+                              {if $review.relative_time_description}
+                                <p class="mb-2 small text-muted">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
+                              {/if}
+                              {if $review.rating}
+                                <div class="everblock-google-reviews__score d-flex align-items-center gap-2" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
+                                  <span class="fw-semibold">{$review.rating|number_format:1}</span>
+                                  <span aria-hidden="true">
+                                    {section name=item loop=5}
+                                      {assign var=position value=$smarty.section.item.index+1}
+                                      <span class="{if $review.rating >= $position}text-warning{else}text-muted{/if}">★</span>
+                                    {/section}
+                                  </span>
+                                </div>
+                              {/if}
+                            </div>
+                          </header>
+                          {if $review.text}
+                            <div class="flex-grow-1">
+                              <p class="everblock-google-reviews__text mb-0">{$review.text|escape:'htmlall':'UTF-8'}</p>
+                            </div>
                           {/if}
-                        </p>
-                      {/if}
-                      {if $review.relative_time_description}
-                        <p class="mb-2 small text-muted">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
-                      {/if}
-                      {if $review.rating}
-                        <div class="everblock-google-reviews__score d-flex align-items-center gap-2" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
-                          <span class="fw-semibold">{$review.rating|number_format:1}</span>
-                          <span aria-hidden="true">
-                            {section name=item loop=5}
-                              {assign var=position value=$smarty.section.item.index+1}
-                              <span class="{if $review.rating >= $position}text-warning{else}text-muted{/if}">★</span>
-                            {/section}
-                          </span>
                         </div>
-                      {/if}
+                        <div class="card-footer bg-transparent border-0 pt-0"></div>
+                      </article>
                     </div>
-                  </header>
-                  {if $review.text}
-                    <div class="flex-grow-1">
-                      <p class="everblock-google-reviews__text mb-0">{$review.text|escape:'htmlall':'UTF-8'}</p>
-                    </div>
-                  {/if}
+                  {/foreach}
                 </div>
-                <div class="card-footer bg-transparent border-0 pt-0"></div>
-              </article>
-            </div>
-          {/foreach}
+              </div>
+            {/foreach}
+          </div>
+          {if $reviewCount > 3}
+            <button class="carousel-control-prev" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-lg" data-bs-slide="prev" aria-label="{l s='Previous reviews' mod='everblock'}">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-lg" data-bs-slide="next" aria-label="{l s='Next reviews' mod='everblock'}">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+            </button>
+          {/if}
+        </div>
+
+        <div id="everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-md" class="carousel slide d-none d-md-block d-lg-none" data-bs-interval="false" data-bs-pause="hover" aria-label="{l s='Google reviews carousel' mod='everblock'}">
+          <div class="carousel-inner">
+            {foreach from=$reviews|@array_chunk:2 item=reviewGroup name=reviewsMd}
+              <div class="carousel-item{if $smarty.foreach.reviewsMd.first} active{/if}">
+                <div class="row g-4">
+                  {foreach from=$reviewGroup item=review}
+                    <div class="col-12 col-md-6">
+                      <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
+                        <div class="card-body d-flex flex-column gap-3">
+                          <header class="everblock-google-reviews__header d-flex gap-3">
+                            {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                              </div>
+                            {elseif $googleReviewsOptions.show_avatar}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                                <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
+                              </div>
+                            {/if}
+                            <div class="everblock-google-reviews__body flex-grow-1">
+                              {if $review.author_name}
+                                <p class="mb-1 fw-semibold">
+                                  {if $review.author_url}
+                                    <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
+                                  {else}
+                                    {$review.author_name|escape:'htmlall':'UTF-8'}
+                                  {/if}
+                                </p>
+                              {/if}
+                              {if $review.relative_time_description}
+                                <p class="mb-2 small text-muted">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
+                              {/if}
+                              {if $review.rating}
+                                <div class="everblock-google-reviews__score d-flex align-items-center gap-2" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
+                                  <span class="fw-semibold">{$review.rating|number_format:1}</span>
+                                  <span aria-hidden="true">
+                                    {section name=item loop=5}
+                                      {assign var=position value=$smarty.section.item.index+1}
+                                      <span class="{if $review.rating >= $position}text-warning{else}text-muted{/if}">★</span>
+                                    {/section}
+                                  </span>
+                                </div>
+                              {/if}
+                            </div>
+                          </header>
+                          {if $review.text}
+                            <div class="flex-grow-1">
+                              <p class="everblock-google-reviews__text mb-0">{$review.text|escape:'htmlall':'UTF-8'}</p>
+                            </div>
+                          {/if}
+                        </div>
+                        <div class="card-footer bg-transparent border-0 pt-0"></div>
+                      </article>
+                    </div>
+                  {/foreach}
+                </div>
+              </div>
+            {/foreach}
+          </div>
+          {if $reviewCount > 2}
+            <button class="carousel-control-prev" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-md" data-bs-slide="prev" aria-label="{l s='Previous reviews' mod='everblock'}">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-md" data-bs-slide="next" aria-label="{l s='Next reviews' mod='everblock'}">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+            </button>
+          {/if}
+        </div>
+
+        <div id="everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-sm" class="carousel slide d-md-none" data-bs-interval="false" data-bs-pause="hover" aria-label="{l s='Google reviews carousel' mod='everblock'}">
+          <div class="carousel-inner">
+            {foreach from=$reviews|@array_chunk:1 item=reviewGroup name=reviewsSm}
+              <div class="carousel-item{if $smarty.foreach.reviewsSm.first} active{/if}">
+                <div class="row g-4">
+                  {foreach from=$reviewGroup item=review}
+                    <div class="col-12">
+                      <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
+                        <div class="card-body d-flex flex-column gap-3">
+                          <header class="everblock-google-reviews__header d-flex gap-3">
+                            {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                              </div>
+                            {elseif $googleReviewsOptions.show_avatar}
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                                <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
+                              </div>
+                            {/if}
+                            <div class="everblock-google-reviews__body flex-grow-1">
+                              {if $review.author_name}
+                                <p class="mb-1 fw-semibold">
+                                  {if $review.author_url}
+                                    <a href="{$review.author_url|escape:'htmlall':'UTF-8'}" rel="noopener nofollow" target="_blank">{$review.author_name|escape:'htmlall':'UTF-8'}</a>
+                                  {else}
+                                    {$review.author_name|escape:'htmlall':'UTF-8'}
+                                  {/if}
+                                </p>
+                              {/if}
+                              {if $review.relative_time_description}
+                                <p class="mb-2 small text-muted">{$review.relative_time_description|escape:'htmlall':'UTF-8'}</p>
+                              {/if}
+                              {if $review.rating}
+                                <div class="everblock-google-reviews__score d-flex align-items-center gap-2" aria-label="{l s='%1$s out of %2$s' sprintf=[$review.rating|number_format:1, 5] mod='everblock'}">
+                                  <span class="fw-semibold">{$review.rating|number_format:1}</span>
+                                  <span aria-hidden="true">
+                                    {section name=item loop=5}
+                                      {assign var=position value=$smarty.section.item.index+1}
+                                      <span class="{if $review.rating >= $position}text-warning{else}text-muted{/if}">★</span>
+                                    {/section}
+                                  </span>
+                                </div>
+                              {/if}
+                            </div>
+                          </header>
+                          {if $review.text}
+                            <div class="flex-grow-1">
+                              <p class="everblock-google-reviews__text mb-0">{$review.text|escape:'htmlall':'UTF-8'}</p>
+                            </div>
+                          {/if}
+                        </div>
+                        <div class="card-footer bg-transparent border-0 pt-0"></div>
+                      </article>
+                    </div>
+                  {/foreach}
+                </div>
+              </div>
+            {/foreach}
+          </div>
+          {if $reviewCount > 1}
+            <button class="carousel-control-prev" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-sm" data-bs-slide="prev" aria-label="{l s='Previous reviews' mod='everblock'}">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Previous' mod='everblock'}</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#everblock-google-reviews-carousel-{$carouselSuffix|escape:'htmlall':'UTF-8'}-sm" data-bs-slide="next" aria-label="{l s='Next reviews' mod='everblock'}">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="visually-hidden">{l s='Next' mod='everblock'}</span>
+            </button>
+          {/if}
         </div>
       {elseif $googleReviewsOptions.is_configured}
         <p class="everblock-google-reviews__empty text-muted mb-0">{l s='No Google reviews available yet.' mod='everblock'}</p>


### PR DESCRIPTION
### Motivation
- Replace the static grid of Google reviews with a responsive, accessible slider to display more reviews while keeping the existing Prettyblocks configuration as the single source of truth for the number of reviews.
- Provide a desktop/tablet/mobile experience with 3/2/1 reviews per slide respectively, implemented server-side in Smarty to avoid JS-based slicing.
- Ensure the left summary column remains static and the visual card layout and business logic are preserved.

### Description
- Converted the reviews list into three Bootstrap 5 `carousel` blocks (desktop `d-none d-lg-block`, tablet `d-none d-md-block d-lg-none`, mobile `d-md-none`) to render 3/2/1 cards per slide using Smarty chunking via `array_chunk` so the configured review count is preserved exactly.
- Added per-carousel unique IDs using `{$googleReviewsOptions.place_id|default:$smarty.now}` as `carouselSuffix`, `data-bs-interval="false"` and `data-bs-pause="hover"`, and accessible controls with `aria-label` and visually-hidden labels; controls are rendered conditionally based on `reviewCount`.
- Kept the original card markup and classes (including `card h-100`) so card heights, layout, and left column remain unchanged and compatible with Prettyblocks.
- No schema or data changes were made and no additional JS libraries were introduced; only Bootstrap 5 data-attributes and classes are used.

### Testing
- Template modified: `views/templates/hook/_partials/google_reviews.tpl` was updated to implement the carousels and chunking logic.
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690110d980832288870d4f5487cea4)