### PR TITLE
Mega Menu: Add seasonal theming (winter) with CSS-variable styles and inheritance

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -293,6 +293,7 @@ return [
     'views/templates/hook/pdf.tpl',
     'views/templates/hook/prettyblocks.tpl',
     'views/templates/hook/prettyblocks/_partials/index.php',
+    'views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl',
     'views/templates/hook/prettyblocks/_partials/spacing_style.tpl',
     'views/templates/hook/prettyblocks/_partials/visibility_class.tpl',
     'views/templates/hook/prettyblocks/index.php',

--- a/everblock.php
+++ b/everblock.php
@@ -135,6 +135,7 @@ class Everblock extends Module
         Configuration::updateValue('EVERBLOCK_SOLDOUT_FLAG', 0);
         Configuration::updateValue('EVERBLOCK_LOW_STOCK_THRESHOLD', 5);
         Configuration::updateValue('EVERBLOCK_STORELOCATOR_TOGGLE', 0);
+        Configuration::updateValue('EVERBLOCK_WINTER_MODE', 0);
         Configuration::updateValue('EVERBLOCK_GOOGLE_API_KEY', '');
         Configuration::updateValue('EVERBLOCK_GOOGLE_PLACE_ID', '');
         Configuration::updateValue('EVERBLOCK_GOOGLE_REVIEWS_LIMIT', 5);
@@ -2245,6 +2246,25 @@ class Everblock extends Module
                     'required' => false,
                 ],
                 [
+                    'type' => 'switch',
+                    'label' => $this->l('Enable winter theme mode'),
+                    'desc' => $this->l('Force the winter variant for PrettyBlocks mega menu styles.'),
+                    'name' => 'EVERBLOCK_WINTER_MODE',
+                    'is_bool' => true,
+                    'values' => [
+                        [
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->l('Enabled'),
+                        ],
+                        [
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->l('Disabled'),
+                        ],
+                    ],
+                ],
+                [
                     'type' => 'select',
                     'label' => $this->l('PrettyBlocks hook to export'),
                     'desc' => $prettyblocksHookDesc,
@@ -2636,6 +2656,7 @@ class Everblock extends Module
             'EVERBLOCK_GMAP_KEY' => Configuration::get('EVERBLOCK_GMAP_KEY'),
             'EVERBLOCK_MARKER_ICON' => Configuration::get('EVERBLOCK_MARKER_ICON'),
             'EVERBLOCK_STORELOCATOR_TOGGLE' => Configuration::get('EVERBLOCK_STORELOCATOR_TOGGLE'),
+            'EVERBLOCK_WINTER_MODE' => Configuration::get('EVERBLOCK_WINTER_MODE'),
             'EVERPSCSS_CACHE' => Configuration::get('EVERPSCSS_CACHE'),
             'EVERBLOCK_CACHE' => Configuration::get('EVERBLOCK_CACHE'),
             'EVERBLOCK_USE_OBF' => Configuration::get('EVERBLOCK_USE_OBF'),
@@ -3109,6 +3130,10 @@ class Everblock extends Module
         Configuration::updateValue(
             'EVERBLOCK_STORELOCATOR_TOGGLE',
             Tools::getValue('EVERBLOCK_STORELOCATOR_TOGGLE')
+        );
+        Configuration::updateValue(
+            'EVERBLOCK_WINTER_MODE',
+            Tools::getValue('EVERBLOCK_WINTER_MODE')
         );
         if (isset($_FILES['EVERBLOCK_MARKER_ICON'])
             && isset($_FILES['EVERBLOCK_MARKER_ICON']['tmp_name'])
@@ -4891,6 +4916,9 @@ class Everblock extends Module
 
     public function hookDisplayHeader()
     {
+        $this->context->smarty->assign([
+            'everblock_winter_mode' => (bool) Configuration::get('EVERBLOCK_WINTER_MODE'),
+        ]);
         if (Tools::getValue('eac')
             && Validate::isInt(Tools::getValue('eac'))
         ) {

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -109,6 +109,48 @@ class EverblockPrettyBlocks
         return $fields;
     }
 
+    private static function getMegaMenuStyleFields(Module $module): array
+    {
+        return [
+            'text_color' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Text color'),
+                'default' => '',
+            ],
+            'text_color_winter' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Text color (winter)'),
+                'default' => '',
+            ],
+            'background_color' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Background color'),
+                'default' => '',
+            ],
+            'background_color_winter' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Background color (winter)'),
+                'default' => '',
+            ],
+            'hover_text_color' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Hover text color'),
+                'default' => '',
+            ],
+            'hover_background_color' => [
+                'tab' => 'design',
+                'type' => 'color',
+                'label' => $module->l('Hover background color'),
+                'default' => '',
+            ],
+        ];
+    }
+
     private static function getColumnChoices(Module $module): array
     {
         return [
@@ -495,7 +537,7 @@ class EverblockPrettyBlocks
                     'default' => $megamenuContainerTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => array_merge([
                         'menu_label' => [
                             'type' => 'text',
                             'label' => $module->l('Menu label'),
@@ -511,7 +553,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Active'),
                             'default' => true,
                         ],
-                    ],
+                    ], static::getMegaMenuStyleFields($module)),
                 ],
             ];
             $blocks[] = [
@@ -525,7 +567,7 @@ class EverblockPrettyBlocks
                     'default' => $megamenuItemTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => array_merge([
                         'parent_id' => [
                             'type' => 'select',
                             'label' => $module->l('Parent menu container'),
@@ -562,7 +604,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Active'),
                             'default' => true,
                         ],
-                    ],
+                    ], static::getMegaMenuStyleFields($module)),
                 ],
             ];
             $blocks[] = [
@@ -576,7 +618,7 @@ class EverblockPrettyBlocks
                     'default' => $megamenuColumnTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => array_merge([
                         'parent_id' => [
                             'type' => 'select',
                             'label' => $module->l('Parent menu item'),
@@ -624,7 +666,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Active'),
                             'default' => true,
                         ],
-                    ],
+                    ], static::getMegaMenuStyleFields($module)),
                 ],
             ];
             $blocks[] = [
@@ -638,7 +680,7 @@ class EverblockPrettyBlocks
                     'default' => $megamenuTitleTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => array_merge([
                         'parent_id' => [
                             'type' => 'select',
                             'label' => $module->l('Parent column'),
@@ -665,7 +707,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Active'),
                             'default' => true,
                         ],
-                    ],
+                    ], static::getMegaMenuStyleFields($module)),
                 ],
             ];
             $blocks[] = [
@@ -679,7 +721,7 @@ class EverblockPrettyBlocks
                     'default' => $megamenuItemLinkTemplate,
                 ],
                 'config' => [
-                    'fields' => [
+                    'fields' => array_merge([
                         'parent_id' => [
                             'type' => 'select',
                             'label' => $module->l('Parent column'),
@@ -716,7 +758,7 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Active'),
                             'default' => true,
                         ],
-                    ],
+                    ], static::getMegaMenuStyleFields($module)),
                 ],
             ];
             $blocks[] = [

--- a/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl
+++ b/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl
@@ -1,0 +1,92 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{assign var='style_vars' value=''}
+
+{assign var='text_color' value=$block.settings.text_color|default:''}
+{if is_array($text_color)}
+  {if isset($language.id_lang) && isset($text_color[$language.id_lang])}
+    {assign var='text_color' value=$text_color[$language.id_lang]}
+  {else}
+    {assign var='text_color' value=$text_color|@reset}
+  {/if}
+{/if}
+{if $text_color}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-text:'|cat:$text_color|cat:';'}
+{/if}
+
+{assign var='text_color_winter' value=$block.settings.text_color_winter|default:''}
+{if is_array($text_color_winter)}
+  {if isset($language.id_lang) && isset($text_color_winter[$language.id_lang])}
+    {assign var='text_color_winter' value=$text_color_winter[$language.id_lang]}
+  {else}
+    {assign var='text_color_winter' value=$text_color_winter|@reset}
+  {/if}
+{/if}
+{if $text_color_winter}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-text-winter:'|cat:$text_color_winter|cat:';'}
+{/if}
+
+{assign var='background_color' value=$block.settings.background_color|default:''}
+{if is_array($background_color)}
+  {if isset($language.id_lang) && isset($background_color[$language.id_lang])}
+    {assign var='background_color' value=$background_color[$language.id_lang]}
+  {else}
+    {assign var='background_color' value=$background_color|@reset}
+  {/if}
+{/if}
+{if $background_color}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-bg:'|cat:$background_color|cat:';'}
+{/if}
+
+{assign var='background_color_winter' value=$block.settings.background_color_winter|default:''}
+{if is_array($background_color_winter)}
+  {if isset($language.id_lang) && isset($background_color_winter[$language.id_lang])}
+    {assign var='background_color_winter' value=$background_color_winter[$language.id_lang]}
+  {else}
+    {assign var='background_color_winter' value=$background_color_winter|@reset}
+  {/if}
+{/if}
+{if $background_color_winter}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-bg-winter:'|cat:$background_color_winter|cat:';'}
+{/if}
+
+{assign var='hover_text_color' value=$block.settings.hover_text_color|default:''}
+{if is_array($hover_text_color)}
+  {if isset($language.id_lang) && isset($hover_text_color[$language.id_lang])}
+    {assign var='hover_text_color' value=$hover_text_color[$language.id_lang]}
+  {else}
+    {assign var='hover_text_color' value=$hover_text_color|@reset}
+  {/if}
+{/if}
+{if $hover_text_color}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-hover-text:'|cat:$hover_text_color|cat:';'}
+{/if}
+
+{assign var='hover_background_color' value=$block.settings.hover_background_color|default:''}
+{if is_array($hover_background_color)}
+  {if isset($language.id_lang) && isset($hover_background_color[$language.id_lang])}
+    {assign var='hover_background_color' value=$hover_background_color[$language.id_lang]}
+  {else}
+    {assign var='hover_background_color' value=$hover_background_color|@reset}
+  {/if}
+{/if}
+{if $hover_background_color}
+  {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-hover-bg:'|cat:$hover_background_color|cat:';'}
+{/if}
+
+{$style_vars}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -17,6 +17,7 @@
 *}
 
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
+  {include file='module:everblock/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl' block=$block assign='megamenu_style_vars'}
   {assign var='column_width' value=$block.settings.width|default:3}
   {if is_array($column_width)}
     {if isset($column_width[$language.id_lang])}
@@ -46,7 +47,7 @@
   {if $page.page_name|default:'' != 'index'}
     {assign var='obfme_class' value=' obfme'}
   {/if}
-  <div class="col col-12 col-lg-{$column_width|escape:'htmlall':'UTF-8'}">
+  <div class="col col-12 col-lg-{$column_width|escape:'htmlall':'UTF-8'} everblock-megamenu-column"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
     {if $render_title}
       {assign var='column_title' value=$block.settings.title.value}
       {if is_array($column_title)}
@@ -62,11 +63,11 @@
         {/foreach}
       {elseif $column_title}
         {if $block.settings.title_url}
-          <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$block.settings.title_url|escape:'htmlall':'UTF-8'}" title="{$column_title|escape:'htmlall':'UTF-8'}">
+          <a class="dropdown-header h6 text-decoration-none everblock-megamenu-title{$obfme_class}" href="{$block.settings.title_url|escape:'htmlall':'UTF-8'}" title="{$column_title|escape:'htmlall':'UTF-8'}">
             {$column_title|escape:'htmlall':'UTF-8'}
           </a>
         {else}
-          <span class="dropdown-header h6">{$column_title|escape:'htmlall':'UTF-8'}</span>
+          <span class="dropdown-header h6 everblock-megamenu-title">{$column_title|escape:'htmlall':'UTF-8'}</span>
         {/if}
       {/if}
     {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -16,6 +16,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl' block=$block assign='megamenu_style_vars'}
 
 
   {assign var='collapse_id' value="everblock-megamenu-collapse-`$block.id_prettyblocks`"}
@@ -33,7 +34,7 @@
   {if $page.page_name|default:'' != 'index'}
     {assign var='obfme_class' value=' obfme'}
   {/if}
-  <nav class="navbar navbar-expand-lg navbar-light everblock-megamenu{$prettyblock_visibility_class}" aria-label="{$menu_label|escape:'htmlall':'UTF-8'}">
+  <nav class="navbar navbar-expand-lg navbar-light everblock-megamenu{if $everblock_winter_mode} everblock-megamenu--winter{/if}{$prettyblock_visibility_class}" aria-label="{$menu_label|escape:'htmlall':'UTF-8'}"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#{$collapse_id}" aria-controls="{$collapse_id}" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -53,6 +54,61 @@
   </nav>
 
   <style>
+    .everblock-megamenu,
+    .everblock-megamenu-item,
+    .everblock-megamenu-column,
+    .everblock-megamenu-title,
+    .everblock-megamenu-link {
+      --everblock-megamenu-text-active: var(--everblock-megamenu-text);
+      --everblock-megamenu-bg-active: var(--everblock-megamenu-bg);
+    }
+
+    .theme-winter .everblock-megamenu,
+    .theme-winter .everblock-megamenu-item,
+    .theme-winter .everblock-megamenu-column,
+    .theme-winter .everblock-megamenu-title,
+    .theme-winter .everblock-megamenu-link,
+    .everblock-megamenu--winter,
+    .everblock-megamenu--winter .everblock-megamenu-item,
+    .everblock-megamenu--winter .everblock-megamenu-column,
+    .everblock-megamenu--winter .everblock-megamenu-title,
+    .everblock-megamenu--winter .everblock-megamenu-link {
+      --everblock-megamenu-text-active: var(--everblock-megamenu-text-winter, var(--everblock-megamenu-text));
+      --everblock-megamenu-bg-active: var(--everblock-megamenu-bg-winter, var(--everblock-megamenu-bg));
+    }
+
+    .everblock-megamenu {
+      color: var(--everblock-megamenu-text-active);
+      background-color: var(--everblock-megamenu-bg-active);
+    }
+
+    .everblock-megamenu-dropdown,
+    .everblock-megamenu-column {
+      color: var(--everblock-megamenu-text-active);
+      background-color: var(--everblock-megamenu-bg-active);
+    }
+
+    .everblock-megamenu-item > .everblock-megamenu-item-link,
+    .everblock-megamenu-item > .everblock-megamenu-item-link.btn,
+    .everblock-megamenu-title,
+    .everblock-megamenu-link,
+    .everblock-megamenu .accordion-button {
+      color: var(--everblock-megamenu-text-active);
+      background-color: var(--everblock-megamenu-bg-active);
+    }
+
+    .everblock-megamenu-item > .everblock-megamenu-item-link:hover,
+    .everblock-megamenu-item > .everblock-megamenu-item-link:focus,
+    .everblock-megamenu-title:hover,
+    .everblock-megamenu-title:focus,
+    .everblock-megamenu-link:hover,
+    .everblock-megamenu-link:focus,
+    .everblock-megamenu .accordion-button:hover,
+    .everblock-megamenu .accordion-button:focus {
+      color: var(--everblock-megamenu-hover-text, var(--everblock-megamenu-text-active));
+      background-color: var(--everblock-megamenu-hover-bg, var(--everblock-megamenu-bg-active));
+    }
+
     @media (min-width: 992px) {
       .everblock-megamenu .dropdown:hover > .dropdown-menu,
       .everblock-megamenu .dropdown:focus-within > .dropdown-menu {

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -17,6 +17,7 @@
 *}
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
   {include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+  {include file='module:everblock/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl' block=$block assign='megamenu_style_vars'}
 
   {assign var='menu_label' value=$block.settings.label}
   {if is_array($menu_label)}
@@ -34,13 +35,13 @@
   {if $page.page_name|default:'' != 'index'}
     {assign var='obfme_class' value=' obfme'}
   {/if}
-  <li id="block-{$block.id_prettyblocks}" class="nav-item{if $has_dropdown} dropdown{/if}{$prettyblock_visibility_class} everblock-megamenu-item">
+  <li id="block-{$block.id_prettyblocks}" class="nav-item{if $has_dropdown} dropdown{/if}{$prettyblock_visibility_class} everblock-megamenu-item"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
     {if $menu_url}
-      <a class="nav-link{if $has_dropdown} dropdown-toggle{/if}{$obfme_class}" href="{$menu_url|escape:'htmlall':'UTF-8'}" title="{$menu_label|escape:'htmlall':'UTF-8'}"{if $has_dropdown} id="{$menu_toggle_id}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
+      <a class="nav-link everblock-megamenu-item-link{if $has_dropdown} dropdown-toggle{/if}{$obfme_class}" href="{$menu_url|escape:'htmlall':'UTF-8'}" title="{$menu_label|escape:'htmlall':'UTF-8'}"{if $has_dropdown} id="{$menu_toggle_id}" role="button" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
         {$menu_label|escape:'htmlall':'UTF-8'}
       </a>
     {else}
-      <button class="nav-link btn btn-link{if $has_dropdown} dropdown-toggle{/if}" type="button"{if $has_dropdown} id="{$menu_toggle_id}" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
+      <button class="nav-link btn btn-link everblock-megamenu-item-link{if $has_dropdown} dropdown-toggle{/if}" type="button"{if $has_dropdown} id="{$menu_toggle_id}" data-bs-toggle="dropdown" aria-expanded="false"{/if}>
         {$menu_label|escape:'htmlall':'UTF-8'}
       </button>
     {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
@@ -16,6 +16,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
+  {include file='module:everblock/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl' block=$block assign='megamenu_style_vars'}
   {assign var='link_label' value=$block.settings.label}
   {if is_array($link_label)}
     {if isset($link_label[$language.id_lang])}
@@ -41,7 +42,7 @@
     {assign var='obfme_class' value=' obfme'}
   {/if}
   {if $link_label && $link_url}
-    <a class="dropdown-item d-flex align-items-center gap-2{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}" title="{$link_title|escape:'htmlall':'UTF-8'}">
+    <a class="dropdown-item d-flex align-items-center gap-2 everblock-megamenu-link{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}" title="{$link_title|escape:'htmlall':'UTF-8'}"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
       {if $link_icon}<span class="everblock-megamenu-icon">{$link_icon|escape:'htmlall':'UTF-8'}</span>{/if}
       <span>{$link_label|escape:'htmlall':'UTF-8'}</span>
     </a>

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_title.tpl
@@ -16,6 +16,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($from_parent) && $from_parent && (!isset($block.settings.active) || $block.settings.active)}
+  {include file='module:everblock/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl' block=$block assign='megamenu_style_vars'}
   {assign var='title_label' value=$block.settings.label|default:$block.settings.title}
   {if is_array($title_label)}
     {if isset($title_label[$language.id_lang])}
@@ -32,11 +33,11 @@
   {/if}
   {if $title_label}
     {if $title_url}
-      <a class="dropdown-header h6 text-decoration-none{$obfme_class}" href="{$title_url|escape:'htmlall':'UTF-8'}" title="{$title_label|escape:'htmlall':'UTF-8'}">
+      <a class="dropdown-header h6 text-decoration-none everblock-megamenu-title{$obfme_class}" href="{$title_url|escape:'htmlall':'UTF-8'}" title="{$title_label|escape:'htmlall':'UTF-8'}"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
         {$title_label|escape:'htmlall':'UTF-8'}
       </a>
     {else}
-      <span class="dropdown-header h6">{$title_label|escape:'htmlall':'UTF-8'}</span>
+      <span class="dropdown-header h6 everblock-megamenu-title"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>{$title_label|escape:'htmlall':'UTF-8'}</span>
     {/if}
   {/if}
 {/if}


### PR DESCRIPTION
### Motivation

- Provide per-block visual configuration for the PrettyBlocks mega menu (text/background, hover and winter variants) with smart inheritance parent→child while avoiding hard-coded colors and massive inline CSS.
- Keep native PrettyBlocks integration, Bootstrap 5 compatibility, multilingual/multishop support and performant centralized styling using classes/CSS variables.

### Description

- Added `getMegaMenuStyleFields()` in `src/Service/EverblockPrettyBlocks.php` and merged its color fields into the `config.fields` of `megamenu_container`, `megamenu_item`, `megamenu_column`, `megamenu_title` and `megamenu_item_link` via `array_merge()` so each block exposes the same optional design controls (`text_color`, `text_color_winter`, `background_color`, `background_color_winter`, `hover_text_color`, `hover_background_color`).
- Introduced a shared Smarty partial `views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl` that reads block settings (with multilingual fallback) and emits a compact CSS variable string (for use in `style="--var:...;"`) rather than mass inline CSS.
- Updated megamenu templates to include the partial and apply styles through CSS variables and classes (no per-property inline styles): container now defines centralized rules that use `--everblock-megamenu-*` variables and switches to winter values when `.theme-winter` is present or the module-level winter toggle is enabled (`everblock-megamenu--winter`); child blocks inherit variables when their own settings are empty.
- Added a module toggle `EVERBLOCK_WINTER_MODE` (install default, config form input, persistence in `postProcess`, included in `getConfigFormValues`) and assign it to Smarty in `hookDisplayHeader` as `everblock_winter_mode` to allow forcing the winter variant site-wide.
- Registered the new partial in `config/allowed_files.php` so it is allowed in packaged builds.

### Testing

- Automated tests: none executed for this change (no CI/unit tests run in this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4e78ffb48322b26396043cb68a44)