### PR TITLE
Guard megamenu item rendering when items missing

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -26,7 +26,7 @@
     </button>
     <div class="collapse navbar-collapse" id="{$collapse_id}">
       <ul class="navbar-nav w-100">
-        {if $block.extra.items}
+        {if isset($block.extra.items) && $block.extra.items}
           {foreach from=$block.extra.items item=item}
             {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl' block=$item from_parent=true}
           {/foreach}


### PR DESCRIPTION
### Motivation
- Prevent PHP/Smarty notices like "Undefined array key 'items'" when `$block.extra.items` is absent by guarding the template iteration.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl` to check `isset($block.extra.items) && $block.extra.items` before iterating with `{foreach}`, falling back to a safe `Menu` link when no items are present.

### Testing
- No automated tests were run for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3b54a3c88322885387e6ffaf063f)