### PR TITLE
Mega menu: full-width dropdown, smart link layouts and CSS variable cleanup

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -85,6 +85,17 @@
     z-index: var(--everblock-megamenu-dropdown-zindex);
 }
 
+.everblock-megamenu .dropdown {
+    position: static;
+}
+
+.everblock-megamenu .dropdown-menu.everblock-megamenu-dropdown {
+    left: 0;
+    right: 0;
+    width: auto;
+    min-width: 100%;
+}
+
 .everblock-megamenu-item > .everblock-megamenu-item-link,
 .everblock-megamenu-item > .everblock-megamenu-item-link.btn,
 .everblock-megamenu-title,
@@ -125,6 +136,11 @@
     padding: 1.5rem 0;
 }
 
+.everblock-megamenu .everblock-megamenu-dropdown .container,
+.everblock-megamenu .everblock-megamenu-dropdown .container-fluid {
+    width: 100%;
+}
+
 .everblock-megamenu .everblock-megamenu-icon {
     font-size: 0.9em;
     line-height: 1;
@@ -148,9 +164,22 @@
 }
 
 .everblock-megamenu .dropdown-megamenu-links--grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 0.5rem;
+    --bs-gutter-x: 0.75rem;
+    --bs-gutter-y: 0.5rem;
+}
+
+.everblock-megamenu .dropdown-megamenu-links--grid .dropdown-item {
+    width: auto;
+}
+
+.everblock-megamenu .dropdown-megamenu-links--grid .dropdown-item.col-6 {
+    width: 50%;
+}
+
+@media (min-width: 768px) {
+    .everblock-megamenu .dropdown-megamenu-links--grid .dropdown-item.col-md-4 {
+        width: 33.3333%;
+    }
 }
 
 @media (max-width: 991.98px) {

--- a/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl
+++ b/views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl
@@ -26,7 +26,8 @@
     {assign var='text_color' value=$text_color|@reset}
   {/if}
 {/if}
-{if $text_color}
+{assign var='text_color' value=$text_color|trim}
+{if $text_color && $text_color|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-text:'|cat:$text_color|cat:';'}
 {/if}
 
@@ -38,7 +39,8 @@
     {assign var='text_color_winter' value=$text_color_winter|@reset}
   {/if}
 {/if}
-{if $text_color_winter}
+{assign var='text_color_winter' value=$text_color_winter|trim}
+{if $text_color_winter && $text_color_winter|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-text-winter:'|cat:$text_color_winter|cat:';'}
 {/if}
 
@@ -50,7 +52,8 @@
     {assign var='background_color' value=$background_color|@reset}
   {/if}
 {/if}
-{if $background_color}
+{assign var='background_color' value=$background_color|trim}
+{if $background_color && $background_color|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-bg:'|cat:$background_color|cat:';'}
 {/if}
 
@@ -62,7 +65,8 @@
     {assign var='background_color_winter' value=$background_color_winter|@reset}
   {/if}
 {/if}
-{if $background_color_winter}
+{assign var='background_color_winter' value=$background_color_winter|trim}
+{if $background_color_winter && $background_color_winter|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-bg-winter:'|cat:$background_color_winter|cat:';'}
 {/if}
 
@@ -74,7 +78,8 @@
     {assign var='hover_text_color' value=$hover_text_color|@reset}
   {/if}
 {/if}
-{if $hover_text_color}
+{assign var='hover_text_color' value=$hover_text_color|trim}
+{if $hover_text_color && $hover_text_color|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-hover-text:'|cat:$hover_text_color|cat:';'}
 {/if}
 
@@ -86,7 +91,8 @@
     {assign var='hover_background_color' value=$hover_background_color|@reset}
   {/if}
 {/if}
-{if $hover_background_color}
+{assign var='hover_background_color' value=$hover_background_color|trim}
+{if $hover_background_color && $hover_background_color|lower != 'color'}
   {assign var='style_vars' value=$style_vars|cat:'--everblock-megamenu-hover-bg:'|cat:$hover_background_color|cat:';'}
 {/if}
 

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl
@@ -35,7 +35,7 @@
     {assign var='column_width' value=12}
   {/if}
   {assign var='render_title' value=$render_title|default:true}
-  {assign var='link_layout' value=$block.settings.link_layout|default:'stacked'}
+  {assign var='link_layout' value=$block.settings.link_layout|default:''}
   {if is_array($link_layout)}
     {if isset($link_layout[$language.id_lang])}
       {assign var='link_layout' value=$link_layout[$language.id_lang]}
@@ -43,12 +43,22 @@
       {assign var='link_layout' value=$link_layout|@reset}
     {/if}
   {/if}
-  {assign var='link_layout' value=$link_layout|default:'stacked'}
+  {assign var='link_layout' value=$link_layout|default:''}
+  {if !$link_layout}
+    {assign var='links_count' value=$block.extra.links|@count}
+    {if $links_count > 6}
+      {assign var='link_layout' value='grid'}
+    {elseif $links_count > 1}
+      {assign var='link_layout' value='inline'}
+    {else}
+      {assign var='link_layout' value='stacked'}
+    {/if}
+  {/if}
   {assign var='link_layout_class' value='dropdown-megamenu-links--stacked'}
   {if $link_layout == 'inline'}
     {assign var='link_layout_class' value='dropdown-megamenu-links--inline'}
   {elseif $link_layout == 'grid'}
-    {assign var='link_layout_class' value='dropdown-megamenu-links--grid'}
+    {assign var='link_layout_class' value='dropdown-megamenu-links--grid row g-2'}
   {/if}
   {assign var='obfme_class' value=''}
   {if $page.page_name|default:'' != 'index'}
@@ -82,7 +92,7 @@
     {if $block.extra.links}
       <div class="dropdown-megamenu-links {$link_layout_class} mb-3">
         {foreach from=$block.extra.links item=item}
-          {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl' block=$item from_parent=true}
+          {include file='module:everblock/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl' block=$item from_parent=true link_layout=$link_layout}
         {/foreach}
       </div>
     {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl
@@ -42,7 +42,7 @@
     {assign var='obfme_class' value=' obfme'}
   {/if}
   {if $link_label && $link_url}
-    <a class="dropdown-item d-flex align-items-center gap-2 everblock-megamenu-link{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}" title="{$link_title|escape:'htmlall':'UTF-8'}"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
+    <a class="dropdown-item d-flex align-items-center gap-2 everblock-megamenu-link{$obfme_class}{if $block.settings.highlight} fw-semibold{/if}{if $link_layout|default:'' == 'grid'} col-6 col-md-4{/if}" href="{$link_url|escape:'htmlall':'UTF-8'}" title="{$link_title|escape:'htmlall':'UTF-8'}"{if $megamenu_style_vars} style="{$megamenu_style_vars|escape:'htmlall':'UTF-8'}"{/if}>
       {if $link_icon}<span class="everblock-megamenu-icon">{$link_icon|escape:'htmlall':'UTF-8'}</span>{/if}
       <span>{$link_label|escape:'htmlall':'UTF-8'}</span>
     </a>


### PR DESCRIPTION
### Motivation
- Fix visual and HTML issues in the Prettyblocks Mega Menu so the dropdown uses the available width, columns can be side-by-side or displayed in inline/grid modes, no empty `style=""` attributes are emitted, CSS variables are valid and desktop/mobile rendering is consistent.

### Description
- Update CSS to expand the dropdown to the full menu width by making `.everblock-megamenu .dropdown` static and adding rules for `.everblock-megamenu .dropdown-menu.everblock-megamenu-dropdown` and container sizing (`views/css/everblock.css`).
- Replace the old grid declaration with a Bootstrap-friendly gutter approach and add responsive helper widths for items in grid mode (`views/css/everblock.css`).
- Add a smarter default `link_layout` in the column template that chooses between `stacked`, `inline` and `grid` based on the number of links, and pass the chosen `link_layout` down to link items so grid cells receive `col-6 col-md-4` classes (`views/templates/hook/prettyblocks/prettyblock_megamenu_column.tpl`, `views/templates/hook/prettyblocks/prettyblock_megamenu_item_link.tpl`).
- Sanitize and `trim` color inputs and ignore placeholder values like `color` when composing inline CSS variables so invalid or empty variables are not injected (`views/templates/hook/prettyblocks/_partials/megamenu_style_vars.tpl`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a585716808322a810bd9db9ecd275)