### PR TITLE
Fix simple image slider centering and spacing

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1102,7 +1102,7 @@
 .ever-slider-track {
     transition: transform 0.4s ease;
     will-change: transform;
-    column-gap: 1.5rem;
+    column-gap: 2rem;
     padding: 0.75rem 0;
 }
 
@@ -1191,7 +1191,7 @@
     }
 
     .ever-slider-track {
-        column-gap: 1rem;
+        column-gap: 1.25rem;
     }
 }
 

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -70,7 +70,8 @@
             return;
         }
         const containerWidth = state.containerWidth || state.slider.clientWidth || 0;
-        const offset = (containerWidth / 2) - (state.itemWidth / 2) - (state.index * state.itemWidth);
+        const itemOffset = state.index * (state.itemWidth + state.gap);
+        const offset = (containerWidth / 2) - (state.itemWidth / 2) - itemOffset;
         state.track.style.transform = `translateX(${offset}px)`;
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the active image in the Prettyblock "Simple Image" slider is truly centered between the navigation arrows and prevent adjacent images from being visually cut off by increasing item gaps.

### Description
- Updated `updateTrackPosition` in `views/js/everblock-slider.js` to account for `state.gap` when computing the track `translateX`, so the active item is centered correctly between the arrows by using `state.index * (state.itemWidth + state.gap)` in the offset calculation.
- Increased spacing in `views/css/everblock.css` by changing `.ever-slider-track` `column-gap` from `1.5rem` to `2rem` on desktop and from `1rem` to `1.25rem` at the tablet breakpoint to reduce image cropping.

### Testing
- Attempted an automated visual check by taking a screenshot with Playwright, but the local server was unreachable and the run failed with `net::ERR_EMPTY_RESPONSE`.
- No unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b216a8cec8322b97b8ad6344d17a8)