### PR TITLE
Uniformiser la hauteur des cartes d'avis Google

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3158,6 +3158,14 @@
 }
 
 /* Prettyblock Google reviews */
+.everblock-google-reviews__col {
+  display: flex;
+}
+
+.everblock-google-reviews__card {
+  flex: 1 1 auto;
+}
+
 .everblock-google-reviews__avatar {
   width: 56px;
   height: 56px;

--- a/views/templates/hook/_partials/google_reviews.tpl
+++ b/views/templates/hook/_partials/google_reviews.tpl
@@ -76,7 +76,7 @@
               <div class="carousel-item{if $smarty.foreach.reviewsLg.first} active{/if}">
                 <div class="row g-4">
                   {foreach from=$reviewGroup item=review}
-                    <div class="col-12 col-lg-4">
+                    <div class="col-12 col-lg-4 everblock-google-reviews__col">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
                           <header class="everblock-google-reviews__header d-flex align-items-center gap-3">
@@ -147,7 +147,7 @@
               <div class="carousel-item{if $smarty.foreach.reviewsMd.first} active{/if}">
                 <div class="row g-4">
                   {foreach from=$reviewGroup item=review}
-                    <div class="col-12 col-md-6">
+                    <div class="col-12 col-md-6 everblock-google-reviews__col">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
                           <header class="everblock-google-reviews__header d-flex align-items-center gap-3">
@@ -218,7 +218,7 @@
               <div class="carousel-item{if $smarty.foreach.reviewsSm.first} active{/if}">
                 <div class="row g-4">
                   {foreach from=$reviewGroup item=review}
-                    <div class="col-12">
+                    <div class="col-12 everblock-google-reviews__col">
                       <article class="card h-100 d-flex flex-column border-0 shadow-sm everblock-google-reviews__card">
                         <div class="card-body d-flex flex-column gap-3">
                           <header class="everblock-google-reviews__header d-flex align-items-center gap-3">


### PR DESCRIPTION
### Motivation
- Uniformiser la hauteur des cards d'avis Google dans le prettyblock pour éviter des colonnes de tailles inégales entre éléments affichés sur différents breakpoints.

### Description
- Ajout de la classe wrapper `everblock-google-reviews__col` aux colonnes dans `views/templates/hook/_partials/google_reviews.tpl` pour les layouts `lg`, `md` et `sm` afin de pouvoir appliquer un comportement flex sur chaque cellule.
- Ajout de règles CSS dans `views/css/everblock.css` : ` .everblock-google-reviews__col { display: flex; }` et `.everblock-google-reviews__card { flex: 1 1 auto; }` pour forcer les cards à s'étirer et assurer une hauteur uniforme.
- Les modifications s'appliquent à tous les carrousels de reviews (desktop/tablet/mobile) et n'altèrent pas le contenu des cards, uniquement leur comportement d'affichage.

### Testing
- Aucun test automatisé n'a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a460f76e083229d48371851bab4af)