### PR TITLE
Avoid array-to-string and null replacement warnings in PrettyBlocks and shortcodes

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -165,7 +165,11 @@ class EverblockPrettyBlocks
             $config = json_decode((string) ($row['config'] ?? ''), true);
             $label = '';
             if (is_array($config)) {
-                $label = (string) ($config[$labelField] ?? '');
+                $labelValue = $config[$labelField] ?? '';
+                if (is_array($labelValue)) {
+                    $labelValue = reset($labelValue) ?: '';
+                }
+                $label = is_scalar($labelValue) ? (string) $labelValue : '';
             }
             if ($label === '') {
                 $label = $module->l('Item') . ' #' . $id;

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -3553,7 +3553,8 @@ class EverblockTools extends ObjectModel
             if (is_array($value)) {
                 $txt = static::renderSmartyVarsInArray($txt, $elementSearch, $value);
             } else {
-                $txt = str_replace($elementSearch, $value, $txt);
+                $replacement = is_scalar($value) ? (string) $value : '';
+                $txt = str_replace($elementSearch, $replacement, $txt);
             }
         }
         return $txt;
@@ -4502,7 +4503,8 @@ class EverblockTools extends ObjectModel
             '[entity_gender]' => $gender->name,
         ];
         foreach ($entityShortcodes as $key => $value) {
-            $txt = str_replace($key, $value, $txt);
+            $replacement = $value ?? '';
+            $txt = str_replace($key, (string) $replacement, $txt);
         }
         return $txt;
     }
@@ -4515,7 +4517,8 @@ class EverblockTools extends ObjectModel
         );
         $returnedShortcodes = [];
         foreach ($customShortcodes as $sc) {
-            $txt = str_replace($sc->shortcode, $sc->content, $txt);
+            $content = $sc->content ?? '';
+            $txt = str_replace($sc->shortcode, (string) $content, $txt);
         }
         return $txt;
     }


### PR DESCRIPTION
### Motivation
- Prevent PHP warnings like "Array to string conversion" when PrettyBlocks labels are arrays and avoid deprecation notices when `null` is passed to `str_replace` during shortcode/template rendering.

### Description
- In `src/Service/EverblockPrettyBlocks.php` guard label extraction by normalizing the `$config[$labelField]` value: if it's an array use the first element, and only cast scalar values to string before using as a label.
- In `src/Service/EverblockTools.php` ensure replacements never pass non-scalar or `null` directly to `str_replace` by coercing values to safe strings in `renderSmartyVarsInArray`, `getCustomerShortcodes`, and `getEverShortcodes`.
- These changes avoid array-to-string casts and deprecated `null` replacements while preserving existing fallback behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691d1f7c3883229fe06ca8a40c8e5d)