### PR TITLE
Fix megamenu column width rendering

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -18,6 +18,14 @@
 
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
   {assign var='column_width' value=$block.settings.width|default:3}
+  {if is_array($column_width)}
+    {if isset($column_width[$language.id_lang])}
+      {assign var='column_width' value=$column_width[$language.id_lang]}
+    {else}
+      {assign var='column_width' value=$column_width|@reset}
+    {/if}
+  {/if}
+  {assign var='column_width' value=$column_width|default:3|intval}
   {assign var='render_title' value=$render_title|default:true}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}


### PR DESCRIPTION
### Motivation
- The megamenu column width could be an array keyed by language which produced `col-lg-Array` in the generated HTML, so the template must resolve language-specific values and ensure a numeric width.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl` to detect when `column_width` is an array and pick the value for `$language.id_lang` or fallback to the first element.
- Normalize the resolved `column_width` with `|default:3|intval` before rendering so the output becomes a valid class like `col-lg-4`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a44d8a98083228c896b2f276817ae)