### PR TITLE
Prettyblocks: center-focused image slider with scaled active slide and centered controls

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1042,6 +1042,10 @@
 }
 
 /* Simple image slider (vanilla) */
+.ever-slider {
+    width: 100%;
+}
+
 .ever-slider-track {
     transition: transform 0.4s ease;
     will-change: transform;
@@ -1056,6 +1060,8 @@
 .ever-slider-item.is-active {
     opacity: 1;
     filter: none;
+    transform: scale(1.08);
+    z-index: 2;
 }
 
 .ever-slider-item.is-inactive {
@@ -1088,11 +1094,11 @@
 }
 
 .ever-slider-prev {
-    left: -40px;
+    left: calc(50% - (var(--ever-slider-active-width, 0px) / 2) - 3.25rem);
 }
 
 .ever-slider-next {
-    right: -40px;
+    right: calc(50% - (var(--ever-slider-active-width, 0px) / 2) - 3.25rem);
 }
 
 .ever-slider-prev:hover,

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -93,6 +93,7 @@
         state.containerWidth = containerWidth;
         const totalGap = state.gap * Math.max(0, state.itemsPerView - 1);
         state.itemWidth = state.itemsPerView > 0 ? (containerWidth - totalGap) / state.itemsPerView : 0;
+        state.slider.style.setProperty('--ever-slider-active-width', `${state.itemWidth * 1.08}px`);
         state.items.forEach((item) => {
             item.style.width = `${state.itemWidth}px`;
         });


### PR DESCRIPTION
### Motivation
- Center the Prettyblock image slider, make it full-width and show three images with the middle image emphasized and surrounding images dimmed to match the desired UI.
- Position the navigation arrows around the focused (center) image and compute their offset dynamically to maintain consistent alignment when item width changes.

### Description
- Added `width: 100%` to `.ever-slider` and scale/z-index for the focused slide by adding `transform: scale(1.08)` and `z-index: 2` to `.ever-slider-item.is-active` in `views/css/everblock.css`.
- Repositioned slider arrows using a computed CSS expression that reads `--ever-slider-active-width` to center controls around the active image in `views/css/everblock.css`.
- Exposed the active slide width from JavaScript by setting the CSS variable `--ever-slider-active-width` to `itemWidth * 1.08` inside `updateState` in `views/js/everblock-slider.js` so arrow placement stays accurate on resize and different breakpoints.
- Kept inactive/adjacent items visually dimmed by using existing opacity classes and ensured the slider remains full-width and responsive.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697231bcad9883229869cb2dc4e207d4)