### PR TITLE
Style ever-slider active states, permanent arrows and remove dots

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1047,31 +1047,52 @@
     will-change: transform;
 }
 
-.ever-slider-button {
-    z-index: 2;
-    width: 2.5rem;
-    height: 2.5rem;
+.ever-slider-item {
+    transition: opacity 0.4s ease, filter 0.4s ease;
+    opacity: 1;
+    filter: none;
+}
+
+.ever-slider-item.is-active {
+    opacity: 1;
+    filter: none;
+}
+
+.ever-slider-item.is-inactive {
+    opacity: 0.6;
+    filter: grayscale(10%) brightness(0.95);
+}
+
+.ever-slider-prev,
+.ever-slider-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 3;
+    width: 2.75rem;
+    height: 2.75rem;
     border-radius: 999px;
+    border: 0;
+    background-color: rgba(0, 0, 0, 0.45);
+    color: #fff;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    opacity: 1;
+    transition: background-color 0.3s ease, opacity 0.3s ease;
 }
 
-.ever-slider-dots {
-    gap: 0.5rem;
+.ever-slider-prev {
+    left: 10px;
 }
 
-.ever-slider-dot {
-    width: 0.75rem;
-    height: 0.75rem;
-    border-radius: 999px;
-    border: 0;
-    background-color: rgba(0, 0, 0, 0.25);
-    transition: background-color 0.2s ease;
+.ever-slider-next {
+    right: 10px;
 }
 
-.ever-slider-dot.is-active {
-    background-color: rgba(0, 0, 0, 0.6);
+.ever-slider-prev:hover,
+.ever-slider-next:hover {
+    background-color: rgba(0, 0, 0, 0.65);
 }
 
 @media (max-width: 767.98px) {

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -65,39 +65,20 @@
         state.nextButton.disabled = state.index >= state.maxIndex;
     }
 
-    function updateDots(state) {
-        if (!state.dotsWrapper) {
-            return;
-        }
-        state.dotsWrapper.innerHTML = '';
-        if (state.pageCount <= 1) {
-            state.dotsWrapper.hidden = true;
-            return;
-        }
-        state.dotsWrapper.hidden = false;
-        for (let i = 0; i < state.pageCount; i += 1) {
-            const dot = document.createElement('button');
-            dot.type = 'button';
-            dot.className = 'ever-slider-dot';
-            dot.setAttribute('aria-label', `Aller au slide ${i + 1}`);
-            dot.dataset.index = String(i);
-            if (i === state.pageIndex) {
-                dot.classList.add('is-active');
-                dot.setAttribute('aria-current', 'true');
-            }
-            dot.addEventListener('click', () => {
-                goToPage(state, i, true);
-            });
-            state.dotsWrapper.appendChild(dot);
-        }
-    }
-
     function updateTrackPosition(state) {
         if (!state.track) {
             return;
         }
         const offset = (state.itemWidth + state.gap) * state.index;
         state.track.style.transform = `translateX(${-offset}px)`;
+    }
+
+    function updateItemStates(state) {
+        state.items.forEach((item, itemIndex) => {
+            const isActive = itemIndex === state.index;
+            item.classList.toggle('is-active', isActive);
+            item.classList.toggle('is-inactive', !isActive);
+        });
     }
 
     function updateState(state) {
@@ -119,8 +100,8 @@
         state.pageCount = state.disabled ? 1 : Math.ceil(totalItems / state.itemsPerView);
         state.pageIndex = Math.min(state.pageCount - 1, Math.round(state.index / state.itemsPerView));
         updateTrackPosition(state);
+        updateItemStates(state);
         updateButtons(state);
-        updateDots(state);
     }
 
     function clearAutoplay(state) {
@@ -155,21 +136,11 @@
         state.index = targetIndex;
         state.pageIndex = Math.min(state.pageCount - 1, Math.round(state.index / state.itemsPerView));
         updateTrackPosition(state);
+        updateItemStates(state);
         updateButtons(state);
         if (resetAutoplay) {
             startAutoplay(state);
         }
-        const dots = state.dotsWrapper ? state.dotsWrapper.querySelectorAll('.ever-slider-dot') : [];
-        dots.forEach((dot, dotIndex) => {
-            const isActive = dotIndex === state.pageIndex;
-            dot.classList.toggle('is-active', isActive);
-            dot.toggleAttribute('aria-current', isActive);
-        });
-    }
-
-    function goToPage(state, pageIndex, resetAutoplay) {
-        const targetIndex = Math.min(pageIndex * state.itemsPerView, state.maxIndex);
-        goToIndex(state, targetIndex, resetAutoplay);
     }
 
     function bindControls(state) {
@@ -193,7 +164,6 @@
         const items = Array.from(track.querySelectorAll('.ever-slider-item'));
         const prevButton = slider.querySelector('.ever-slider-prev');
         const nextButton = slider.querySelector('.ever-slider-next');
-        const dotsWrapper = slider.querySelector('.ever-slider-dots');
         const autoplay = parseNumber(slider.dataset.autoplay, 0) === 1;
         const autoplayDelay = parseNumber(slider.dataset.autoplayDelay, 5000);
         const infinite = parseNumber(slider.dataset.infinite, 0) === 1;
@@ -204,7 +174,6 @@
             items,
             prevButton,
             nextButton,
-            dotsWrapper,
             autoplay,
             autoplayDelay,
             infinite,

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -178,7 +178,6 @@
       </div>
       <button class="ever-slider-prev" type="button" aria-label="Previous"></button>
       <button class="ever-slider-next" type="button" aria-label="Next"></button>
-      <div class="ever-slider-dots"></div>
     </div>
   {else}
     {if $block.settings.default.force_full_width}


### PR DESCRIPTION
### Motivation
- Provide premium e-commerce visual finishing for the Everblock slider so the center slide is sharp and lateral slides are gently attenuated. 
- Keep existing slider logic and layout intact while exposing a simple `is-active` / `is-inactive` state to drive visuals. 

### Description
- Add CSS rules in `views/css/everblock.css` introducing `.ever-slider-item`, `.ever-slider-item.is-active` and `.ever-slider-item.is-inactive` for smooth `opacity`/`filter` transitions and permanent directional arrow styling for `.ever-slider-prev` and `.ever-slider-next`. 
- Remove dot-related styling and pagination visual clutter and ensure arrow buttons are `position:absolute`, centered vertically and above images (`z-index`).
- Update `views/js/everblock-slider.js` to remove dot generation/management and add `updateItemStates(state)` which toggles `is-active`/`is-inactive` on items, and call it from `updateState` and `goToIndex` without changing layout calculations. 
- Remove the dots container from the template `views/templates/hook/prettyblocks/prettyblock_img.tpl` so no pagination elements remain in the DOM. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972242b551c8322a020fe1f2fc4d24b)