### PR TITLE
Enhance Simple Image layout controls and overrides

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1434,6 +1434,58 @@ class EverblockPrettyBlocks
                 ],
                 'config' => [
                     'fields' => static::appendSpacingFields([
+                        'display_mode' => [
+                            'type' => 'select',
+                            'label' => $module->l('Display mode'),
+                            'default' => 'grid',
+                            'choices' => [
+                                'grid' => $module->l('Grid'),
+                                'slider' => $module->l('Slider'),
+                                'columns' => $module->l('Columns'),
+                            ],
+                        ],
+                        'columns_desktop' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns (desktop)'),
+                            'default' => 1,
+                            'choices' => [
+                                1 => '1',
+                                2 => '2',
+                                3 => '3',
+                                4 => '4',
+                                6 => '6',
+                            ],
+                        ],
+                        'columns_tablet' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns (tablet)'),
+                            'default' => 1,
+                            'choices' => [
+                                1 => '1',
+                                2 => '2',
+                                3 => '3',
+                            ],
+                        ],
+                        'columns_mobile' => [
+                            'type' => 'select',
+                            'label' => $module->l('Columns (mobile)'),
+                            'default' => 1,
+                            'choices' => [
+                                1 => '1',
+                                2 => '2',
+                            ],
+                        ],
+                        'gap' => [
+                            'type' => 'select',
+                            'label' => $module->l('Gap'),
+                            'default' => 'medium',
+                            'choices' => [
+                                'none' => $module->l('None'),
+                                'small' => $module->l('Small'),
+                                'medium' => $module->l('Medium'),
+                                'large' => $module->l('Large'),
+                            ],
+                        ],
                         'slider' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Enable slider'),

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -25,6 +25,46 @@
   {/if}
 {assign var=everblockNow value=$smarty.now}
 {assign var=visibleStatesCount value=0}
+{assign var=displayMode value=$block.settings.display_mode|default:''}
+{if $displayMode == '' && isset($block.settings.slider) && $block.settings.slider}
+  {assign var=displayMode value='slider'}
+{elseif $displayMode == ''}
+  {assign var=displayMode value='grid'}
+{/if}
+{assign var=columnsDesktop value=$block.settings.columns_desktop|default:1}
+{assign var=columnsTablet value=$block.settings.columns_tablet|default:1}
+{assign var=columnsMobile value=$block.settings.columns_mobile|default:1}
+{assign var=colDesktopClass value='col-lg-12'}
+{if $columnsDesktop == 2}
+  {assign var=colDesktopClass value='col-lg-6'}
+{elseif $columnsDesktop == 3}
+  {assign var=colDesktopClass value='col-lg-4'}
+{elseif $columnsDesktop == 4}
+  {assign var=colDesktopClass value='col-lg-3'}
+{elseif $columnsDesktop == 6}
+  {assign var=colDesktopClass value='col-lg-2'}
+{/if}
+{assign var=colTabletClass value='col-md-12'}
+{if $columnsTablet == 2}
+  {assign var=colTabletClass value='col-md-6'}
+{elseif $columnsTablet == 3}
+  {assign var=colTabletClass value='col-md-4'}
+{/if}
+{assign var=colMobileClass value='col-12'}
+{if $columnsMobile == 2}
+  {assign var=colMobileClass value='col-6'}
+{/if}
+{assign var=gapSetting value=$block.settings.gap|default:'medium'}
+{assign var=gapClass value='g-3'}
+{if $gapSetting == 'none'}
+  {assign var=gapClass value='g-0'}
+{elseif $gapSetting == 'small'}
+  {assign var=gapClass value='g-2'}
+{elseif $gapSetting == 'large'}
+  {assign var=gapClass value='g-4'}
+{/if}
+{assign var=baseItemClass value='position-relative overflow-hidden'}
+{assign var=layoutItemClass value="{$baseItemClass} {$colMobileClass} {$colTabletClass} {$colDesktopClass}"}
 {if isset($block.states) && $block.states}
   {foreach from=$block.states item=state}
     {assign var=isStateVisible value=true}
@@ -48,15 +88,15 @@
       {assign var=visibleStatesCount value=$visibleStatesCount+1}
     {/if}
   {/foreach}
-  {assign var='use_slider' value=(isset($block.settings.slider) && $block.settings.slider && $visibleStatesCount > 1)}
+  {assign var='use_slider' value=($displayMode == 'slider' && $visibleStatesCount > 1)}
   {if $use_slider}
     <div class="mt-4 ever-cover-carousel ever-bootstrap-carousel"
          data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}"
-         data-items-mobile="1"
+         data-items-mobile="{$block.settings.columns_mobile|default:1|escape:'htmlall':'UTF-8'}"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
          data-infinite="1"
          data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}"
-         data-row-class="row g-3 justify-content-center"
+         data-row-class="row {$gapClass} justify-content-center"
          data-controls="true"
          data-indicators="true">
       {foreach from=$block.states item=state key=key}
@@ -78,8 +118,12 @@
           {/if}
         {/if}
         {if $isStateVisible}
+          {assign var=itemClass value=$layoutItemClass}
+          {if $state.css_class}
+            {assign var=itemClass value="{$baseItemClass} {$state.css_class}"}
+          {/if}
           {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
-          <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden col{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
+          <div id="block-{$block.id_prettyblocks}-{$key}" class="{$itemClass|escape:'htmlall'}" style="
             {$prettyblock_state_spacing_style}
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">
@@ -130,7 +174,7 @@
       {/foreach}
     </div>
   {else}
-    <div class="row mt-4 g-3 justify-content-center">
+    <div class="row mt-4 {$gapClass} justify-content-center">
       {foreach from=$block.states item=state key=key}
         {assign var=isStateVisible value=true}
         {assign var=startDateStr value=$state.start_date|default:''}
@@ -150,8 +194,12 @@
           {/if}
         {/if}
         {if $isStateVisible}
+          {assign var=itemClass value=$layoutItemClass}
+          {if $state.css_class}
+            {assign var=itemClass value="{$baseItemClass} {$state.css_class}"}
+          {/if}
           {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
-          <div id="block-{$block.id_prettyblocks}-{$key}" class="position-relative overflow-hidden col-12{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" style="
+          <div id="block-{$block.id_prettyblocks}-{$key}" class="{$itemClass|escape:'htmlall'}" style="
             {$prettyblock_state_spacing_style}
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">


### PR DESCRIPTION
### Motivation

- Provide parent-level layout controls for the Simple Image prettyblock so non-dev users can choose grid/slider/columns without manually adding classes per item.
- Preserve existing `html_class`/`css_class` per-item overrides so developers keep full control when needed.
- Compute layout classes once at parent level and apply them to items unless an item explicitly provides a class, avoiding duplicated logic in the repeater.
- Keep backward compatibility with existing slider behavior and avoid forcing manual classes.

### Description

- Added new parent configuration fields in `EverblockPrettyBlocks` for the Simple Image block: `display_mode`, `columns_desktop`, `columns_tablet`, `columns_mobile`, and `gap` to drive default layout behavior from the block settings.
- Updated `views/templates/hook/prettyblocks/prettyblock_img.tpl` to calculate Bootstrap column classes and gap classes once using the parent settings and to set a `layoutItemClass` that is applied to each item by default.
- Implemented the override rule where an item with `css_class` keeps only that manual class while items without `css_class` get the computed parent classes, and ensured the slider mode uses the parent `display_mode` and responsive columns for `data-items-mobile`.
- Kept existing slider options and behavior intact while replacing hard-coded per-item `col-*` usage with the centralized layout computation.

### Testing

- No automated tests were executed for this change.
- Manual inspection: template changes are static and preserve previous conditional visibility and slider logic (no runtime test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691885a9b08322b423712e68e07f44)