### PR TITLE
Fix megamenu label resolution

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5939,6 +5939,12 @@ class Everblock extends Module
         $preparedItems = [];
         foreach ($items as $item) {
             $item['settings']['url'] = $this->normalizePrettyblocksLink($item['settings']['url'] ?? '');
+            $item['settings']['label'] = (string) $this->resolvePrettyblocksValue(
+                $item['settings']['label'] ?? ''
+            );
+            $item['settings']['fallback_label'] = (string) $this->resolvePrettyblocksValue(
+                $item['settings']['fallback_label'] ?? ''
+            );
             $item['extra']['columns'] = $this->buildMegaMenuColumns(
                 (int) ($item['id_prettyblocks'] ?? 0),
                 $idLang,
@@ -6046,6 +6052,9 @@ class Everblock extends Module
                 continue;
             }
             $title['settings']['url'] = $this->normalizePrettyblocksLink($title['settings']['url'] ?? '');
+            $title['settings']['label'] = (string) $this->resolvePrettyblocksValue(
+                $title['settings']['label'] ?? $title['settings']['title'] ?? ''
+            );
             $titlesByColumn[$parentId][] = $title;
         }
 
@@ -6059,6 +6068,7 @@ class Everblock extends Module
                 continue;
             }
             $link['settings']['url'] = $this->normalizePrettyblocksLink($link['settings']['url'] ?? '');
+            $link['settings']['label'] = (string) $this->resolvePrettyblocksValue($link['settings']['label'] ?? '');
             $linksByColumn[$parentId][] = $link;
         }
 


### PR DESCRIPTION
### Motivation
- Menu labels rendered for the mega menu were not using the values stored in PrettyBlocks settings, causing the displayed labels to differ from the configured text.
- The megamenu columns' titles and links also required normalization so configured labels are respected when building the rendered structure.

### Description
- Resolve and set `label` and `fallback_label` on top-level mega menu items using `resolvePrettyblocksValue` before returning container `items` so the menu entries reflect configured PrettyBlocks labels.
- Resolve `label` for `megamenu_title` blocks (falling back to `title` setting) and for `megamenu_item_link` blocks when assembling column data, and keep link URLs normalized with `normalizePrettyblocksLink`.
- Changes are implemented in `everblock.php` inside `hookBeforeRenderingMegaMenuContainer` and `buildMegaMenuColumns` to populate `settings.label` consistently for items, titles and links.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a434de8948322a2972610d97bd07d)