### PR TITLE
Limit PrettyBlocks hook chooser to display hooks and add chosen class

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -494,7 +494,7 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
                 $forms .= '<form method="post" action="' . $action . '" id="prettyblocks-hook-change-form">';
                 $forms .= '<div class="form-group">';
                 $forms .= '<label class="control-label">' . $this->l('New hook') . '</label>';
-                $forms .= '<select name="prettyblocks_hook_target" class="form-control">';
+                $forms .= '<select name="prettyblocks_hook_target" class="form-control chosen">';
                 foreach ($hookOptions as $option) {
                     $forms .= sprintf(
                         '<option value="%s">%s</option>',
@@ -548,6 +548,10 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
         $options = [];
         foreach ($hooks as $hook) {
             if (empty($hook['name'])) {
+                continue;
+            }
+
+            if (strpos($hook['name'], 'display') !== 0) {
                 continue;
             }
 


### PR DESCRIPTION
### Motivation
- Restrict the bulk hook-change dropdown to display-only hooks and make the select easier to search via a CSS helper class.

### Description
- Add the `chosen` CSS class to the bulk hook select (`prettyblocks_hook_target`) and update `getAvailableHookOptions()` to only include hooks whose `name` starts with `display`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a554f5dc88322af3e2d4fedb12091)