### PR TITLE
Normalize prettyblock iframe URLs

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl
@@ -30,7 +30,11 @@
     {/if}
       <div class="everblock {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
         {if isset($block.settings.iframe_src) && $block.settings.iframe_src}
-          <iframe class="everblock-prettyblock-iframe" src="{$block.settings.iframe_src|escape:'htmlall':'UTF-8'}"
+          {assign var='iframe_src' value=$block.settings.iframe_src|trim}
+          {if $iframe_src && ($iframe_src|regex_replace:"/^(https?:)?\\/\\//":'' == $iframe_src)}
+            {assign var='iframe_src' value="https://`$iframe_src`"}
+          {/if}
+          <iframe class="everblock-prettyblock-iframe" src="{$iframe_src|escape:'htmlall':'UTF-8'}"
                   width="{if isset($block.settings.iframe_width) && $block.settings.iframe_width}{$block.settings.iframe_width|escape:'htmlall':'UTF-8'}{else}100%{/if}"
                   height="{if isset($block.settings.iframe_height) && $block.settings.iframe_height}{$block.settings.iframe_height|escape:'htmlall':'UTF-8'}{else}400{/if}"
                   style="border:0;"

--- a/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_iframe.tpl
@@ -28,16 +28,20 @@
     <div class="everblock"  style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
       {foreach from=$block.states item=state key=key}
           {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+          {assign var='iframe_link' value=$state.iframe_link|trim}
+          {if $iframe_link && ($iframe_link|regex_replace:"/^(https?:)?\\/\\//":'' == $iframe_link)}
+            {assign var='iframe_link' value="https://`$iframe_link`"}
+          {/if}
 
           <div id="block-{$block.id_prettyblocks}-{$key}" class="everblock {$state.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_state_spacing_style}{if isset($state.default.bg_color) && $state.default.bg_color}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
             {if $state.iframe_source == 'youtube'}
-            <iframe class="everblock-prettyblock-iframe" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}315{/if}" src="{$state.iframe_link}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen scrolling="no"></iframe>
+            <iframe class="everblock-prettyblock-iframe" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}315{/if}" src="{$iframe_link|escape:'htmlall':'UTF-8'}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'vimeo'}
             <iframe class="everblock-prettyblock-iframe" src="https://player.vimeo.com/video/' . $matches[1] . '?color=ffffff&title=0&byline=0&portrait=0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'dailymotion'}
-            <iframe class="everblock-prettyblock-iframe" frameborder="0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}270{/if}" src="{$state.iframe_link}" allowfullscreen scrolling="no"></iframe>
+            <iframe class="everblock-prettyblock-iframe" frameborder="0" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}270{/if}" src="{$iframe_link|escape:'htmlall':'UTF-8'}" allowfullscreen scrolling="no"></iframe>
             {elseif $state.iframe_source == 'vidyard'}
-            <iframe class="everblock-prettyblock-iframe" src="{$state.iframe_link}" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen scrolling="no"></iframe>
+            <iframe class="everblock-prettyblock-iframe" src="{$iframe_link|escape:'htmlall':'UTF-8'}" width="{if isset($state.width) && $state.width}{$state.width}{else}100{/if}" height="{if isset($state.height) && $state.height}{$state.height}{else}360{/if}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen scrolling="no"></iframe>
             {/if}
           </div>
       {/foreach}


### PR DESCRIPTION
### Motivation
- Prevent iframe URLs entered without a scheme from being interpreted as relative paths and prefixed by the site domain, which caused incorrect iframe `src` values.

### Description
- Trim and normalize iframe URL inputs in `views/templates/hook/prettyblocks/prettyblock_iframe.tpl` by detecting a missing scheme and prefixing `https://` when absent, and use the normalized value for the iframe `src`.
- Apply the same normalization in `views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl` and ensure the normalized URL is escaped when rendered.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696917875f58832291280ab56fe8d387)