### PR TITLE
Fix mobile Prettyblock cover text overflow

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -856,6 +856,11 @@
 }
 
 @media (max-width: 767px) {
+    .prettyblock-cover-overlay {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
     .prettyblock-cover-overlay.position-mobile-top {
         justify-content: flex-start;
         align-items: center;


### PR DESCRIPTION
### Motivation
- On mobile the Prettyblock Cover overlay could hide or truncate content when the overlay content exceeds the image height, preventing users from reading long text.

### Description
- Add `overflow-y: auto` and `-webkit-overflow-scrolling: touch` to `.prettyblock-cover-overlay` inside `@media (max-width: 767px)` in `views/css/everblock.css` so overlay content can scroll on small screens.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978bf30086c8322b81f149c46ca8b6c)