### PR TITLE
Fix Google reviews avatars and add secondary “Laisser un avis” CTA

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3164,6 +3164,12 @@
   flex: 0 0 56px;
 }
 
+.everblock-google-reviews__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .everblock-google-reviews__text {
   display: -webkit-box;
   -webkit-line-clamp: 4;

--- a/views/templates/hook/_partials/google_reviews.tpl
+++ b/views/templates/hook/_partials/google_reviews.tpl
@@ -55,9 +55,12 @@
         <span class="text-danger">e</span>
       </div>
       {if $googleReviewsOptions.show_cta && $googleReviewsOptions.cta_url}
-        <div class="everblock-google-reviews__cta">
+        <div class="everblock-google-reviews__cta d-flex flex-column align-items-start gap-2">
           <a class="btn btn-primary btn-lg" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow" aria-label="{l s='Read all reviews on Google' mod='everblock'}">
             {if $googleReviewsOptions.cta_label}{$googleReviewsOptions.cta_label|escape:'htmlall':'UTF-8'}{else}{l s='Read all reviews on Google' mod='everblock'}{/if}
+          </a>
+          <a class="btn btn-outline-secondary btn-sm" href="{$googleReviewsOptions.cta_url|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener nofollow" aria-label="{l s='Laisser un avis sur Google' mod='everblock'}">
+            {l s='Laisser un avis' mod='everblock'}
           </a>
         </div>
       {/if}
@@ -76,13 +79,13 @@
                     <div class="col-12 col-lg-4">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
-                          <header class="everblock-google-reviews__header d-flex gap-3">
+                          <header class="everblock-google-reviews__header d-flex align-items-center gap-3">
                             {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
                               <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
-                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid w-100 h-100 object-fit-cover" width="56" height="56">
                               </div>
                             {elseif $googleReviewsOptions.show_avatar}
-                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold text-uppercase" aria-hidden="true">
                                 <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
                               </div>
                             {/if}
@@ -147,13 +150,13 @@
                     <div class="col-12 col-md-6">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
-                          <header class="everblock-google-reviews__header d-flex gap-3">
+                          <header class="everblock-google-reviews__header d-flex align-items-center gap-3">
                             {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
                               <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
-                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid w-100 h-100 object-fit-cover" width="56" height="56">
                               </div>
                             {elseif $googleReviewsOptions.show_avatar}
-                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold text-uppercase" aria-hidden="true">
                                 <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
                               </div>
                             {/if}
@@ -218,13 +221,13 @@
                     <div class="col-12">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
-                          <header class="everblock-google-reviews__header d-flex gap-3">
+                          <header class="everblock-google-reviews__header d-flex align-items-center gap-3">
                             {if $googleReviewsOptions.show_avatar && $review.profile_photo_url}
                               <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-light">
-                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid rounded-circle" width="56" height="56">
+                                <img src="{$review.profile_photo_url|escape:'htmlall':'UTF-8'}" alt="{$review.author_name|escape:'htmlall':'UTF-8'}" loading="lazy" class="img-fluid w-100 h-100 object-fit-cover" width="56" height="56">
                               </div>
                             {elseif $googleReviewsOptions.show_avatar}
-                              <div class="everblock-google-reviews__avatar flex-shrink-0 rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold" aria-hidden="true">
+                              <div class="everblock-google-reviews__avatar flex-shrink-0 overflow-hidden rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center fw-semibold text-uppercase" aria-hidden="true">
                                 <span>{$review.author_name|default:'?'|truncate:1:""|escape:'htmlall':'UTF-8'}</span>
                               </div>
                             {/if}


### PR DESCRIPTION
### Motivation
- Improve avatar reliability and visual consistency so every review shows a circular, fixed-size avatar (image or initial) without layout regressions.
- Ensure reviewer header (avatar + name + date) stays on a single line and is vertically aligned.
- Add a clear, secondary CTA to let visitors leave a Google review from the block without changing schema or data.

### Description
- Update `views/templates/hook/_partials/google_reviews.tpl` to add a secondary CTA under the primary button inside the left aside using `btn btn-outline-secondary btn-sm` that opens the existing `cta_url` in a new tab and is visually secondary to the main CTA.
- Adjust review header markup to use `d-flex align-items-center gap-3` so avatar, name and date remain on one line across breakpoints.
- Ensure avatar containers include `overflow-hidden rounded-circle` and for image avatars replace `rounded-circle` on the `img` with `w-100 h-100 object-fit-cover` so photos fill the fixed 56px container without distortion or stretching, and add `text-uppercase` to fallback initials containers for consistent style.
- Add CSS rules in `views/css/everblock.css` for `.everblock-google-reviews__avatar img` to enforce `width:100%`, `height:100%` and `object-fit: cover` while keeping the fixed avatar size via the existing `.everblock-google-reviews__avatar` rule.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969117c47108322bf7c57243a48e0e0)