### PR TITLE
Ensure Everblock tables exist before block registration

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5090,6 +5090,7 @@ class Everblock extends Module
 
     public function hookActionRegisterBlock($params)
     {
+        EverblockTools::checkAndFixDatabase();
         return EverblockPrettyBlocks::getEverPrettyBlocks($this->context);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent fatal SQL errors such as missing `everblock_page` table when prettyblocks are registered via `hookActionRegisterBlock`.

### Description
- Add a call to `EverblockTools::checkAndFixDatabase()` at the start of `hookActionRegisterBlock` in `everblock.php` so tables and columns are verified/created before calling `EverblockPrettyBlocks::getEverPrettyBlocks()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fb90e8608322832c6876a1c6994f)