### PR TITLE
Fix simple image slider arrow positioning

### DIFF
--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -85,6 +85,24 @@
         });
     }
 
+    function updateActiveWidth(state) {
+        const activeItem = state.items[state.index];
+        let activeWidth = 0;
+        if (activeItem) {
+            const activeImage = activeItem.querySelector('img');
+            if (activeImage) {
+                activeWidth = activeImage.getBoundingClientRect().width;
+            }
+            if (!activeWidth) {
+                activeWidth = activeItem.getBoundingClientRect().width;
+            }
+        }
+        if (!activeWidth) {
+            activeWidth = state.itemWidth * 1.15;
+        }
+        state.slider.style.setProperty('--ever-slider-active-width', `${activeWidth}px`);
+    }
+
     function updateState(state) {
         const totalItems = state.items.length;
         state.itemsPerView = getItemsPerView(state.slider);
@@ -98,7 +116,6 @@
         state.contentWidth = Math.max(0, containerWidth - paddingLeft - paddingRight);
         const totalGap = state.gap * Math.max(0, state.itemsPerView - 1);
         state.itemWidth = state.itemsPerView > 0 ? (state.contentWidth - totalGap) / state.itemsPerView : 0;
-        state.slider.style.setProperty('--ever-slider-active-width', `${state.itemWidth * 1.15}px`);
         state.items.forEach((item) => {
             item.style.width = `${state.itemWidth}px`;
         });
@@ -111,6 +128,7 @@
         state.pageIndex = Math.min(state.pageCount - 1, state.index);
         updateTrackPosition(state);
         updateItemStates(state);
+        updateActiveWidth(state);
         updateButtons(state);
     }
 
@@ -172,6 +190,9 @@
             return;
         }
         const items = Array.from(track.querySelectorAll('.ever-slider-item'));
+        const images = items
+            .map((item) => item.querySelector('img'))
+            .filter((image) => image);
         const prevButton = slider.querySelector('.ever-slider-prev');
         const nextButton = slider.querySelector('.ever-slider-next');
         const autoplay = parseNumber(slider.dataset.autoplay, 0) === 1;
@@ -201,6 +222,14 @@
         sliderStates.set(slider, state);
         bindControls(state);
         updateState(state);
+        images.forEach((image) => {
+            if (image.complete) {
+                return;
+            }
+            image.addEventListener('load', () => {
+                updateState(state);
+            });
+        });
         startAutoplay(state);
     }
 


### PR DESCRIPTION
### Motivation
- Arrow controls in the Prettyblock Simple Image slider could be misaligned when the active slide image size differs from the computed item width, so the design needs the active width to reflect the actual rendered image.

### Description
- Added a new `updateActiveWidth` function in `views/js/everblock-slider.js` that computes the active width from the currently active slide's rendered `img` width with fallbacks to the item width and previous multiplier.
- Replaced the previous fixed `--ever-slider-active-width` assignment in `updateState` with a call to the new `updateActiveWidth` so arrow positions are recalculated whenever the slider state updates.
- Collected slide images during `setupSlider` and attached `load` event listeners to each image to call `updateState` after images finish loading so the active width is refreshed once images are rendered.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b297f6f8c8322a943551c26c6020f)