### PR TITLE
Add vanilla everblock slider frontend and allow script

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -226,6 +226,7 @@ return [
     'views/js/custom.js',
     'views/js/everblock-obfuscation.js',
     'views/js/everblock.js',
+    'views/js/everblock-slider.js',
     'views/js/index.php',
     'views/js/product-faq.js',
     'views/js/product-modal.js',

--- a/everblock.php
+++ b/everblock.php
@@ -4983,6 +4983,11 @@ class Everblock extends Module
             'modules/' . $this->name . '/views/js/' . $this->name . '.js',
             ['position' => 'bottom', 'priority' => 200]
         );
+        $this->context->controller->registerJavascript(
+            'module-' . $this->name . '-slider-js',
+            'modules/' . $this->name . '/views/js/everblock-slider.js',
+            ['position' => 'bottom', 'priority' => 200]
+        );
         if ((bool) EverblockCache::getModuleConfiguration('EVERBLOCK_USE_OBF') === true) {
             $this->context->controller->registerJavascript(
                 'module-' . $this->name . '-obf-js',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1041,6 +1041,39 @@
         opacity var(--prettyblocks-transition-speed, 600ms) ease-in-out;
 }
 
+/* Simple image slider (vanilla) */
+.ever-slider-track {
+    transition: transform 0.4s ease;
+    will-change: transform;
+}
+
+.ever-slider-button {
+    z-index: 2;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ever-slider-dots {
+    gap: 0.5rem;
+}
+
+.ever-slider-dot {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 999px;
+    border: 0;
+    background-color: rgba(0, 0, 0, 0.25);
+    transition: background-color 0.2s ease;
+}
+
+.ever-slider-dot.is-active {
+    background-color: rgba(0, 0, 0, 0.6);
+}
+
 @media (max-width: 767.98px) {
     .prettyblocks-image-slider-wrapper {
         padding-left: 0.5rem;

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -56,12 +56,16 @@
 {/if}
 {assign var=gapSetting value=$block.settings.gap|default:'medium'}
 {assign var=gapClass value='g-3'}
+{assign var=sliderGapClass value='gap-3'}
 {if $gapSetting == 'none'}
   {assign var=gapClass value='g-0'}
+  {assign var=sliderGapClass value='gap-0'}
 {elseif $gapSetting == 'small'}
   {assign var=gapClass value='g-2'}
+  {assign var=sliderGapClass value='gap-2'}
 {elseif $gapSetting == 'large'}
   {assign var=gapClass value='g-4'}
+  {assign var=sliderGapClass value='gap-4'}
 {/if}
 {assign var=baseItemClass value='position-relative overflow-hidden'}
 {assign var=layoutItemClass value="{$baseItemClass} {$colMobileClass} {$colTabletClass} {$colDesktopClass}"}
@@ -90,15 +94,14 @@
   {/foreach}
   {assign var='use_slider' value=($displayMode == 'slider' && $visibleStatesCount > 1)}
   {if $use_slider}
-    <div class="mt-4 ever-cover-carousel ever-bootstrap-carousel"
+    <div class="mt-4 ever-slider overflow-hidden position-relative"
          data-items="{$block.settings.slider_items|default:3|escape:'htmlall':'UTF-8'}"
+         data-items-tablet="{$block.settings.columns_tablet|default:1|escape:'htmlall':'UTF-8'}"
          data-items-mobile="{$block.settings.columns_mobile|default:1|escape:'htmlall':'UTF-8'}"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
          data-infinite="1"
-         data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}"
-         data-row-class="row {$gapClass} justify-content-center"
-         data-controls="true"
-         data-indicators="true">
+         data-autoplay-delay="{$block.settings.slider_autoplay_delay|default:5000|escape:'htmlall':'UTF-8'}">
+      <div class="ever-slider-track d-flex {$sliderGapClass}">
       {foreach from=$block.states item=state key=key}
         {assign var=isStateVisible value=true}
         {assign var=startDateStr value=$state.start_date|default:''}
@@ -118,9 +121,9 @@
           {/if}
         {/if}
         {if $isStateVisible}
-          {assign var=itemClass value=$layoutItemClass}
+          {assign var=itemClass value="{$baseItemClass} ever-slider-item flex-shrink-0"}
           {if $state.css_class}
-            {assign var=itemClass value="{$baseItemClass} {$state.css_class}"}
+            {assign var=itemClass value="{$baseItemClass} ever-slider-item flex-shrink-0 {$state.css_class}"}
           {/if}
           {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
           <div id="block-{$block.id_prettyblocks}-{$key}" class="{$itemClass|escape:'htmlall'}" style="
@@ -172,6 +175,14 @@
           {/if}
         {/if}
       {/foreach}
+      </div>
+      <button class="ever-slider-button ever-slider-prev btn btn-light position-absolute top-50 start-0 translate-middle-y" type="button" aria-label="{l s='Previous slide' mod='everblock'}">
+        <span aria-hidden="true">&lsaquo;</span>
+      </button>
+      <button class="ever-slider-button ever-slider-next btn btn-light position-absolute top-50 end-0 translate-middle-y" type="button" aria-label="{l s='Next slide' mod='everblock'}">
+        <span aria-hidden="true">&rsaquo;</span>
+      </button>
+      <div class="ever-slider-dots d-flex justify-content-center mt-3"></div>
     </div>
   {else}
     <div class="row mt-4 {$gapClass} justify-content-center">


### PR DESCRIPTION
### Motivation
- Restore and implement a frontend `slider` mode for the Simple Image prettyblock using vanilla JS and Bootstrap utilities so it works without external dependencies.  
- Provide a responsive, accessible and configurable slider supporting per-breakpoint items, autoplay and infinite looping.  
- Allow the new slider script to be distributed/loaded by adding it to the module allowed files list.

### Description
- Add a new vanilla slider implementation in `views/js/everblock-slider.js` that reads `data-*` attributes (`data-items`, `data-items-tablet`, `data-items-mobile`, `data-autoplay`, `data-autoplay-delay`, `data-infinite`), computes item widths, handles prev/next, dots pagination, autoplay, resize and uses `transform: translateX()` for movement.  
- Register the slider script for frontend inclusion by calling `registerJavascript` for `modules/<module>/views/js/everblock-slider.js` in `everblock.php`.  
- Add minimal styling for the slider track, controls and dots in `views/css/everblock.css` (classes like `.ever-slider-track`, `.ever-slider-button`, `.ever-slider-dot`).  
- Update `views/templates/hook/prettyblocks/prettyblock_img.tpl` to render the slider markup (`.ever-slider`, `.ever-slider-track`, `.ever-slider-item`, prev/next buttons and `.ever-slider-dots`) and wire the data attributes and gap classes for slider mode.
- Add `views/js/everblock-slider.js` to `config/allowed_files.php` so the file is whitelisted for distribution.

### Testing
- No automated tests were executed for these changes (no CI or test suite run).  
- Local manual verification steps are not included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69720aa909288322958e6801387fe2a0)