### PR TITLE
Render PrettyBlocks custom code as raw output (remove pre/code wrapper)

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_custom_code.tpl
@@ -30,7 +30,9 @@
     <div class="row">
   {/if}
     <div class="col-12">
-      <pre class="prettyblock-custom-code {$block.settings.css_class nofilter}"><code>{$block.settings.code nofilter}</code></pre>
+      <div class="prettyblock-custom-code {$block.settings.css_class nofilter}">
+        {$block.settings.code nofilter}
+      </div>
     </div>
   {if $block.settings.default.container}
     </div>


### PR DESCRIPTION
### Motivation
- Make custom PrettyBlocks code blocks render their content directly instead of being displayed as preformatted text so embedded HTML or scripts can be interpreted by the page.

### Description
- Replace the `<pre><code>` wrapper with a simple container and output `{$block.settings.code nofilter}` directly in `views/templates/hook/prettyblocks/prettyblock_custom_code.tpl`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972084cda648322b8abf5a23c24e1dc)