### PR TITLE
Guard language id lookups in megamenu labels

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -20,7 +20,7 @@
 
   {assign var='menu_label' value=$block.settings.label}
   {if is_array($menu_label)}
-    {if isset($menu_label[$language.id_lang])}
+    {if isset($language.id_lang) && isset($menu_label[$language.id_lang])}
       {assign var='menu_label' value=$menu_label[$language.id_lang]}
     {else}
       {assign var='menu_label' value=$menu_label|@reset}
@@ -56,7 +56,7 @@
             {foreach from=$block.extra.columns item=column name=mobile_columns}
               {assign var='column_title' value=$column.extra.title_label|default:$column.settings.title|default:$menu_label}
               {if is_array($column_title)}
-                {if isset($column_title[$language.id_lang])}
+                {if isset($language.id_lang) && isset($column_title[$language.id_lang])}
                   {assign var='column_title' value=$column_title[$language.id_lang]}
                 {else}
                   {assign var='column_title' value=$column_title|@reset}


### PR DESCRIPTION
### Motivation
- Prevent PHP notices about an undefined array key `id_lang` when resolving megamenu labels and mobile column titles in the template `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`.

### Description
- Add `isset($language.id_lang)` checks before indexing into label arrays when selecting the per-language `menu_label` and `column_title` in `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4296e3748322a31929dd929ead8c)