### PR TITLE
Fix Everblock WP button CSS

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3085,7 +3085,8 @@
 /* ---- BOUTON ---- */
 .everblock-wp-section .btn-warning {
   background-color: #f28c3a;
-  border
+  border: 0;
+}
 
 /* Prettyblock FAQ */
 .everblock-prettyblock-iframe {


### PR DESCRIPTION
### Motivation
- Fix invalid CSS in `views/css/everblock.css` where the `.everblock-wp-section .btn-warning` rule was left incomplete, causing a syntax error and potential styling issues.

### Description
- Complete the `.everblock-wp-section .btn-warning` rule by adding `border: 0;` and the missing closing brace in `views/css/everblock.css`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4a81eebc83228d061c4161dd6d52)