### PR TITLE
Remove background from WP section title span

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3061,7 +3061,6 @@
   display: inline-block;
 }
 .everblock-wp-section .section-title span {
-  background: #fff;
   padding: 0 1rem;
   position: relative;
   z-index: 2;


### PR DESCRIPTION
### Motivation
- Remove the white background behind the WP section title so the heading no longer displays a white box on top of section backgrounds.

### Description
- Deleted the `background: #fff;` rule from the `.everblock-wp-section .section-title span` selector in `views/css/everblock.css`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779cb468b483228c75da5c35153762)