### PR TITLE
Remove caching from everPresentProducts

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4827,78 +4827,64 @@ class EverblockTools extends ObjectModel
 
     public static function everPresentProducts(array $result, Context $context): array
     {
-        $resultHash = md5(json_encode($result));
-        $cacheId = 'everblock_everPresentProducts_'
-            . (int) $context->shop->id
-            . '_'
-            . (int) $context->language->id
-            . '_'
-            . $resultHash;
-
         $products = [];
 
-        if (!EverblockCache::isCacheStored($cacheId)) {
-            if (!empty($result)) {
-                $assembler = new \ProductAssembler($context);
-                $presenterFactory = new \ProductPresenterFactory($context);
-                $presentationSettings = $presenterFactory->getPresentationSettings();
+        if (!empty($result)) {
+            $assembler = new \ProductAssembler($context);
+            $presenterFactory = new \ProductPresenterFactory($context);
+            $presentationSettings = $presenterFactory->getPresentationSettings();
 
-                // compatibilité PS 8 et PS 9
-                if (class_exists(\PrestaShop\PrestaShop\Core\Product\ProductListingPresenter::class)) {
-                    // PS 1.7 / 8
-                    $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
-                        new ImageRetriever($context->link),
-                        $context->link,
-                        new PriceFormatter(),
-                        new ProductColorsRetriever(),
-                        $context->getTranslator()
-                    );
-                } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter::class)) {
-                    // PS 9
-                    $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter(
-                        new ImageRetriever($context->link),
-                        $context->link,
-                        new PriceFormatter(),
-                        new ProductColorsRetriever(),
-                        $context->getTranslator()
-                    );
-                } else {
-                    throw new \Exception('No suitable product presenter class found for this PrestaShop version.');
-                }
-
-
-                $presentationSettings->showPrices = true;
-
-                foreach ($result as $productId) {
-                    $psProduct = new Product((int) $productId);
-
-                    if (!Validate::isLoadedObject($psProduct) || !(bool) $psProduct->active) {
-                        continue;
-                    }
-
-                    $rawProduct = [
-                        'id_product' => $productId,
-                        'id_lang'   => $context->language->id,
-                        'id_shop'   => $context->shop->id,
-                    ];
-
-                    $pproduct = $assembler->assembleProduct($rawProduct);
-
-                    if (Product::checkAccessStatic((int) $productId, (int) $context->customer->id)) {
-                        $products[] = $presenter->present(
-                            $presentationSettings,
-                            $pproduct,
-                            $context->language
-                        );
-                    }
-                }
+            // compatibilité PS 8 et PS 9
+            if (class_exists(\PrestaShop\PrestaShop\Core\Product\ProductListingPresenter::class)) {
+                // PS 1.7 / 8
+                $presenter = new \PrestaShop\PrestaShop\Core\Product\ProductListingPresenter(
+                    new ImageRetriever($context->link),
+                    $context->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $context->getTranslator()
+                );
+            } elseif (class_exists(\PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter::class)) {
+                // PS 9
+                $presenter = new \PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter(
+                    new ImageRetriever($context->link),
+                    $context->link,
+                    new PriceFormatter(),
+                    new ProductColorsRetriever(),
+                    $context->getTranslator()
+                );
+            } else {
+                throw new \Exception('No suitable product presenter class found for this PrestaShop version.');
             }
 
-            EverblockCache::cacheStore($cacheId, $products);
-            return $products;
+            $presentationSettings->showPrices = true;
+
+            foreach ($result as $productId) {
+                $psProduct = new Product((int) $productId);
+
+                if (!Validate::isLoadedObject($psProduct) || !(bool) $psProduct->active) {
+                    continue;
+                }
+
+                $rawProduct = [
+                    'id_product' => $productId,
+                    'id_lang'   => $context->language->id,
+                    'id_shop'   => $context->shop->id,
+                ];
+
+                $pproduct = $assembler->assembleProduct($rawProduct);
+
+                if (Product::checkAccessStatic((int) $productId, (int) $context->customer->id)) {
+                    $products[] = $presenter->present(
+                        $presentationSettings,
+                        $pproduct,
+                        $context->language
+                    );
+                }
+            }
         }
 
-        return EverblockCache::cacheRetrieve($cacheId);
+        return $products;
     }
     public static function dropUnusedLangs(): array
     {


### PR DESCRIPTION
### Motivation
- Ensure `everPresentProducts` always returns freshly computed product presentations to avoid serving stale cached data.
- The change simplifies the function by removing cache-related branches and relying on live assembly/presentation of products.

### Description
- Modified `src/Service/EverblockTools.php` to remove cache key construction (`$resultHash`, `$cacheId`) and all `EverblockCache` calls from `everPresentProducts`.
- Kept the existing presenter selection logic for PrestaShop 8/9 compatibility and the product assembly/presentation flow using `ProductAssembler` and the presenter.
- The function now always iterates over input product IDs, assembles and presents accessible active products, and returns the resulting array directly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faa81fe0083229a9db49f219837fb)