### PR TITLE
Align simple image slider arrows to active image

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1140,12 +1140,23 @@
     margin-right: auto;
 }
 
+/* Apple-like navigation: arrows centered on the active image */
+.ever-slider-nav {
+    position: absolute;
+    left: var(--ever-slider-active-center-x, 50%);
+    top: var(--ever-slider-active-center-y, 50%);
+    width: var(--ever-slider-active-width, 100%);
+    height: var(--ever-slider-active-height, 100%);
+    transform: translate(-50%, -50%);
+    z-index: 3;
+    pointer-events: none;
+}
+
 .ever-slider-prev,
 .ever-slider-next {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    z-index: 3;
     width: 2.75rem;
     height: 2.75rem;
     border-radius: 999px;
@@ -1157,6 +1168,7 @@
     justify-content: center;
     opacity: 1;
     transition: background-color 0.3s ease, opacity 0.3s ease;
+    pointer-events: auto;
 }
 
 .ever-slider-prev::before,
@@ -1178,11 +1190,13 @@
 }
 
 .ever-slider-prev {
-    left: calc(50% - (var(--ever-slider-active-width, 0px) / 2) - 3.25rem);
+    left: 0;
+    transform: translate(-50%, -50%);
 }
 
 .ever-slider-next {
-    right: calc(50% - (var(--ever-slider-active-width, 0px) / 2) - 3.25rem);
+    right: 0;
+    transform: translate(50%, -50%);
 }
 
 .ever-slider-prev:hover,

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -85,22 +85,49 @@
         });
     }
 
-    function updateActiveWidth(state) {
+    function updateActiveMetrics(state) {
         const activeItem = state.items[state.index];
+        const nav = state.nav;
         let activeWidth = 0;
+        let activeHeight = 0;
+        let activeCenterX = 0;
+        let activeCenterY = 0;
         if (activeItem) {
             const activeImage = activeItem.querySelector('img');
             if (activeImage) {
-                activeWidth = activeImage.getBoundingClientRect().width;
+                const rect = activeImage.getBoundingClientRect();
+                activeWidth = rect.width;
+                activeHeight = rect.height;
+                const sliderRect = state.slider.getBoundingClientRect();
+                activeCenterX = rect.left - sliderRect.left + rect.width / 2;
+                activeCenterY = rect.top - sliderRect.top + rect.height / 2;
             }
             if (!activeWidth) {
-                activeWidth = activeItem.getBoundingClientRect().width;
+                const rect = activeItem.getBoundingClientRect();
+                activeWidth = rect.width;
+                activeHeight = rect.height;
+                const sliderRect = state.slider.getBoundingClientRect();
+                activeCenterX = rect.left - sliderRect.left + rect.width / 2;
+                activeCenterY = rect.top - sliderRect.top + rect.height / 2;
             }
         }
         if (!activeWidth) {
             activeWidth = state.itemWidth * 1.15;
         }
+        if (!activeHeight) {
+            activeHeight = activeItem ? activeItem.getBoundingClientRect().height : 0;
+        }
+        if (!activeCenterX || !activeCenterY) {
+            activeCenterX = state.slider.clientWidth / 2;
+            activeCenterY = state.slider.clientHeight / 2;
+        }
         state.slider.style.setProperty('--ever-slider-active-width', `${activeWidth}px`);
+        state.slider.style.setProperty('--ever-slider-active-height', `${activeHeight}px`);
+        state.slider.style.setProperty('--ever-slider-active-center-x', `${activeCenterX}px`);
+        state.slider.style.setProperty('--ever-slider-active-center-y', `${activeCenterY}px`);
+        if (nav) {
+            nav.hidden = false;
+        }
     }
 
     function updateState(state) {
@@ -128,7 +155,7 @@
         state.pageIndex = Math.min(state.pageCount - 1, state.index);
         updateTrackPosition(state);
         updateItemStates(state);
-        updateActiveWidth(state);
+        updateActiveMetrics(state);
         updateButtons(state);
     }
 
@@ -165,6 +192,7 @@
         state.pageIndex = Math.min(state.pageCount - 1, state.index);
         updateTrackPosition(state);
         updateItemStates(state);
+        updateActiveMetrics(state);
         updateButtons(state);
         if (resetAutoplay) {
             startAutoplay(state);
@@ -193,6 +221,7 @@
         const images = items
             .map((item) => item.querySelector('img'))
             .filter((image) => image);
+        const nav = slider.querySelector('.ever-slider-nav');
         const prevButton = slider.querySelector('.ever-slider-prev');
         const nextButton = slider.querySelector('.ever-slider-next');
         const autoplay = parseNumber(slider.dataset.autoplay, 0) === 1;
@@ -203,6 +232,7 @@
             slider,
             track,
             items,
+            nav,
             prevButton,
             nextButton,
             autoplay,

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -176,8 +176,10 @@
         {/if}
       {/foreach}
       </div>
-      <button class="ever-slider-prev" type="button" aria-label="Previous"></button>
-      <button class="ever-slider-next" type="button" aria-label="Next"></button>
+      <div class="ever-slider-nav">
+        <button class="ever-slider-prev" type="button" aria-label="Previous"></button>
+        <button class="ever-slider-next" type="button" aria-label="Next"></button>
+      </div>
     </div>
   {else}
     {if $block.settings.default.force_full_width}


### PR DESCRIPTION
### Motivation
- Fix misaligned navigation arrows in the Simple Image PrettyBlock by anchoring arrow position to the active image bounds so centering behaves like Apple sliders even with lazy-loaded or variable-height images.
- Ensure arrow placement depends only on the displayed image metrics and not on viewport, global slide dimensions, or fixed heights.

### Description
- Wrap navigation buttons in a dedicated container by adding `div.ever-slider-nav` around the prev/next buttons in `views/templates/hook/prettyblocks/prettyblock_img.tpl` so arrows are positioned relative to the active image.
- Add Apple-like CSS rules in `views/css/everblock.css` to place the nav container using CSS variables `--ever-slider-active-center-x`, `--ever-slider-active-center-y`, `--ever-slider-active-width`, and `--ever-slider-active-height`, and make the individual buttons clickable while keeping the nav anchored to the active image.
- Update slider logic in `views/js/everblock-slider.js` by replacing `updateActiveWidth` with `updateActiveMetrics`, computing the active image's width, height and center coordinates on image load/resize/slide change, and exposing those values as CSS variables to drive nav placement; the slider state now stores the `nav` element and unhides it once metrics are computed.
- Preserve existing behaviors: autoplay, responsive items per view, and non-intrusive changes to button click handlers and accessibility (`aria-label`).

### Testing
- No automated tests were executed for this change in the rollout environment.
- Manual validation steps are recommended: verify navigation arrows remain vertically centered on the visible image for portrait/landscape/square images, check behavior with lazyloaded images, and test responsive breakpoints and swipe interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2bfe977c832299cb39594df2814c)