### PR TITLE
Add background image support to Everblock repeater

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -692,6 +692,14 @@ class EverblockPrettyBlocks
                             'default' => '',
                             'label' => $module->l('Block background color'),
                         ],
+                        'background_image' => [
+                            'tab' => 'design',
+                            'type' => 'fileupload',
+                            'label' => $module->l('Block background image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'text_color' => [
                             'tab' => 'design',
                             'type' => 'color',

--- a/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
@@ -27,6 +27,7 @@
     {foreach from=$block.states item=state key=key}
     {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
     <div id="block-{$block.id_prettyblocks}-{$key}" class="{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" style="{$prettyblock_state_spacing_style}
+        {if isset($state.background_image.url) && $state.background_image.url}background-image:url('{$state.background_image.url|escape:'htmlall':'UTF-8'}');background-size:cover;background-position:center;background-repeat:no-repeat;{/if}
         {if isset($state.background_color) && $state.background_color}background-color:{$state.background_color};{/if}
         {if isset($state.text_color) && $state.text_color}color:{$state.text_color};{/if}
       ">


### PR DESCRIPTION
### Motivation
- Allow editors to upload a background image per item in the PrettyBlocks repeater for Everblock so repeaters can use an image background in addition to color.

### Description
- Add a `background_image` repeater field (`type: 'fileupload'`) to the Everblock PrettyBlocks block configuration in `src/Service/EverblockPrettyBlocks.php`.
- Render the uploaded image in the repeater template by injecting `background-image:url(...)` with `background-size: cover; background-position: center; background-repeat: no-repeat;` in `views/templates/hook/prettyblocks/prettyblock_everblock.tpl`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f8cb54c483228a3390b0b653063d)