### PR TITLE
Add Custom Code prettyblock and render content without escaping

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -169,6 +169,7 @@ class EverblockPrettyBlocks
             $buttonTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_button.tpl';
             $gmapTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_gmap.tpl';
             $customIframeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_custom_iframe.tpl';
+            $customCodeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl';
             $shortcodeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_shortcode.tpl';
             $iframeTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_iframe.tpl';
             $scrollVideoTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_scroll_video.tpl';
@@ -2259,6 +2260,32 @@ class EverblockPrettyBlocks
                             'type' => 'text',
                             'label' => $module->l('Loading attribute (like lazy)'),
                             'default' => 'lazy',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+
+            $blocks[] = [
+                'name' => $module->l('Custom code'),
+                'description' => $module->l('Display JSON-like code snippet'),
+                'code' => 'everblock_custom_code',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $customCodeTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'code' => [
+                            'type' => 'textarea',
+                            'label' => $module->l('Code'),
+                            'default' => "{\n  \"message\": \"Hello\"\n}",
                         ],
                         'css_class' => [
                             'type' => 'text',

--- a/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
@@ -1,0 +1,43 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+
+<div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}">
+  {if $block.settings.default.force_full_width}
+    <div class="row gx-0 no-gutters">
+  {elseif $block.settings.default.container}
+    <div class="row">
+  {/if}
+
+<div class="{if $block.settings.default.container}container{/if}" style="{$prettyblock_spacing_style}">
+  {if $block.settings.default.container}
+    <div class="row">
+  {/if}
+    <div class="col-12">
+      <pre class="prettyblock-custom-code {$block.settings.css_class|nofilter}"><code>{$block.settings.code|nofilter}</code></pre>
+    </div>
+  {if $block.settings.default.container}
+    </div>
+  {/if}
+</div>
+
+  {if $block.settings.default.force_full_width || $block.settings.default.container}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
### Motivation
- Add a dedicated prettyblock to allow editors to embed raw, JSON-like code snippets in content blocks. 
- Ensure the code and any custom CSS class are output verbatim so formatting and indentation are preserved. 
- Provide a simple default example and spacing controls so the block integrates with existing layout options. 

### Description
- Register a new template variable `customCodeTemplate` in `getEverPrettyBlocks` and add a new block entry for `everblock_custom_code` with UI `textarea` `code` and optional `css_class` fields. 
- Add the template file `views/templates/hook/prettyblocks/prettyblock_custom_code.tpl` that renders the block structure and includes spacing/visibility partials. 
- Render the `code` and `css_class` using Smarty `|nofilter` so content is not HTML-escaped and original formatting is preserved. 
- Include a small default JSON example (`{"message": "Hello"}`) and wire the block into the module templates list. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4789ed988322b7efeb08d3eb518b)