### PR TITLE
Fix centered slider translate offset

### DIFF
--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -70,8 +70,7 @@
             return;
         }
         const containerWidth = state.containerWidth || state.slider.clientWidth || 0;
-        const step = state.itemWidth + state.gap;
-        const offset = (containerWidth / 2) - (state.itemWidth / 2) - (state.index * step);
+        const offset = (containerWidth / 2) - (state.itemWidth / 2) - (state.index * state.itemWidth);
         state.track.style.transform = `translateX(${offset}px)`;
     }
 


### PR DESCRIPTION
### Motivation
- Aligner le calcul de translation du mode « centered » pour centrer précisément la slide active sans inclure incorrectement le `gap` dans le pas.

### Description
- Mise à jour de `views/js/everblock-slider.js` : le calcul de `translateX` utilise désormais `offset = (containerWidth / 2) - (state.itemWidth / 2) - (state.index * state.itemWidth)` au lieu d'un `step` qui incluait `state.gap`.

### Testing
- Aucun test automatisé exécuté pour ce changement lors du rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722bad96d883229876746d9cb28d8a)