### PR TITLE
Remove redundant slider setting for Simple Image prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -1529,11 +1529,6 @@ class EverblockPrettyBlocks
                                 'large' => $module->l('Large'),
                             ],
                         ],
-                        'slider' => [
-                            'type' => 'checkbox',
-                            'label' => $module->l('Enable slider'),
-                            'default' => 0,
-                        ],
                         'slider_autoplay' => [
                             'type' => 'checkbox',
                             'label' => $module->l('Enable auto scroll'),


### PR DESCRIPTION
### Motivation
- Remove the redundant `Enable slider` checkbox from the Prettyblock Simple Image configuration because the `Display mode` select already includes a `Slider` option and the toggle is unused.

### Description
- Deleted the `'slider'` field from the `everblock_img` block configuration in `src/Service/EverblockPrettyBlocks.php`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d6d353b48322958688b17b5525fa)