### PR TITLE
Fix megamenu parent label choices (use saved state)

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -149,7 +149,7 @@ class EverblockPrettyBlocks
             '' => $module->l('Select an item'),
         ];
 
-        $query = 'SELECT id_prettyblocks, config'
+        $query = 'SELECT id_prettyblocks, state'
             . ' FROM ' . _DB_PREFIX_ . 'prettyblocks'
             . ' WHERE code = "' . pSQL($code) . '"'
             . ' AND id_lang = ' . (int) $context->language->id
@@ -162,14 +162,10 @@ class EverblockPrettyBlocks
 
         foreach ($rows as $row) {
             $id = (int) ($row['id_prettyblocks'] ?? 0);
-            $config = json_decode((string) ($row['config'] ?? ''), true);
+            $state = json_decode((string) ($row['state'] ?? ''), true);
             $label = '';
-            if (is_array($config)) {
-                $labelValue = $config[$labelField] ?? '';
-                if (is_array($labelValue)) {
-                    $labelValue = reset($labelValue) ?: '';
-                }
-                $label = is_scalar($labelValue) ? (string) $labelValue : '';
+            if (is_array($state)) {
+                $label = self::resolvePrettyblockLabel($state, $labelField);
             }
             if ($label === '') {
                 $label = $module->l('Item') . ' #' . $id;
@@ -178,6 +174,23 @@ class EverblockPrettyBlocks
         }
 
         return $choices;
+    }
+
+    private static function resolvePrettyblockLabel(array $data, string $labelField): string
+    {
+        $labelValue = '';
+
+        if (array_key_exists($labelField, $data)) {
+            $labelValue = $data[$labelField];
+        } elseif (isset($data['default']) && is_array($data['default']) && array_key_exists($labelField, $data['default'])) {
+            $labelValue = $data['default'][$labelField];
+        }
+
+        if (is_array($labelValue)) {
+            $labelValue = $labelValue['text'] ?? (reset($labelValue) ?: '');
+        }
+
+        return is_scalar($labelValue) ? (string) $labelValue : '';
     }
 
     public static function getEverPrettyBlocks($context)


### PR DESCRIPTION
### Motivation
- Choice lists for megamenu parents/columns were showing schema field values (like the field type) instead of the user-entered label because labels were read from the block `config` schema rather than the saved `state`.
- The intent is to display the actual label entered by the merchant for megamenu items and columns in select lists.

### Description
- Read `state` instead of `config` from the `prettyblocks` table when building choice lists in `getPrettyblocksChoicesByCode` in `src/Service/EverblockPrettyBlocks.php`.
- Added `resolvePrettyblockLabel(array $data, string $labelField)` helper that extracts a label from common saved state shapes (direct field, `default` sub-array, and nested array shapes like `['text' => '...']`).
- Updated choice formatting to fall back to a generic "Item #id" label when no label is found.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a11031eb08322adbcced0d1f04ef0)