### PR TITLE
Add GitHub release check and back-office update status display

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -36,6 +36,7 @@ use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockPrettyBlocksImportExport;
 use Everblock\Tools\Service\EverblockCache;
 use Everblock\Tools\Service\EverblockTools;
+use Everblock\Tools\Service\GithubReleaseChecker;
 use Everblock\Tools\Service\ImportFile;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -1062,6 +1063,9 @@ class Everblock extends Module
         }
         $notifications = $this->html;
         $this->html = '';
+        $releaseChecker = new GithubReleaseChecker($this->version);
+        $latestRelease = $releaseChecker->getLatestEverblockRelease();
+        $updateAvailable = $releaseChecker->isEverblockUpdateAvailable();
         $this->context->smarty->assign([
             'module_name' => $this->displayName,
             $this->name . '_version' => $this->version,
@@ -1083,6 +1087,8 @@ class Everblock extends Module
             'everblock_faq_front_link' => $faqFrontLink,
             'everblock_faq_front_tag' => $faqFrontTag,
             'everblock_all_faqs_front_link' => $faqAllFrontLink,
+            'everblock_latest_release' => $latestRelease,
+            'everblock_update_available' => $updateAvailable,
         ]);
         $output = $this->context->smarty->fetch(
             $this->local_path . 'views/templates/admin/header.tpl'

--- a/src/Service/GithubReleaseChecker.php
+++ b/src/Service/GithubReleaseChecker.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+namespace Everblock\Tools\Service;
+
+use Configuration;
+use PrestaShopLogger;
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class GithubReleaseChecker
+{
+    private const API_URL = 'https://api.github.com/repos/TeamEver/everblock/releases/latest';
+    private const CACHE_KEY = 'QCD_EVERBLOCK_LATEST_RELEASE';
+    private const CACHE_TTL = 86400;
+
+    /**
+     * @var string
+     */
+    private $moduleVersion;
+
+    /**
+     * @var array|null
+     */
+    private $latestRelease;
+
+    /**
+     * @var bool
+     */
+    private $latestReleaseLoaded = false;
+
+    public function __construct(string $moduleVersion)
+    {
+        $this->moduleVersion = $moduleVersion;
+    }
+
+    public function getLatestEverblockRelease(): ?array
+    {
+        if ($this->latestReleaseLoaded) {
+            return $this->latestRelease;
+        }
+
+        $cachedPayload = $this->getCachedPayload();
+        if ($cachedPayload && !$this->isCacheExpired($cachedPayload)) {
+            $this->latestReleaseLoaded = true;
+            $this->latestRelease = $cachedPayload['release'];
+            return $this->latestRelease;
+        }
+
+        $release = $this->fetchLatestRelease();
+        if ($release === null) {
+            if ($cachedPayload) {
+                $this->latestReleaseLoaded = true;
+                $this->latestRelease = $cachedPayload['release'];
+                return $this->latestRelease;
+            }
+
+            $this->latestReleaseLoaded = true;
+            return null;
+        }
+
+        $this->storeCache($release);
+
+        $this->latestReleaseLoaded = true;
+        $this->latestRelease = $release;
+        return $release;
+    }
+
+    public function isEverblockUpdateAvailable(): bool
+    {
+        $release = $this->getLatestEverblockRelease();
+        if (!$release || empty($release['tag_name'])) {
+            return false;
+        }
+
+        $latestVersion = $this->normalizeVersion((string) $release['tag_name']);
+        $currentVersion = $this->normalizeVersion((string) $this->moduleVersion);
+
+        if ($latestVersion === '' || $currentVersion === '') {
+            return false;
+        }
+
+        return version_compare($latestVersion, $currentVersion, '>');
+    }
+
+    private function normalizeVersion(string $version): string
+    {
+        $version = trim($version);
+        if ($version === '') {
+            return '';
+        }
+
+        return ltrim($version, 'vV');
+    }
+
+    private function getCachedPayload(): ?array
+    {
+        $cachedValue = Configuration::get(self::CACHE_KEY);
+        if (!$cachedValue) {
+            return null;
+        }
+
+        $payload = json_decode((string) $cachedValue, true);
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        if (!isset($payload['release']) || !is_array($payload['release'])) {
+            return null;
+        }
+
+        $release = $payload['release'];
+        if (empty($release['tag_name'])) {
+            return null;
+        }
+
+        if (!isset($payload['fetched_at'])) {
+            return null;
+        }
+
+        $payload['release'] = [
+            'tag_name' => (string) ($release['tag_name'] ?? ''),
+            'published_at' => (string) ($release['published_at'] ?? ''),
+            'body' => (string) ($release['body'] ?? ''),
+        ];
+
+        $payload['fetched_at'] = (int) $payload['fetched_at'];
+
+        return $payload;
+    }
+
+    private function isCacheExpired(array $payload): bool
+    {
+        if (!isset($payload['fetched_at'])) {
+            return true;
+        }
+
+        return (time() - (int) $payload['fetched_at']) > self::CACHE_TTL;
+    }
+
+    private function fetchLatestRelease(): ?array
+    {
+        $headers = [
+            'User-Agent: EverblockModule/' . $this->moduleVersion,
+            'Accept: application/vnd.github+json',
+        ];
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => 5,
+                'header' => implode("\r\n", $headers),
+            ],
+        ]);
+
+        $response = @file_get_contents(self::API_URL, false, $context);
+        if ($response === false) {
+            PrestaShopLogger::addLog('Everblock: unable to reach GitHub API for latest release.');
+            return null;
+        }
+
+        $payload = json_decode($response, true);
+        if (!is_array($payload)) {
+            PrestaShopLogger::addLog('Everblock: invalid GitHub response for latest release.');
+            return null;
+        }
+
+        $tagName = (string) ($payload['tag_name'] ?? '');
+        if ($tagName === '') {
+            return null;
+        }
+
+        return [
+            'tag_name' => $tagName,
+            'published_at' => (string) ($payload['published_at'] ?? ''),
+            'body' => (string) ($payload['body'] ?? ''),
+        ];
+    }
+
+    private function storeCache(array $release): void
+    {
+        $payload = [
+            'fetched_at' => time(),
+            'release' => [
+                'tag_name' => (string) ($release['tag_name'] ?? ''),
+                'published_at' => (string) ($release['published_at'] ?? ''),
+                'body' => (string) ($release['body'] ?? ''),
+            ],
+        ];
+
+        Configuration::updateValue(self::CACHE_KEY, json_encode($payload));
+    }
+}

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -68,6 +68,37 @@
 
     <div class="everblock-config__layout">
         <div class="everblock-config__main">
+            <div class="everblock-config__card everblock-config__card--update">
+                <h3 class="everblock-config__card-title">{l s='Module update' mod='everblock'}</h3>
+                <ul class="everblock-config__card-list">
+                    <li>
+                        <strong>{l s='Installed version' mod='everblock'}:</strong>
+                        {$everblock_version|escape:'htmlall':'UTF-8'}
+                    </li>
+                    <li>
+                        <strong>{l s='Latest GitHub version' mod='everblock'}:</strong>
+                        {if isset($everblock_latest_release.tag_name) && $everblock_latest_release.tag_name}
+                            {$everblock_latest_release.tag_name|escape:'htmlall':'UTF-8'}
+                        {else}
+                            {l s='Unavailable' mod='everblock'}
+                        {/if}
+                    </li>
+                    <li>
+                        <strong>{l s='Status' mod='everblock'}:</strong>
+                        {if isset($everblock_update_available) && $everblock_update_available}
+                            {l s='An update is available' mod='everblock'}
+                        {else}
+                            {l s='Your module is up to date' mod='everblock'}
+                        {/if}
+                    </li>
+                </ul>
+                {if isset($everblock_latest_release.published_at) && $everblock_latest_release.published_at}
+                    <p class="everblock-config__card-meta">
+                        {l s='Published on' mod='everblock'}:
+                        {$everblock_latest_release.published_at|escape:'htmlall':'UTF-8'}
+                    </p>
+                {/if}
+            </div>
             {if isset($everblock_form)}
                 <div class="everblock-config__card everblock-config__card--form">
                     {$everblock_form nofilter}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, cached mechanism to detect when a newer Everblock release is available on GitHub without impacting BO performance or adding dependencies.
- Surface the installed version and latest GitHub release information in the module configuration page so admins can see update status at a glance.

### Description
- Added a dedicated service `src/Service/GithubReleaseChecker.php` implementing `getLatestEverblockRelease(): ?array` and `isEverblockUpdateAvailable(): bool`, with internal instance caching to avoid duplicate calls.
- The checker calls the GitHub API using native PHP (`file_get_contents` with a stream context), sets a `User-Agent`, uses a 5s timeout, returns `null` on failure, logs failures via `PrestaShopLogger`, and normalizes `vX.Y.Z` tags for `version_compare`.
- Cached API payloads are stored in PrestaShop `Configuration` under the key `QCD_EVERBLOCK_LATEST_RELEASE` as JSON with a 24h TTL, and the service will fall back to stale cache or return `null` if GitHub is unavailable.
- Integrated the service into the module BO flow by instantiating `GithubReleaseChecker` in `getContent()` (passing ` $this->version`) and assigning `everblock_latest_release` and `everblock_update_available` to Smarty; added a small configuration card in `views/templates/admin/configure.tpl` to display installed version, latest GitHub tag, published date and a status message.

### Testing
- No automated tests were executed in this rollout (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d5bf31a08322b466f79dc51796a4)