### PR TITLE
Make WordPress posts slider optional

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -113,6 +113,7 @@ class Everblock extends Module
         Configuration::updateValue('EVERWP_BLOG_URL', '/blog');
         Configuration::updateValue('EVERWP_POST_NBR', 3);
         Configuration::updateValue('EVERWP_POSTS_BG_IMAGE', '');
+        Configuration::updateValue('EVERWP_POSTS_SLIDER_ENABLED', 1);
         Configuration::updateValue('EVER_SOLDOUT_COLOR', '#ff0000');
         Configuration::updateValue('EVER_SOLDOUT_TEXTCOLOR', '#ffffff');
         Configuration::updateValue('EVERINSTA_SHOW_CAPTION', 0);
@@ -253,6 +254,7 @@ class Everblock extends Module
         Configuration::deleteByName('EVERWP_BLOG_URL');
         Configuration::deleteByName('EVERWP_POST_NBR');
         Configuration::deleteByName('EVERWP_POSTS_BG_IMAGE');
+        Configuration::deleteByName('EVERWP_POSTS_SLIDER_ENABLED');
         Configuration::deleteByName('EVER_SOLDOUT_COLOR');
         Configuration::deleteByName('EVER_SOLDOUT_TEXTCOLOR');
         Configuration::deleteByName('EVERBLOCK_SOLDOUT_FLAG');
@@ -1792,6 +1794,25 @@ class Everblock extends Module
                 'name' => 'EVERWP_POST_NBR',
             ],
             [
+                'type' => 'switch',
+                'label' => $this->l('Enable WordPress posts slider'),
+                'desc' => $this->l('Enable the carousel for WordPress posts on mobile.'),
+                'name' => 'EVERWP_POSTS_SLIDER_ENABLED',
+                'is_bool' => true,
+                'values' => [
+                    [
+                        'id' => 'everwp_posts_slider_enabled_on',
+                        'value' => 1,
+                        'label' => $this->l('Enabled'),
+                    ],
+                    [
+                        'id' => 'everwp_posts_slider_enabled_off',
+                        'value' => 0,
+                        'label' => $this->l('Disabled'),
+                    ],
+                ],
+            ],
+            [
                 'type' => 'file',
                 'label' => $this->l('Background image for WordPress posts'),
                 'desc' => $this->l('Optional background image for the latest WordPress posts section.'),
@@ -2587,6 +2608,7 @@ class Everblock extends Module
             'EVERWP_BLOG_URL' => Configuration::get('EVERWP_BLOG_URL'),
             'EVERWP_POST_NBR' => Configuration::get('EVERWP_POST_NBR'),
             'EVERWP_POSTS_BG_IMAGE' => Configuration::get('EVERWP_POSTS_BG_IMAGE'),
+            'EVERWP_POSTS_SLIDER_ENABLED' => Configuration::get('EVERWP_POSTS_SLIDER_ENABLED'),
             'EVERBLOCK_GOOGLE_API_KEY' => Configuration::get('EVERBLOCK_GOOGLE_API_KEY'),
             'EVERBLOCK_GOOGLE_PLACE_ID' => Configuration::get('EVERBLOCK_GOOGLE_PLACE_ID'),
             'EVERBLOCK_GOOGLE_REVIEWS_LIMIT' => Configuration::get('EVERBLOCK_GOOGLE_REVIEWS_LIMIT'),
@@ -2779,6 +2801,7 @@ class Everblock extends Module
                 'EVERBLOCK_GOOGLE_REVIEWS_SHOW_RATING',
                 'EVERBLOCK_GOOGLE_REVIEWS_SHOW_AVATAR',
                 'EVERBLOCK_GOOGLE_REVIEWS_SHOW_CTA',
+                'EVERWP_POSTS_SLIDER_ENABLED',
             ];
             foreach ($boolFields as $boolField) {
                 $value = Tools::getValue($boolField);
@@ -2965,6 +2988,12 @@ class Everblock extends Module
         Configuration::updateValue(
             'EVERWP_POST_NBR',
             Tools::getValue('EVERWP_POST_NBR')
+        );
+        $wpPostsSliderEnabled = Tools::getValue('EVERWP_POSTS_SLIDER_ENABLED');
+        $wpPostsSliderEnabled = in_array((string) $wpPostsSliderEnabled, ['1', 'true', 'on'], true) ? 1 : 0;
+        Configuration::updateValue(
+            'EVERWP_POSTS_SLIDER_ENABLED',
+            $wpPostsSliderEnabled
         );
         $pagesBaseUrl = trim((string) Tools::getValue('EVERBLOCK_PAGES_BASE_URL'));
         if ($pagesBaseUrl === '') {

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -1140,10 +1140,15 @@ class EverblockTools extends ObjectModel
             $backgroundUrl = $context->link->getBaseLink(null, null)
                 . 'modules/' . $module->name . '/views/img/' . $backgroundImage;
         }
+        $sliderEnabled = Configuration::get('EVERWP_POSTS_SLIDER_ENABLED');
+        if ($sliderEnabled === false) {
+            $sliderEnabled = true;
+        }
         $context->smarty->assign([
             'everblock_wp_posts' => $storedPosts,
             'everblock_wp_blog_url' => Configuration::get('EVERWP_BLOG_URL') ?: '/blog',
             'everblock_wp_background_image' => $backgroundUrl,
+            'everblock_wp_posts_slider_enabled' => (bool) $sliderEnabled,
         ]);
 
         foreach ($matches as $match) {

--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -6,61 +6,64 @@
 
   {assign var='carouselId' value='everblock-wp-posts-carousel-'|cat:mt_rand(1000,999999)}
   <div class="everblock-wp-posts container">
-    <div id="{$carouselId}"
-         class="ever-cover-carousel ever-bootstrap-carousel d-md-none"
-         data-items="1"
-         data-layout="cover"
-         data-controls="true"
-         data-indicators="true"
-         data-infinite="1">
-      {foreach from=$everblock_wp_posts item=post}
-        <div class="everblock-wp-posts__slide">
-          <div class="card blog-card flex-fill border-0 shadow-sm rounded-4 h-100 overflow-hidden">
-            {if $post.featured_image}
-              <div class="blog-image-wrapper overflow-hidden">
-                <a href="{$post.link|escape:'htmlall':'UTF-8'}"
-                   target="_blank"
-                   rel="noopener"
-                   title="{$post.title|escape:'htmlall':'UTF-8'}">
-                  <img src="{$post.featured_image|escape:'htmlall':'UTF-8'}"
-                       width="{$post.featured_image_width|intval}"
-                       height="{$post.featured_image_height|intval}"
-                       loading="lazy"
-                       alt="{$post.title|escape:'htmlall':'UTF-8'}"
-                       class="card-img-top img-fluid" />
-                </a>
-              </div>
-            {/if}
-
-            <div class="card-body d-flex flex-column justify-content-between text-start p-3">
-              <div>
-                <div class="h5 fw-bold fs-6 mb-2 text-dark blog-title position-relative">
+    {assign var='useWpSlider' value=(isset($everblock_wp_posts_slider_enabled) && $everblock_wp_posts_slider_enabled)}
+    {if $useWpSlider}
+      <div id="{$carouselId}"
+           class="ever-cover-carousel ever-bootstrap-carousel d-md-none"
+           data-items="1"
+           data-layout="cover"
+           data-controls="true"
+           data-indicators="true"
+           data-infinite="1">
+        {foreach from=$everblock_wp_posts item=post}
+          <div class="everblock-wp-posts__slide">
+            <div class="card blog-card flex-fill border-0 shadow-sm rounded-4 h-100 overflow-hidden">
+              {if $post.featured_image}
+                <div class="blog-image-wrapper overflow-hidden">
                   <a href="{$post.link|escape:'htmlall':'UTF-8'}"
                      target="_blank"
                      rel="noopener"
-                     title="{$post.title|escape:'htmlall':'UTF-8'}"
-                     class="text-dark text-decoration-none">
-                    {$post.title|escape:'htmlall':'UTF-8'}
+                     title="{$post.title|escape:'htmlall':'UTF-8'}">
+                    <img src="{$post.featured_image|escape:'htmlall':'UTF-8'}"
+                         width="{$post.featured_image_width|intval}"
+                         height="{$post.featured_image_height|intval}"
+                         loading="lazy"
+                         alt="{$post.title|escape:'htmlall':'UTF-8'}"
+                         class="card-img-top img-fluid" />
                   </a>
                 </div>
-                <div class="card-divider mb-2"></div>
-                <p class="card-text text-muted small mb-0 line-clamp-5">
-                  <a href="{$post.link|escape:'htmlall':'UTF-8'}"
-                     target="_blank"
-                     rel="noopener"
-                     title="{$post.title|escape:'htmlall':'UTF-8'}"
-                     class="text-muted text-decoration-none">
-                    {$post.excerpt|strip_tags|truncate:100:'…'|escape:'htmlall':'UTF-8'}
-                  </a>
-                </p>
+              {/if}
+
+              <div class="card-body d-flex flex-column justify-content-between text-start p-3">
+                <div>
+                  <div class="h5 fw-bold fs-6 mb-2 text-dark blog-title position-relative">
+                    <a href="{$post.link|escape:'htmlall':'UTF-8'}"
+                       target="_blank"
+                       rel="noopener"
+                       title="{$post.title|escape:'htmlall':'UTF-8'}"
+                       class="text-dark text-decoration-none">
+                      {$post.title|escape:'htmlall':'UTF-8'}
+                    </a>
+                  </div>
+                  <div class="card-divider mb-2"></div>
+                  <p class="card-text text-muted small mb-0 line-clamp-5">
+                    <a href="{$post.link|escape:'htmlall':'UTF-8'}"
+                       target="_blank"
+                       rel="noopener"
+                       title="{$post.title|escape:'htmlall':'UTF-8'}"
+                       class="text-muted text-decoration-none">
+                      {$post.excerpt|strip_tags|truncate:100:'…'|escape:'htmlall':'UTF-8'}
+                    </a>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      {/foreach}
-    </div>
+        {/foreach}
+      </div>
+    {/if}
 
-    <div class="row justify-content-center align-items-stretch d-none d-md-flex">
+    <div class="row justify-content-center align-items-stretch{if $useWpSlider} d-none d-md-flex{/if}">
       {foreach from=$everblock_wp_posts item=post}
         <div class="col-12 col-sm-6 col-md-4 mb-4 d-flex">
           <div class="card blog-card flex-fill border-0 shadow-sm rounded-4 h-100 overflow-hidden">


### PR DESCRIPTION
### Motivation
- Provide an option to disable the mobile carousel for the WordPress posts section so it can render as a static grid instead of an automatic slider.

### Description
- Added a new boolean configuration `EVERWP_POSTS_SLIDER_ENABLED` with default enabled during `install()` and removed on `uninstall()` in `everblock.php`.
- Exposed a new admin form input `EVERWP_POSTS_SLIDER_ENABLED` (switch) and included the key in the module `configData` so it is editable in the configuration UI in `everblock.php`.
- Validated and persisted the new setting in `postValidation()` and `postProcess()` using `Tools::getValue()` and `Configuration::updateValue()` in `everblock.php`.
- Passed the resolved slider flag to templates via Smarty as `everblock_wp_posts_slider_enabled` in `src/Service/EverblockTools.php`, with a sensible fallback when the config is missing.
- Updated the WordPress posts template `views/templates/hook/generated_wp_posts.tpl` to render the mobile carousel only when `everblock_wp_posts_slider_enabled` is true and to fall back to the responsive grid layout otherwise.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697087b601c08322a778200f31729d34)