### PR TITLE
Add GithubReleaseChecker to allowed files list

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -104,6 +104,7 @@ return [
     'src/Service/EverblockPrettyBlocks.php',
     'src/Service/EverblockPreviewBuilder.php',
     'src/Service/EverblockTools.php',
+    'src/Service/GithubReleaseChecker.php',
     'src/Service/ImportFile.php',
     'src/Service/ShortcodeDocumentationProvider.php',
     'src/Service/EverblockPrettyBlocksImportExport.php',


### PR DESCRIPTION
### Motivation
- Ensure the new `src/Service/GithubReleaseChecker.php` service is present in the project's allowed files list so it is recognized by file allowlisting.

### Description
- Added the entry `'src/Service/GithubReleaseChecker.php'` to `config/allowed_files.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d9557d5483229ef25e94cc72c0a1)