### PR TITLE
Add one-click update flow to download and install latest GitHub release

### DIFF
--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -92,6 +92,16 @@
                         {/if}
                     </li>
                 </ul>
+                {if isset($everblock_update_available) && $everblock_update_available}
+                    <form method="post" action="{$everblock_update_action|escape:'htmlall':'UTF-8'}" class="everblock-config__update-form">
+                        <button type="submit" name="submitEverblockUpdate" class="btn btn-primary">
+                            <i class="icon-download"></i> {l s='Download and install the latest version' mod='everblock'}
+                        </button>
+                        <p class="help-block">
+                            {l s='The page will reload automatically once the update is installed.' mod='everblock'}
+                        </p>
+                    </form>
+                {/if}
                 {if isset($everblock_latest_release.published_at) && $everblock_latest_release.published_at}
                     <p class="everblock-config__card-meta">
                         {l s='Published on' mod='everblock'}:


### PR DESCRIPTION
### Motivation
- Provide a one-click way to download and install the latest Everblock release from GitHub when a newer version is detected and reload the module configuration page after install.

### Description
- Add handling for `submitEverblockUpdate` in `getContent()` and expose an `everblock_update_action` admin URL to the configure template via `Smarty`.
- Implement `processEverblockUpdate()` which downloads the release zip from the GitHub tag, extracts it, locates the module source inside the archive, and replaces the current module files.
- Add helper methods `locateEverblockSource()`, `replaceModuleFiles()`, `recursiveCopy()`, `removeDirectory()`, and `redirectToModuleConfiguration()` to support safe installation and cleanup.
- Add a form/button to `views/templates/admin/configure.tpl` to trigger the update (`submitEverblockUpdate`) and display a short notice that the page will reload after update.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ad0ab9d48322821b6226aea9b26f)