### PR TITLE
Fix cover block mobile text overflow

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -856,9 +856,24 @@
 }
 
 @media (max-width: 767px) {
+    .prettyblock-cover-item,
+    .prettyblock-cover-row > .col {
+        overflow: visible;
+    }
+
+    .prettyblock-cover-item img.prettyblock-cover-image,
+    .prettyblock-cover-row > .col img.prettyblock-cover-image {
+        position: absolute;
+        inset: 0;
+        height: 100%;
+        object-fit: cover;
+    }
+
     .prettyblock-cover-overlay {
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
+        position: relative;
+        overflow-y: visible;
+        height: auto;
+        min-height: 100%;
     }
 
     .prettyblock-cover-overlay.position-mobile-top {


### PR DESCRIPTION
### Motivation
- On mobile the Prettyblock Cover overlay could clip or truncate overlay text instead of displaying the entire content centered vertically.
- The goal is to let overlay content expand on small screens while keeping the cover image visually filling the block.

### Description
- Update `views/css/everblock.css` mobile rules under `@media (max-width: 767px)` to set `.prettyblock-cover-item` and `.prettyblock-cover-row > .col` to `overflow: visible`.
- Position cover images as full-size backgrounds by applying `position: absolute; inset: 0; height: 100%; object-fit: cover;` to `.prettyblock-cover-item img.prettyblock-cover-image` and column images.
- Change `.prettyblock-cover-overlay` on mobile to `position: relative`, `overflow-y: visible`, `height: auto`, and `min-height: 100%` and remove the previous `-webkit-overflow-scrolling` usage so overlay height can grow without clipping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c054c97c83228e35090d38994e44)