### PR TITLE
Refine Prettyblock hover effects by link type

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2413,6 +2413,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Block title'),
                             'default' => $module->l('Links'),
                         ],
+                        'link_hover_effect' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable hover effect on links'),
+                            'default' => '0',
+                        ],
                     ], $module),
                 ],
                 'repeater' => [
@@ -2459,6 +2464,11 @@ class EverblockPrettyBlocks
                             'type' => 'text',
                             'label' => $module->l('Block title'),
                             'default' => $module->l('Downloads'),
+                        ],
+                        'link_hover_effect' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable hover effect on links'),
+                            'default' => '0',
                         ],
                     ], $module),
                 ],
@@ -2564,6 +2574,11 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Custom CSS class'),
                             'default' => '',
                         ],
+                        'link_hover_effect' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable hover effect on links'),
+                            'default' => '0',
+                        ],
                     ], $module),
                 ],
             ];
@@ -2583,6 +2598,11 @@ class EverblockPrettyBlocks
                             'type' => 'color',
                             'label' => $module->l('Icon color'),
                             'default' => '',
+                        ],
+                        'link_hover_effect' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable hover effect on links'),
+                            'default' => '0',
                         ],
                     ], $module),
                 ],

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -41,6 +41,32 @@
     cursor: pointer;
 }
 
+/* Prettyblock link hover effect */
+.everblock-link-hover--text {
+    text-decoration-line: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
+    transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.everblock-link-hover--text:hover,
+.everblock-link-hover--text:focus {
+    text-decoration-color: currentColor;
+}
+
+.everblock-link-hover--block {
+    display: inline-flex;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    will-change: transform;
+}
+
+.everblock-link-hover--block:hover,
+.everblock-link-hover--block:focus {
+    opacity: 0.85;
+    transform: scale(1.04);
+}
+
 /* Lookbook product markers */
 
 .lookbook-marker {

--- a/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_downloads.tpl
@@ -44,7 +44,7 @@
           {/if}
           <div>
             {if isset($state.file.url) && $state.file.url}
-              <a href="{$state.file.url|escape:'htmlall'}" class="download-title" download title="{$state.title|escape:'htmlall'}">{$state.title|escape:'htmlall'}</a>
+              <a href="{$state.file.url|escape:'htmlall'}" class="download-title{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" download title="{$state.title|escape:'htmlall'}">{$state.title|escape:'htmlall'}</a>
             {else}
               <span class="download-title">{$state.title|escape:'htmlall'}</span>
             {/if}

--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -31,7 +31,7 @@
       {foreach from=$block.states item=state key=key}
         {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
         <li class="{if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}">
-          <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
+          <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
         </li>
       {/foreach}
     </ul>

--- a/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_sharer.tpl
@@ -32,7 +32,7 @@
       <div class="everblock-sharer {$block.settings.css_class|escape:'htmlall':'UTF-8'}" style="{$prettyblock_spacing_style}">
         <!-- Bouton de partage Facebook -->
         <div class="social-share-button">
-          <a href="https://www.facebook.com/sharer/sharer.php?u={$urls.current_url nofilter}" target="_blank" title="{l s='Share on Facebook' mod='everblock'}">
+          <a href="https://www.facebook.com/sharer/sharer.php?u={$urls.current_url nofilter}" class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}" target="_blank" title="{l s='Share on Facebook' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#1877f2" width="24" height="24">
               <path d="M20 2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h8v-7h-3v-3h3V9.364C11 6.364 12.79 5 15.5 5c1.77 0 3.25.66 3.5 1.5h2V8h-2c-.28 0-.5-.22-.5-.5V5h3l-.362 3H19v3h3l-.5 3h-2v7h4c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
             </svg>
@@ -41,7 +41,7 @@
 
         <!-- Bouton de partage Twitter -->
         <div class="social-share-button">
-          <a href="https://twitter.com/intent/tweet?url={$urls.current_url nofilter}" target="_blank" title="{l s='Share on Twitter' mod='everblock'}">
+          <a href="https://twitter.com/intent/tweet?url={$urls.current_url nofilter}" class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}" target="_blank" title="{l s='Share on Twitter' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#1da1f2" width="24" height="24">
               <path d="M23.954 4.563c-.885.389-1.83.652-2.825.773 1.014-.611 1.795-1.574 2.164-2.723-.95.564-2.004.974-3.125 1.194-.894-.957-2.165-1.555-3.574-1.555-2.704 0-4.896 2.19-4.896 4.884 0 .383.043.756.127 1.117-4.068-.204-7.674-2.149-10.084-5.106-.42.724-.661 1.566-.661 2.465 0 1.7.865 3.195 2.174 4.075-.801-.025-1.553-.246-2.214-.612v.062c0 2.365 1.681 4.336 3.92 4.783-.41.11-.844.169-1.291.169-.314 0-.615-.03-.918-.086.622 1.92 2.429 3.32 4.572 3.357-1.675 1.311-3.787 2.09-6.077 2.09-.395 0-.787-.023-1.174-.068 2.163 1.387 4.73 2.198 7.5 2.198 9.001 0 13.92-7.464 13.92-13.926 0-.21-.005-.419-.014-.627.955-.692 1.794-1.557 2.458-2.542l-.047-.02z"/>
             </svg>
@@ -50,7 +50,7 @@
 
         <!-- Bouton de partage LinkedIn -->
         <div class="social-share-button">
-          <a href="https://www.linkedin.com/shareArticle?url={$urls.current_url nofilter}" target="_blank" title="{l s='Share on LinkedIn' mod='everblock'}">
+          <a href="https://www.linkedin.com/shareArticle?url={$urls.current_url nofilter}" class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}" target="_blank" title="{l s='Share on LinkedIn' mod='everblock'}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#bd081c" width="24" height="24">
               <path d="M12 0c6.628 0 12 5.372 12 12 0 5.237-3.348 9.683-8 11.313-.117-1.001.238-2.663.557-3.981.063-.256.031-.332-.167-.523-.537-.532-1.043-1.28-1.043-2.211 0-1.718 1.235-3.001 2.764-3.001 1.307 0 1.938.982 1.938 2.162 0 1.318-.838 3.284-1.273 5.111-.361 1.517.765 2.742 2.266 2.742 2.718 0 4.548-3.559 4.548-7.891 0-3.325-2.338-5.68-5.634-5.68-4.093 0-6.524 3.078-6.524 6.27 0 1.273.52 2.66 1.16 3.394.129.152.147.213.1.389-.088.344-.289 1.084-.329 1.24-.045.165-.152.201-.334.12-1.08-.49-1.766-1.96-1.766-3.407 0-2.662 1.936-5.013 5.505-5.013 2.853 0 4.96 1.924 4.96 4.486 0 2.995-1.756 5.312-4.324 5.312-.845 0-1.639-.44-1.91-1.037 0 0-.443 1.688-.54 2.06-.203.769-.753 1.534-1.276 2.135-.942.962-2.234 1.726-3.582 1.958-.668.118-1.336.07-1.998-.102-.293-.069-.352-.16-.33-.453.027-.648.074-1.284.135-1.917.074-.803-1.354-14.07-1.354-14.07-.24-1.081.006-2.216.727-3.083.655-.808 1.503-1.3 2.412-1.393 2.062-.18 4.105-.154 6.158-.156z"/>
             </svg>

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -59,6 +59,7 @@
               {assign var='prettyblock_social_link_style_attr' value=$smarty.capture.prettyblock_social_link_style_attr|trim}
               <span class="everblock-social-link"{if $prettyblock_social_link_style_attr} style="{$prettyblock_social_link_style_attr}"{/if}>
                 <a href="{$state.url|escape:'htmlall'}"
+                   class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}"
                    title="{$state.url|escape:'htmlall'}"
                    target="_blank"
                    style="{if isset($block.settings.icon_color) && $block.settings.icon_color}color:{$block.settings.icon_color|escape:'htmlall'};{/if}">
@@ -75,4 +76,3 @@
   {/if}
 </div>
 <!-- /Module Ever Block -->
-


### PR DESCRIPTION
### Motivation
- Avoid applying underlines to icon/block links while keeping a subtle underline reveal for textual links to meet the design constraints (`underline` only for textual anchors, icons/blocks get a more visible transform/opacity). 
- Provide a clear, reusable way to enable/disable the hover effect per-block via the existing block settings UI. 

### Description
- Add two hover variants in `views/css/everblock.css`: `everblock-link-hover--text` for textual links (underline reveal) and `everblock-link-hover--block` for block/icon links (opacity + slight scale). 
- Apply `everblock-link-hover--text` to link lists and downloads in `views/templates/hook/prettyblocks/prettyblock_link_list.tpl` and `prettyblock_downloads.tpl`. 
- Apply `everblock-link-hover--block` to social icons and the sharer buttons in `views/templates/hook/prettyblocks/prettyblock_social_links.tpl` and `prettyblock_sharer.tpl`. 
- Expose a `link_hover_effect` checkbox in `src/Service/EverblockPrettyBlocks.php` for the `Links list`, `Downloads list`, `Page sharer`, and `Social links` blocks so editors can toggle the effect per-block. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697918cf3e6883228895b384fa04b7a0)