### PR TITLE
Restore desktop columns for reassurance when slider is mobile-only

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -23,10 +23,10 @@
 {assign var='useDesktopSlider' value=($useSlider && ($sliderDevices == 'Desktop and mobile' || $sliderDevices == 'Desktop'))}
 {assign var='useMobileSlider' value=($useSlider && ($sliderDevices == 'Desktop and mobile' || $sliderDevices == 'Mobile only'))}
 {assign var='reassuranceColumnClass' value=''}
-{if $reassuranceColumns > 0 && !$useSlider}
+{if $reassuranceColumns > 0 && (!$useSlider || ($useSlider && !$useDesktopSlider))}
   {math assign="reassuranceColumnWidth" equation="12 / x" x=$reassuranceColumns format="%.0f"}
   {assign var='reassuranceColumnClass' value="col-12 col-md-"|cat:$reassuranceColumnWidth|cat:' '}
-{elseif $block.settings.default.display_inline && !$useSlider}
+{elseif $block.settings.default.display_inline && (!$useSlider || ($useSlider && !$useDesktopSlider))}
   {assign var='reassuranceColumnClass' value='col '}
 {elseif $useSlider}
   {assign var='reassuranceColumnClass' value='col-12 '}


### PR DESCRIPTION
### Motivation
- Prevent reassurance items from stacking on desktop when the Prettyblocks slider is enabled only for mobile by preserving the desktop column classes.

### Description
- Adjusted the condition in `views/templates/hook/prettyblocks/prettyblock_reassurance.tpl` so `reassuranceColumnClass` is set for desktop when `items_per_row` or `display_inline` should apply either when the slider is disabled or when the slider is enabled but not on desktop (`useDesktopSlider` false).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a7b0044c8322a763517ab9a8bf17)