### PR TITLE
Rename mega menu hook to beforeRenderingMegaMenuItem

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -645,9 +645,9 @@ class Everblock extends Module
                 $hook->description = 'This hook triggers before special event block is rendered';
                 $hook->save();
             }
-            if (!Hook::getIdByName('beforeRenderingEverblockMegamenuItem')) {
+            if (!Hook::getIdByName('beforeRenderingMegaMenuItem')) {
                 $hook = new Hook();
-                $hook->name = 'beforeRenderingEverblockMegamenuItem';
+                $hook->name = 'beforeRenderingMegaMenuItem';
                 $hook->title = 'Before rendering mega menu item block';
                 $hook->description = 'This hook triggers before mega menu item block is rendered';
                 $hook->save();
@@ -660,7 +660,7 @@ class Everblock extends Module
             $this->registerHook('beforeRenderingEverblockCategoryProducts');
             $this->registerHook('beforeRenderingEverblockSpecialEvent');
             $this->registerHook('beforeRenderingEverblockEverblock');
-            $this->registerHook('beforeRenderingEverblockMegamenuItem');
+            $this->registerHook('beforeRenderingMegaMenuItem');
         } else {
             $this->unregisterHook('beforeRenderingEverblockProductHighlight');
             $this->unregisterHook('beforeRenderingEverblockCategoryTabs');
@@ -670,7 +670,7 @@ class Everblock extends Module
             $this->unregisterHook('beforeRenderingEverblockCategoryProducts');
             $this->unregisterHook('beforeRenderingEverblockSpecialEvent');
             $this->unregisterHook('beforeRenderingEverblockEverblock');
-            $this->unregisterHook('beforeRenderingEverblockMegamenuItem');
+            $this->unregisterHook('beforeRenderingMegaMenuItem');
         }
         // Vérifier si l'onglet "AdminEverBlockParent" existe déjà
         $id_tab = Tab::getIdFromClassName('AdminEverBlockParent');
@@ -5874,7 +5874,7 @@ class Everblock extends Module
         return ['products' => $products];
     }
 
-    public function hookBeforeRenderingEverblockMegamenuItem($params)
+    public function hookBeforeRenderingMegaMenuItem($params)
     {
         $menuId = (int) ($params['block']['id_prettyblocks'] ?? 0);
         if ($menuId <= 0) {

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -53,7 +53,7 @@ class EverblockPrettyBlocks
         'beforeRenderingEverblockGuidedSelector',
         'beforeRenderingEverblockLookbook',
         'beforeRenderingEverblockCategoryProducts',
-        'beforeRenderingEverblockMegamenuItem',
+        'beforeRenderingMegaMenuItem',
     ];
 
     public function registerBlockToZone($zone_name, $code, $id_lang, $id_shop)


### PR DESCRIPTION
### Motivation
- Align the mega menu hook name with the expected hook signature by removing the module prefix so menu hooks use `beforeRenderingMegaMenuItem` / `hookBeforeRenderingMegaMenuItem`.

### Description
- Replace occurrences of `beforeRenderingEverblockMegamenuItem` with `beforeRenderingMegaMenuItem` in `everblock.php` and update the handler to `hookBeforeRenderingMegaMenuItem`, and update the `BEFORE_RENDERING_HOOKS` list in `src/Service/EverblockPrettyBlocks.php` to include `beforeRenderingMegaMenuItem`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0d7e30c88322a028f4e1b3798fba)