### PR TITLE
Mega Menu: full-width mobile, link layouts, explicit image sizing and SEO/accessibility fixes

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -604,6 +604,16 @@ class EverblockPrettyBlocks
                             ],
                             'default' => '3',
                         ],
+                        'link_layout' => [
+                            'type' => 'select',
+                            'label' => $module->l('Links layout'),
+                            'choices' => [
+                                'stacked' => $module->l('Stacked'),
+                                'inline' => $module->l('Inline'),
+                                'grid' => $module->l('Grid'),
+                            ],
+                            'default' => 'stacked',
+                        ],
                         'order' => [
                             'type' => 'text',
                             'label' => $module->l('Order'),
@@ -733,6 +743,16 @@ class EverblockPrettyBlocks
                             'default' => [
                                 'url' => '',
                             ],
+                        ],
+                        'image_width' => [
+                            'type' => 'text',
+                            'label' => $module->l('Image width'),
+                            'default' => '400',
+                        ],
+                        'image_height' => [
+                            'type' => 'text',
+                            'label' => $module->l('Image height'),
+                            'default' => '300',
                         ],
                         'title' => [
                             'type' => 'text',

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -27,6 +27,21 @@
   {/if}
   {assign var='column_width' value=$column_width|default:3|intval}
   {assign var='render_title' value=$render_title|default:true}
+  {assign var='link_layout' value=$block.settings.link_layout|default:'stacked'}
+  {if is_array($link_layout)}
+    {if isset($link_layout[$language.id_lang])}
+      {assign var='link_layout' value=$link_layout[$language.id_lang]}
+    {else}
+      {assign var='link_layout' value=$link_layout|@reset}
+    {/if}
+  {/if}
+  {assign var='link_layout' value=$link_layout|default:'stacked'}
+  {assign var='link_layout_class' value='dropdown-megamenu-links--stacked'}
+  {if $link_layout == 'inline'}
+    {assign var='link_layout_class' value='dropdown-megamenu-links--inline'}
+  {elseif $link_layout == 'grid'}
+    {assign var='link_layout_class' value='dropdown-megamenu-links--grid'}
+  {/if}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}
     {assign var='obfme_class' value=' obfme'}
@@ -47,7 +62,7 @@
         {/foreach}
       {elseif $column_title}
         {if $block.settings.title_url}
-          <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$block.settings.title_url|escape:'htmlall':'UTF-8'}">
+          <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$block.settings.title_url|escape:'htmlall':'UTF-8'}" title="{$column_title|escape:'htmlall':'UTF-8'}">
             {$column_title|escape:'htmlall':'UTF-8'}
           </a>
         {else}
@@ -57,7 +72,7 @@
     {/if}
 
     {if $block.extra.links}
-      <div class="dropdown-megamenu-links mb-3">
+      <div class="dropdown-megamenu-links {$link_layout_class} mb-3">
         {foreach from=$block.extra.links item=item}
           {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl' block=$item from_parent=true}
         {/foreach}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -29,11 +29,15 @@
   {/if}
   {assign var='menu_label' value=$menu_label|default:'Menu'}
   {assign var='fallback_label' value=$block.settings.fallback_label|default:$menu_label}
+  {assign var='obfme_class' value=''}
+  {if $page.page_name|default:'' != 'index'}
+    {assign var='obfme_class' value=' obfme'}
+  {/if}
   <nav class="navbar navbar-expand-lg navbar-light everblock-megamenu{$prettyblock_visibility_class}" aria-label="{$menu_label|escape:'htmlall':'UTF-8'}">
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#{$collapse_id}" aria-controls="{$collapse_id}" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="collapse navbar-collapse" id="{$collapse_id}">
+    <div class="collapse navbar-collapse everblock-megamenu-collapse w-100" id="{$collapse_id}">
       <ul class="navbar-nav w-100">
         {if isset($block.extra.items) && $block.extra.items}
           {foreach from=$block.extra.items item=item}
@@ -41,7 +45,7 @@
           {/foreach}
         {else}
           <li class="nav-item">
-            <a class="nav-link" href="#">{$fallback_label|escape:'htmlall':'UTF-8'}</a>
+            <a class="nav-link{$obfme_class}" href="#" title="{$fallback_label|escape:'htmlall':'UTF-8'}">{$fallback_label|escape:'htmlall':'UTF-8'}</a>
           </li>
         {/if}
       </ul>
@@ -71,5 +75,31 @@
     .everblock-megamenu .everblock-megamenu-icon {
       font-size: 0.9em;
       line-height: 1;
+    }
+
+    .everblock-megamenu .dropdown-megamenu-links--stacked {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .everblock-megamenu .dropdown-megamenu-links--inline {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .everblock-megamenu .dropdown-megamenu-links--grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.5rem;
+    }
+
+    @media (max-width: 991.98px) {
+      .everblock-megamenu .everblock-megamenu-collapse {
+        width: 100vw;
+        margin-left: calc(50% - 50vw);
+        margin-right: calc(50% - 50vw);
+      }
     }
   </style>

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -30,9 +30,13 @@
   {assign var='menu_url' value=$block.settings.url|default:''}
   {assign var='menu_toggle_id' value="everblock-megamenu-toggle-`$block.id_prettyblocks`"}
   {assign var='has_dropdown' value=($block.settings.is_mega && ($block.extra.columns|@count))}
+  {assign var='obfme_class' value=''}
+  {if $page.page_name|default:'' != 'index'}
+    {assign var='obfme_class' value=' obfme'}
+  {/if}
   <li id="block-{$block.id_prettyblocks}" class="nav-item{if $has_dropdown} dropdown{/if}{$prettyblock_visibility_class} everblock-megamenu-item">
     {if $menu_url}
-      <a class="nav-link{if $has_dropdown} dropdown-toggle{/if}" href="{$menu_url|escape:'htmlall':'UTF-8'}"{if $has_dropdown} id="{$menu_toggle_id}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
+      <a class="nav-link{if $has_dropdown} dropdown-toggle{/if}{$obfme_class}" href="{$menu_url|escape:'htmlall':'UTF-8'}" title="{$menu_label|escape:'htmlall':'UTF-8'}"{if $has_dropdown} id="{$menu_toggle_id}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
         {$menu_label|escape:'htmlall':'UTF-8'}
       </a>
     {else}
@@ -68,7 +72,7 @@
                     {$column_title|escape:'htmlall':'UTF-8'}
                   </button>
                 </h2>
-                <div id="everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" class="accordion-collapse collapse" aria-labelledby="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" data-bs-parent="#everblock-megamenu-accordion-{$block.id_prettyblocks}">
+                <div id="everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" class="accordion-collapse collapse" aria-labelledby="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
                   <div class="accordion-body">
                     <div class="row g-3">
                       {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl' block=$column from_parent=true render_title=false}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_image.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_image.tpl
@@ -22,6 +22,14 @@
   {/if}
   {assign var='image_value' value=$block.settings.image|default:''}
   {assign var='image_url' value=''}
+  {assign var='image_width' value=$block.settings.image_width|default:400|intval}
+  {assign var='image_height' value=$block.settings.image_height|default:300|intval}
+  {if $image_width <= 0}
+    {assign var='image_width' value=400}
+  {/if}
+  {if $image_height <= 0}
+    {assign var='image_height' value=300}
+  {/if}
   {if is_array($image_value)}
     {if isset($image_value.url)}
       {assign var='image_url' value=$image_value.url}
@@ -31,10 +39,11 @@
   {elseif $image_value}
     {assign var='image_url' value=$image_value}
   {/if}
+  {assign var='image_title' value=$block.settings.title|default:$block.settings.cta_label|default:$block.settings.url|default:'Menu image'}
   {if $image_url}
     <div class="everblock-megamenu-image mb-3">
-      <a href="{$block.settings.url|escape:'htmlall':'UTF-8'}" class="text-decoration-none d-block{$obfme_class}">
-        <img src="{$image_url|escape:'htmlall':'UTF-8'}" alt="{$block.settings.title|escape:'htmlall':'UTF-8'}" class="img-fluid rounded">
+      <a href="{$block.settings.url|escape:'htmlall':'UTF-8'}" class="text-decoration-none d-block{$obfme_class}" title="{$image_title|escape:'htmlall':'UTF-8'}">
+        <img src="{$image_url|escape:'htmlall':'UTF-8'}" alt="{$block.settings.title|escape:'htmlall':'UTF-8'}" width="{$image_width}" height="{$image_height}" class="img-fluid rounded">
         {if $block.settings.title}
           <div class="mt-2 fw-semibold">{$block.settings.title|escape:'htmlall':'UTF-8'}</div>
         {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
@@ -35,12 +35,13 @@
   {/if}
   {assign var='link_icon' value=$link_icon|default:''}
   {assign var='link_url' value=$block.settings.url|default:''}
+  {assign var='link_title' value=$link_label|default:$link_url|default:'Link'}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}
     {assign var='obfme_class' value=' obfme'}
   {/if}
   {if $link_label && $link_url}
-    <a class="dropdown-item d-flex align-items-center gap-2{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}">
+    <a class="dropdown-item d-flex align-items-center gap-2{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}" title="{$link_title|escape:'htmlall':'UTF-8'}">
       {if $link_icon}<span class="everblock-megamenu-icon">{$link_icon|escape:'htmlall':'UTF-8'}</span>{/if}
       <span>{$link_label|escape:'htmlall':'UTF-8'}</span>
     </a>

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
@@ -32,7 +32,7 @@
   {/if}
   {if $title_label}
     {if $title_url}
-      <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$title_url|escape:'htmlall':'UTF-8'}">
+      <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$title_url|escape:'htmlall':'UTF-8'}" title="{$title_label|escape:'htmlall':'UTF-8'}">
         {$title_label|escape:'htmlall':'UTF-8'}
       </a>
     {else}


### PR DESCRIPTION
### Motivation
- Fix multiple UX issues in the Prettyblocks Mega Menu so mobile hamburger is full-width, column toggles don't interfere, links can be displayed inline/grid and images include explicit sizes. 
- Enforce strict SEO/accessibility rules so every anchor has a `title` and the `obfme` class is applied off the homepage.

### Description
- Make mobile collapse full-width by adding `everblock-megamenu-collapse w-100` and CSS that sets the collapse to `width: 100vw` with centered margins, and remove accordion coupling by deleting `data-bs-parent` on mobile column collapses in `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl`.
- Add a `link_layout` column option and three rendering modes (`stacked`, `inline`, `grid`) that map to CSS classes `dropdown-megamenu-links--stacked`, `--inline`, `--grid` and are applied in `views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl` and styled in `views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl`.
- Introduce configurable image dimensions with `image_width` and `image_height` fields in `src/Service/EverblockPrettyBlocks.php` and add `width`/`height` attributes plus a fallback `title` for images in `views/templates/hook/prettyblocks/prettyblock_megamenu_item_image.tpl` to prevent layout shifts and preserve aspect ratio.
- Enforce SEO/accessibility rules by ensuring every generated `<a>` includes a `title` and adding the `obfme` class when `{$page.page_name}` is not `index` for container fallback, menu items, titles and links across `prettyblock_megamenu_container.tpl`, `prettyblock_megamenu_item.tpl`, `prettyblock_megamenu_title.tpl`, and `prettyblock_megamenu_item_link.tpl`.
- Small UX tweaks: add `aria`/title attributes to fallback link and menu item anchors, and ensure mobile accordion toggles are independent so clicking one column does not close others.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4d0d4abc8322b8342c041adf6db0)