### PR TITLE
Fix megamenu label fallbacks in Smarty templates

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -27,7 +27,11 @@
     {if $render_title}
       {assign var='column_title' value=$block.settings.title}
       {if is_array($column_title)}
-        {assign var='column_title' value=$column_title[$language.id_lang]|default:$column_title|@reset}
+        {if isset($column_title[$language.id_lang])}
+          {assign var='column_title' value=$column_title[$language.id_lang]}
+        {else}
+          {assign var='column_title' value=$column_title|@reset}
+        {/if}
       {/if}
       {if $block.extra.titles}
         {foreach from=$block.extra.titles item=title}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -21,7 +21,11 @@
   {assign var='collapse_id' value="everblock-megamenu-collapse-`$block.id_prettyblocks`"}
   {assign var='menu_label' value=$block.settings.menu_label}
   {if is_array($menu_label)}
-    {assign var='menu_label' value=$menu_label[$language.id_lang]|default:$menu_label|@reset}
+    {if isset($menu_label[$language.id_lang])}
+      {assign var='menu_label' value=$menu_label[$language.id_lang]}
+    {else}
+      {assign var='menu_label' value=$menu_label|@reset}
+    {/if}
   {/if}
   {assign var='menu_label' value=$menu_label|default:'Menu'}
   {assign var='fallback_label' value=$block.settings.fallback_label|default:$menu_label}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -20,7 +20,11 @@
 
   {assign var='menu_label' value=$block.settings.label}
   {if is_array($menu_label)}
-    {assign var='menu_label' value=$menu_label[$language.id_lang]|default:$menu_label|@reset}
+    {if isset($menu_label[$language.id_lang])}
+      {assign var='menu_label' value=$menu_label[$language.id_lang]}
+    {else}
+      {assign var='menu_label' value=$menu_label|@reset}
+    {/if}
   {/if}
   {assign var='menu_label' value=$menu_label|default:$block.settings.fallback_label|default:'Menu'}
   {assign var='menu_url' value=$block.settings.url|default:''}
@@ -52,7 +56,11 @@
             {foreach from=$block.extra.columns item=column name=mobile_columns}
               {assign var='column_title' value=$column.extra.title_label|default:$column.settings.title|default:$menu_label}
               {if is_array($column_title)}
-                {assign var='column_title' value=$column_title[$language.id_lang]|default:$column_title|@reset}
+                {if isset($column_title[$language.id_lang])}
+                  {assign var='column_title' value=$column_title[$language.id_lang]}
+                {else}
+                  {assign var='column_title' value=$column_title|@reset}
+                {/if}
               {/if}
               <div class="accordion-item">
                 <h2 class="accordion-header" id="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
@@ -18,7 +18,11 @@
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
   {assign var='link_label' value=$block.settings.label}
   {if is_array($link_label)}
-    {assign var='link_label' value=$link_label[$language.id_lang]|default:$link_label|@reset}
+    {if isset($link_label[$language.id_lang])}
+      {assign var='link_label' value=$link_label[$language.id_lang]}
+    {else}
+      {assign var='link_label' value=$link_label|@reset}
+    {/if}
   {/if}
   {assign var='link_label' value=$link_label|default:''}
   {assign var='link_url' value=$block.settings.url|default:''}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
@@ -18,7 +18,11 @@
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
   {assign var='title_label' value=$block.settings.label|default:$block.settings.title}
   {if is_array($title_label)}
-    {assign var='title_label' value=$title_label[$language.id_lang]|default:$title_label|@reset}
+    {if isset($title_label[$language.id_lang])}
+      {assign var='title_label' value=$title_label[$language.id_lang]}
+    {else}
+      {assign var='title_label' value=$title_label|@reset}
+    {/if}
   {/if}
   {assign var='title_label' value=$title_label|default:''}
   {assign var='title_url' value=$block.settings.url|default:''}


### PR DESCRIPTION
### Motivation
- Templates were causing a PHP fatal error by passing temporary expressions to `reset()` when resolving multilingual labels, which cannot be passed by reference.
- The intent is to safely resolve language-specific labels and fall back to a stable value without invoking `reset()` on a temporary expression.

### Description
- Replaced expressions like `{$label[$language.id_lang]|default:$label|@reset}` with an explicit `isset($label[$language.id_lang])` check and a clear fallback to `{$label|@reset}` when the language key is absent.
- Applied this pattern to five Smarty templates: `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`, `prettyblock_megamenu_container.tpl`, `prettyblock_megamenu_title.tpl`, `prettyblock_megamenu_item_link.tpl`, and `prettyblock_megamenu_column.tpl`.
- Ensures `menu_label`, `column_title`, `title_label`, and `link_label` resolve to the correct language entry when present, or to a stable fallback otherwise.
- This change avoids passing temporary values by reference and prevents the reported `reset()` error in the megamenu rendering paths.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a3ec67a5883228a763e921b702f53)