### PR TITLE
Add per-tab background image support for Tabs block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -890,6 +890,14 @@ class EverblockPrettyBlocks
                             'label' => 'Tab content',
                             'default' => '[llorem]',
                         ],
+                        'background_image' => [
+                            'tab' => 'design',
+                            'type' => 'fileupload',
+                            'label' => $module->l('Tab background image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'css_class' => [
                             'type' => 'text',
                             'label' => $module->l('Custom CSS class'),

--- a/views/templates/hook/prettyblocks/prettyblock_tab.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_tab.tpl
@@ -42,7 +42,7 @@
             </ul>
             <div class="tab-content">
                 {foreach from=$block.states item=state key=key}
-                    <div class="tab-pane {if $key == 0}active{/if}" id="tab-{$block.id_prettyblocks}-{$key}" role="tabpanel" aria-labelledby="tab-{$block.id_prettyblocks}-{$key}-tab">
+                    <div class="tab-pane {if $key == 0}active{/if}{if $state.css_class} {$state.css_class|escape:'htmlall'}{/if}" id="tab-{$block.id_prettyblocks}-{$key}" role="tabpanel" aria-labelledby="tab-{$block.id_prettyblocks}-{$key}-tab"{if isset($state.background_image.url) && $state.background_image.url} style="background-image:url('{$state.background_image.url|escape:'htmlall'}');background-size:cover;background-position:center;background-repeat:no-repeat;"{/if}>
                         {$state.content nofilter}
                     </div>
                 {/foreach}


### PR DESCRIPTION
### Motivation
- Allow editors to set a background image for each Tab state so tabs can have independent visual backgrounds and better design control.

### Description
- Added a `background_image` repeater field of type `fileupload` to the Tabs block configuration in `src/Service/EverblockPrettyBlocks.php`.
- Updated the Tabs template `views/templates/hook/prettyblocks/prettyblock_tab.tpl` to render per-tab background images via an inline `background-image` style with `background-size:cover`, `background-position:center`, and `background-repeat:no-repeat` when present.
- Applied any per-tab `css_class` into the tab pane element so custom styling can target individual tabs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1da584988322b8653358c8b92998)