### PR TITLE
Adjust centered Everblock slider behavior and styles

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1048,7 +1048,7 @@
 }
 
 .ever-slider-item {
-    transition: opacity 0.4s ease, filter 0.4s ease;
+    transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s ease;
     opacity: 1;
     filter: none;
 }
@@ -1059,8 +1059,13 @@
 }
 
 .ever-slider-item.is-inactive {
+    opacity: 0.4;
+    filter: brightness(0.85);
+}
+
+.ever-slider-item.is-adjacent {
     opacity: 0.6;
-    filter: grayscale(10%) brightness(0.95);
+    filter: brightness(0.9);
 }
 
 .ever-slider-prev,
@@ -1083,11 +1088,11 @@
 }
 
 .ever-slider-prev {
-    left: 10px;
+    left: -40px;
 }
 
 .ever-slider-next {
-    right: 10px;
+    right: -40px;
 }
 
 .ever-slider-prev:hover,


### PR DESCRIPTION
### Motivation
- Provide a “centered” slider layout where the active slide is visually centered and dominant with attenuated adjacent slides, without adding libraries or changing Prettyblocks config.
- Make navigation move by single slide index so the focused item is always centered after interaction.
- Keep existing slider structure and arrows while ensuring compatibility with PrestaShop 8/9 and no use of `.row`/`.col-*`.

### Description
- Updated JS in `views/js/everblock-slider.js` to compute the translateX per the centered formula using `containerWidth`, `itemWidth`, `gap` and `index`, and to navigate by single-index steps for controls and autoplay (`goToIndex` and `startAutoplay`).
- Modified state handling to set `state.containerWidth`, use `state.maxIndex = totalItems - 1`, and manage `pageCount`/`pageIndex` for per-item centering; added toggles for `is-active`, `is-adjacent`, and `is-inactive` classes in `updateItemStates`.
- Adjusted button behavior so arrows remain visible (`hidden = false`) and are only disabled when navigation is not possible, and wired arrow clicks to move one index (`-1`/`+1`).
- Added minimal CSS in `views/css/everblock.css` to include `transform` in transitions, new `.is-adjacent` and updated `.is-inactive` styles (opacity/filter), and moved arrow positions to `left: -40px` / `right: -40px` to sit outside the central zone.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972290f32b88322b96575472d69e409)