### PR TITLE
Improve Prettyblock simple image slider spacing and controls

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1096,11 +1096,14 @@
 /* Simple image slider (vanilla) */
 .ever-slider {
     width: 100%;
+    padding: 0 3.5rem;
 }
 
 .ever-slider-track {
     transition: transform 0.4s ease;
     will-change: transform;
+    column-gap: 1.5rem;
+    padding: 0.75rem 0;
 }
 
 .ever-slider-item {
@@ -1112,7 +1115,7 @@
 .ever-slider-item.is-active {
     opacity: 1;
     filter: none;
-    transform: scale(1.08);
+    transform: scale(1.15);
     z-index: 2;
 }
 
@@ -1145,6 +1148,24 @@
     transition: background-color 0.3s ease, opacity 0.3s ease;
 }
 
+.ever-slider-prev::before,
+.ever-slider-next::before {
+    content: "";
+    width: 0.65rem;
+    height: 0.65rem;
+    border-right: 3px solid #fff;
+    border-bottom: 3px solid #fff;
+    display: inline-block;
+}
+
+.ever-slider-prev::before {
+    transform: rotate(135deg);
+}
+
+.ever-slider-next::before {
+    transform: rotate(-45deg);
+}
+
 .ever-slider-prev {
     left: calc(50% - (var(--ever-slider-active-width, 0px) / 2) - 3.25rem);
 }
@@ -1156,6 +1177,28 @@
 .ever-slider-prev:hover,
 .ever-slider-next:hover {
     background-color: rgba(0, 0, 0, 0.65);
+}
+
+.ever-slider-prev:disabled,
+.ever-slider-next:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+@media (max-width: 991.98px) {
+    .ever-slider {
+        padding: 0 2.5rem;
+    }
+
+    .ever-slider-track {
+        column-gap: 1rem;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .ever-slider {
+        padding: 0 1.5rem;
+    }
 }
 
 @media (max-width: 767.98px) {

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -93,7 +93,7 @@
         state.containerWidth = containerWidth;
         const totalGap = state.gap * Math.max(0, state.itemsPerView - 1);
         state.itemWidth = state.itemsPerView > 0 ? (containerWidth - totalGap) / state.itemsPerView : 0;
-        state.slider.style.setProperty('--ever-slider-active-width', `${state.itemWidth * 1.08}px`);
+        state.slider.style.setProperty('--ever-slider-active-width', `${state.itemWidth * 1.15}px`);
         state.items.forEach((item) => {
             item.style.width = `${state.itemWidth}px`;
         });


### PR DESCRIPTION
### Motivation

- Make the central image larger when the Prettyblock simple image slider is active so the focal slide stands out.
- Add padding/gap around the slider so side images don't appear visually cut off.
- Ensure navigation arrows are visible and provide proper disabled styling so controls are usable and clear.

### Description

- Updated `views/css/everblock.css` to add outer padding on `.ever-slider` and `column-gap` plus vertical padding on `.ever-slider-track` to create spacing around items and avoid cropped edges.
- Increased the active slide scale from `scale(1.08)` to `scale(1.15)` on `.ever-slider-item.is-active` to enlarge the central image.
- Added visible arrow indicators via `::before` on `.ever-slider-prev`/`.ever-slider-next`, added disabled styling for these buttons, and added responsive padding/gap adjustments for `max-width` breakpoints in `views/css/everblock.css`.
- Synchronized the JS calculation in `views/js/everblock-slider.js` by changing the active-width CSS variable multiplier from `1.08` to `1.15` so button positioning remains correct with the new scale.

### Testing

- No automated tests were executed for this change in the repository during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b1c33d6e48322bf32a8ef2c633359)