### PR TITLE
Add class hooks for prettyblock cover wrappers

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_cover.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_cover.tpl
@@ -25,7 +25,7 @@
 {/capture}
 {assign var='prettyblock_cover_wrapper_style' value=$smarty.capture.prettyblock_cover_wrapper_style|trim}
 
-<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_cover_wrapper_style} style="{$prettyblock_cover_wrapper_style}"{/if}>
+<div id="block-{$block.id_prettyblocks}" class="prettyblock-cover-block prettyblock-cover-block-{$block.id_prettyblocks} {if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_cover_wrapper_style} style="{$prettyblock_cover_wrapper_style}"{/if}>
   {if $block.settings.default.force_full_width}
     <div class="row gx-0 no-gutters">
       <div class="col-12 px-0">


### PR DESCRIPTION
### Motivation
- Cover wrapper elements currently depend on dynamic IDs which makes CSS and JS targeting brittle if the block ID changes.

### Description
- Add `prettyblock-cover-block` and `prettyblock-cover-block-{$block.id_prettyblocks}` classes to the wrapper `<div>` in `views/templates/hook/prettyblocks/prettyblock_cover.tpl` so cover blocks can be targeted by stable selectors.

### Testing
- No automated tests were run because this is a template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a113a3cdc8322a122e429183374d2)