### PR TITLE
Fix Smarty nofilter usage in prettyblock_custom_code.tpl

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
@@ -30,7 +30,7 @@
     <div class="row">
   {/if}
     <div class="col-12">
-      <pre class="prettyblock-custom-code {$block.settings.css_class|nofilter}"><code>{$block.settings.code|nofilter}</code></pre>
+      <pre class="prettyblock-custom-code {$block.settings.css_class nofilter}"><code>{$block.settings.code nofilter}</code></pre>
     </div>
   {if $block.settings.default.container}
     </div>


### PR DESCRIPTION
### Motivation
- Fix a Smarty template syntax error caused by using the `nofilter` modifier with pipe syntax which produced an "unknown modifier 'nofilter'" error at render time.

### Description
- Replace `{$block.settings.css_class|nofilter}` and `{$block.settings.code|nofilter}` with the correct Smarty flag syntax `{$block.settings.css_class nofilter}` and `{$block.settings.code nofilter}` in `views/templates/hook/prettyblocks/prettyblock_custom_code.tpl`.

### Testing
- No automated tests were run because this is a template-only syntax fix and the change was validated by updating and committing the template file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720731ad5c83229b0cb33117ed1dfd)