### PR TITLE
Center simple image slider items in Prettyblock

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1129,6 +1129,17 @@
     filter: brightness(0.9);
 }
 
+.ever-slider--simple-image .ever-slider-item {
+    text-align: center;
+}
+
+.ever-slider--simple-image .ever-slider-item picture,
+.ever-slider--simple-image .ever-slider-item img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .ever-slider-prev,
 .ever-slider-next {
     position: absolute;

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -95,7 +95,7 @@
   {/foreach}
   {assign var='use_slider' value=($displayMode == 'Slider' && $visibleStatesCount > 1 && $maxSliderItems < $visibleStatesCount)}
   {if $use_slider}
-    <div class="ever-slider overflow-hidden position-relative"
+    <div class="ever-slider ever-slider--simple-image overflow-hidden position-relative"
          data-items="{$sliderItemsDesktop|escape:'htmlall':'UTF-8'}"
          data-items-mobile="{$sliderItemsMobile|escape:'htmlall':'UTF-8'}"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"


### PR DESCRIPTION
### Motivation
- Fix centering of images in the Prettyblock "Simple Image" slider when the slider mode is active so images appear visually centered.

### Description
- Add a dedicated wrapper class `ever-slider--simple-image` to the slider in `views/templates/hook/prettyblocks/prettyblock_img.tpl` and scope CSS rules in `views/css/everblock.css` to center `.ever-slider-item` media by applying `text-align: center`, `display: block` and `margin-left/right: auto` to `picture` and `img`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b23c3bed8832292c81471c16f8b12)