### PR TITLE
Replace megamenu accordion heading tag with class

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl
@@ -68,11 +68,11 @@
                 {/if}
               {/if}
               <div class="accordion-item">
-                <h2 class="accordion-header" id="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
+                <div class="accordion-header h2" id="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
                   <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" aria-expanded="false" aria-controls="everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
                     {$column_title|escape:'htmlall':'UTF-8'}
                   </button>
-                </h2>
+                </div>
                 <div id="everblock-megamenu-collapse-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}" class="accordion-collapse collapse" aria-labelledby="everblock-megamenu-heading-{$block.id_prettyblocks}-{$smarty.foreach.mobile_columns.iteration}">
                   <div class="accordion-body">
                     <div class="row g-3">


### PR DESCRIPTION
### Motivation
- Remove semantic heading usage inside the mobile megamenu accordion and rely on CSS classes (e.g. `.h2`) for visual styling to avoid introducing heading levels in menu templates.

### Description
- In `views/templates/hook/prettyblocks/prettyblock_megamenu_item.tpl` replaced the `<h2 class="accordion-header" ...>` wrapper with a `<div class="accordion-header h2" ...>` to keep Bootstrap accordion behavior while using a non-heading element for styling.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5d9671688322b18e117bf4e4e724)