### PR TITLE
Fix megamenu column widths and inline link layout

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -27,6 +27,13 @@
     {/if}
   {/if}
   {assign var='column_width' value=$column_width|default:3|intval}
+  {if $column_width <= 0}
+    {assign var='column_width' value=12}
+  {/if}
+  {assign var='allowed_widths' value=[12, 6, 4, 3]}
+  {if !in_array($column_width, $allowed_widths)}
+    {assign var='column_width' value=12}
+  {/if}
   {assign var='render_title' value=$render_title|default:true}
   {assign var='link_layout' value=$block.settings.link_layout|default:'stacked'}
   {if is_array($link_layout)}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_container.tpl
@@ -145,6 +145,11 @@
       gap: 0.5rem;
     }
 
+    .everblock-megamenu .dropdown-megamenu-links--inline .dropdown-item {
+      display: inline-flex;
+      width: auto;
+    }
+
     .everblock-megamenu .dropdown-megamenu-links--grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));


### PR DESCRIPTION
### Motivation
- Prevent generation of invalid Bootstrap column classes (like `col-lg-0`) and ensure inline link items can appear side-by-side in the Prettyblocks Mega Menu.

### Description
- In `prettyblock_megamenu_column.tpl` normalize `column_width` by falling back to `12` if the computed value is `<= 0` and restrict widths to the allowed set `[12, 6, 4, 3]` to avoid invalid `col-*` classes.
- In `prettyblock_megamenu_container.tpl` add CSS to make inline link layout items use `display: inline-flex` and `width: auto` so `.dropdown-item` children can sit side-by-side when `link_layout` is `inline`.
- No other structural or behavioral changes were made; templates keep the same mobile accordion / desktop dropdown structure.

### Testing
- No automated tests were executed for these template/CSS-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a51db43448322b80a6a985467ea82)