### PR TITLE
Fix Prettyblocks megamenu labels rendering as arrays

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -25,17 +25,21 @@
   {/if}
   <div class="col col-12 col-lg-{$column_width|escape:'htmlall':'UTF-8'}">
     {if $render_title}
+      {assign var='column_title' value=$block.settings.title}
+      {if is_array($column_title)}
+        {assign var='column_title' value=$column_title[$language.id_lang]|default:$column_title|@reset}
+      {/if}
       {if $block.extra.titles}
         {foreach from=$block.extra.titles item=title}
           {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl' block=$title from_parent=true}
         {/foreach}
-      {elseif $block.settings.title}
+      {elseif $column_title}
         {if $block.settings.title_url}
           <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$block.settings.title_url|escape:'htmlall':'UTF-8'}">
-            {$block.settings.title|escape:'htmlall':'UTF-8'}
+            {$column_title|escape:'htmlall':'UTF-8'}
           </a>
         {else}
-          <span class="dropdown-header h6">{$block.settings.title|escape:'htmlall':'UTF-8'}</span>
+          <span class="dropdown-header h6">{$column_title|escape:'htmlall':'UTF-8'}</span>
         {/if}
       {/if}
     {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -19,8 +19,13 @@
 
 
   {assign var='collapse_id' value="everblock-megamenu-collapse-`$block.id_prettyblocks`"}
-  {assign var='fallback_label' value=$block.settings.fallback_label|default:$block.settings.menu_label|default:'Menu'}
-  <nav class="navbar navbar-expand-lg navbar-light everblock-megamenu{$prettyblock_visibility_class}" aria-label="{$block.settings.menu_label|default:'Menu'|escape:'htmlall':'UTF-8'}">
+  {assign var='menu_label' value=$block.settings.menu_label}
+  {if is_array($menu_label)}
+    {assign var='menu_label' value=$menu_label[$language.id_lang]|default:$menu_label|@reset}
+  {/if}
+  {assign var='menu_label' value=$menu_label|default:'Menu'}
+  {assign var='fallback_label' value=$block.settings.fallback_label|default:$menu_label}
+  <nav class="navbar navbar-expand-lg navbar-light everblock-megamenu{$prettyblock_visibility_class}" aria-label="{$menu_label|escape:'htmlall':'UTF-8'}">
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#{$collapse_id}" aria-controls="{$collapse_id}" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -18,7 +18,11 @@
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
   {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
 
-  {assign var='menu_label' value=$block.settings.label|default:$block.settings.fallback_label|default:'Menu'}
+  {assign var='menu_label' value=$block.settings.label}
+  {if is_array($menu_label)}
+    {assign var='menu_label' value=$menu_label[$language.id_lang]|default:$menu_label|@reset}
+  {/if}
+  {assign var='menu_label' value=$menu_label|default:$block.settings.fallback_label|default:'Menu'}
   {assign var='menu_url' value=$block.settings.url|default:''}
   {assign var='menu_toggle_id' value="everblock-megamenu-toggle-`$block.id_prettyblocks`"}
   {assign var='has_dropdown' value=($block.settings.is_mega && ($block.extra.columns|@count))}
@@ -47,6 +51,9 @@
           <div class="d-lg-none accordion" id="everblock-megamenu-accordion-{$block.id_prettyblocks}">
             {foreach from=$block.extra.columns item=column name=mobile_columns}
               {assign var='column_title' value=$column.extra.title_label|default:$column.settings.title|default:$menu_label}
+              {if is_array($column_title)}
+                {assign var='column_title' value=$column_title[$language.id_lang]|default:$column_title|@reset}
+              {/if}
               <div class="accordion-item">
                 <h2 class="accordion-header" id="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
                   <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" aria-expanded="false" aria-controls="everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
@@ -16,7 +16,11 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
-  {assign var='link_label' value=$block.settings.label|default:''}
+  {assign var='link_label' value=$block.settings.label}
+  {if is_array($link_label)}
+    {assign var='link_label' value=$link_label[$language.id_lang]|default:$link_label|@reset}
+  {/if}
+  {assign var='link_label' value=$link_label|default:''}
   {assign var='link_url' value=$block.settings.url|default:''}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
@@ -16,7 +16,11 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
-  {assign var='title_label' value=$block.settings.label|default:$block.settings.title|default:''}
+  {assign var='title_label' value=$block.settings.label|default:$block.settings.title}
+  {if is_array($title_label)}
+    {assign var='title_label' value=$title_label[$language.id_lang]|default:$title_label|@reset}
+  {/if}
+  {assign var='title_label' value=$title_label|default:''}
   {assign var='title_url' value=$block.settings.url|default:''}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}


### PR DESCRIPTION
### Motivation
- The Prettyblocks megamenu sometimes rendered label values as the string `Array` when labels were stored as per-language arrays instead of plain strings.
- The templates need to pick the active language entry from label arrays and provide a robust fallback to avoid displaying the raw array.

### Description
- Normalize menu labels in the container by indexing into `$block.settings.menu_label` when it is an array and falling back to `'Menu'` (`views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl`).
- Normalize `menu_label` for each item by selecting the `$language.id_lang` entry when `$block.settings.label` is an array and falling back to the configured fallback label (`views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`).
- Normalize link and title labels by indexing into label arrays when present and using fallbacks (`views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl` and `views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl`).
- Normalize column titles for desktop and mobile accordion headings by resolving `$block.settings.title` (and `$column.extra.title_label`) when they are arrays and falling back to the menu label (`views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl` and `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`).
- Changes are limited to Smarty template logic to avoid changing data structures or controllers and ensure language-aware display.

### Testing
- No automated tests were run as part of this change.
- Templates were updated with defensive `is_array(...)` checks and language-key lookups; visual verification in a running front-end is recommended to confirm localized labels render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3d77138c8322ac0e628738add0bb)