### PR TITLE
Add background image option to default block

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1081,6 +1081,14 @@ class EverblockPrettyBlocks
                             'default' => '',
                             'label' => $module->l('Block background color')
                         ],
+                        'background_image' => [
+                            'tab' => 'design',
+                            'type' => 'fileupload',
+                            'label' => $module->l('Block background image'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'text_color' => [
                             'tab' => 'design',
                             'type' => 'color',


### PR DESCRIPTION
### Motivation
- Allow configuring an image background for the generic block state in addition to the existing background color and text color settings so blocks can use uploaded background images.

### Description
- Add a `background_image` field (type `fileupload`, `tab: design`, default `url: ''`) to the repeater `groups` in `src/Service/EverblockPrettyBlocks.php` so the generic block exposes an image upload.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2aa0cf4c8322b0aa7c714b431da5)