### PR TITLE
Add text-center to centered prettyblock heading

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -37,7 +37,7 @@
           {assign var='heading_styles' value="{$heading_styles}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"}
         {/if}
         <div class="container">
-          <div class="row justify-content-center">
+          <div class="row justify-content-center text-center">
             <div class="col-auto">
               <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading px-4 py-2 {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
             </div>


### PR DESCRIPTION
### Motivation
- Ensure headings are both horizontally centered and text-aligned when the row uses `justify-content-center` in PrettyBlocks heading output.

### Description
- Add the `text-center` class to the `.row` that contains the centered title in `views/templates/hook/prettyblocks/prettyblock_heading.tpl`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779d17a67c8322ad5763aeb1d7b680)