### PR TITLE
Fix Simple Image slider arrow positioning (image-wrapper-centered Apple-like)

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1140,6 +1140,26 @@
     margin-right: auto;
 }
 
+.everblock-simple-image.slider-active .image-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.everblock-simple-image.slider-active .slider-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+}
+
+.everblock-simple-image.slider-active .slider-arrow.prev {
+    left: -48px;
+}
+
+.everblock-simple-image.slider-active .slider-arrow.next {
+    right: -48px;
+}
+
 /* Apple-like navigation: arrows centered on the active image */
 .ever-slider-nav {
     position: absolute;
@@ -1197,6 +1217,19 @@
 .ever-slider-next {
     right: 0;
     transform: translate(50%, -50%);
+}
+
+.everblock-simple-image.slider-active .ever-slider-prev,
+.everblock-simple-image.slider-active .ever-slider-next {
+    transform: translateY(-50%);
+}
+
+.everblock-simple-image.slider-active .ever-slider-prev {
+    left: -48px;
+}
+
+.everblock-simple-image.slider-active .ever-slider-next {
+    right: -48px;
 }
 
 .ever-slider-prev:hover,

--- a/views/js/everblock-slider.js
+++ b/views/js/everblock-slider.js
@@ -46,23 +46,39 @@
     }
 
     function updateButtons(state) {
-        if (!state.prevButton || !state.nextButton) {
+        if (!state.prevButtons.length && !state.nextButtons.length) {
             return;
         }
-        state.prevButton.hidden = false;
-        state.nextButton.hidden = false;
+        state.prevButtons.forEach((button) => {
+            button.hidden = false;
+        });
+        state.nextButtons.forEach((button) => {
+            button.hidden = false;
+        });
         if (state.infinite) {
-            state.prevButton.disabled = false;
-            state.nextButton.disabled = false;
+            state.prevButtons.forEach((button) => {
+                button.disabled = false;
+            });
+            state.nextButtons.forEach((button) => {
+                button.disabled = false;
+            });
             return;
         }
         if (state.disabled) {
-            state.prevButton.disabled = true;
-            state.nextButton.disabled = true;
+            state.prevButtons.forEach((button) => {
+                button.disabled = true;
+            });
+            state.nextButtons.forEach((button) => {
+                button.disabled = true;
+            });
             return;
         }
-        state.prevButton.disabled = state.index <= 0;
-        state.nextButton.disabled = state.index >= state.maxIndex;
+        state.prevButtons.forEach((button) => {
+            button.disabled = state.index <= 0;
+        });
+        state.nextButtons.forEach((button) => {
+            button.disabled = state.index >= state.maxIndex;
+        });
     }
 
     function updateTrackPosition(state) {
@@ -200,16 +216,16 @@
     }
 
     function bindControls(state) {
-        if (state.prevButton) {
-            state.prevButton.addEventListener('click', () => {
+        state.prevButtons.forEach((button) => {
+            button.addEventListener('click', () => {
                 goToIndex(state, state.index - 1, true);
             });
-        }
-        if (state.nextButton) {
-            state.nextButton.addEventListener('click', () => {
+        });
+        state.nextButtons.forEach((button) => {
+            button.addEventListener('click', () => {
                 goToIndex(state, state.index + 1, true);
             });
-        }
+        });
     }
 
     function setupSlider(slider) {
@@ -222,8 +238,8 @@
             .map((item) => item.querySelector('img'))
             .filter((image) => image);
         const nav = slider.querySelector('.ever-slider-nav');
-        const prevButton = slider.querySelector('.ever-slider-prev');
-        const nextButton = slider.querySelector('.ever-slider-next');
+        const prevButtons = Array.from(slider.querySelectorAll('.ever-slider-prev'));
+        const nextButtons = Array.from(slider.querySelectorAll('.ever-slider-next'));
         const autoplay = parseNumber(slider.dataset.autoplay, 0) === 1;
         const autoplayDelay = parseNumber(slider.dataset.autoplayDelay, 5000);
         const infinite = parseNumber(slider.dataset.infinite, 0) === 1;
@@ -233,8 +249,8 @@
             track,
             items,
             nav,
-            prevButton,
-            nextButton,
+            prevButtons,
+            nextButtons,
             autoplay,
             autoplayDelay,
             infinite,

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -95,7 +95,7 @@
   {/foreach}
   {assign var='use_slider' value=($displayMode == 'Slider' && $visibleStatesCount > 1 && $maxSliderItems < $visibleStatesCount)}
   {if $use_slider}
-    <div class="ever-slider ever-slider--simple-image overflow-hidden position-relative"
+    <div class="ever-slider ever-slider--simple-image everblock-simple-image slider-active overflow-hidden position-relative"
          data-items="{$sliderItemsDesktop|escape:'htmlall':'UTF-8'}"
          data-items-mobile="{$sliderItemsMobile|escape:'htmlall':'UTF-8'}"
          data-autoplay="{if isset($block.settings.slider_autoplay) && $block.settings.slider_autoplay}1{else}0{/if}"
@@ -130,33 +130,37 @@
             {$prettyblock_state_spacing_style}
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">
-            {if isset($state.url) && $state.url}
-              <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
-            {/if}
-              <picture>
-                {if isset($state.banner_mobile.url) && $state.banner_mobile.url}
-                  <source media="(max-width: 767px)" srcset="{$state.banner_mobile.url|replace:'.webp':'.jpg'}">
-                {/if}
-                <source srcset="{$state.banner.url}" type="image/webp">
-                <source srcset="{$state.banner.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                <img src="{$state.banner.url|replace:'.webp':'.jpg'}"
-                     {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
-                     {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
-                     {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
-                     class="img img-fluid lazyload" loading="lazy">
-              </picture>
+            <div class="image-wrapper">
+              {if isset($state.url) && $state.url}
+                <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
+              {/if}
+                <picture>
+                  {if isset($state.banner_mobile.url) && $state.banner_mobile.url}
+                    <source media="(max-width: 767px)" srcset="{$state.banner_mobile.url|replace:'.webp':'.jpg'}">
+                  {/if}
+                  <source srcset="{$state.banner.url}" type="image/webp">
+                  <source srcset="{$state.banner.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                  <img src="{$state.banner.url|replace:'.webp':'.jpg'}"
+                       {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
+                       {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
+                       {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
+                       class="img img-fluid lazyload" loading="lazy">
+                </picture>
 
-              <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
-                {if $state.text_highlight_1}
-                  <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
-                {/if}
-                {if $state.text_highlight_2}
-                  <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
-                {/if}
-              </div>
-            {if isset($state.url) && $state.url}
-              </a>
-            {/if}
+                <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
+                  {if $state.text_highlight_1}
+                    <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
+                  {/if}
+                  {if $state.text_highlight_2}
+                    <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
+                  {/if}
+                </div>
+              {if isset($state.url) && $state.url}
+                </a>
+              {/if}
+              <button class="slider-arrow prev ever-slider-prev" type="button" aria-label="Previous"></button>
+              <button class="slider-arrow next ever-slider-next" type="button" aria-label="Next"></button>
+            </div>
           </div>
           {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
               (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||
@@ -175,10 +179,6 @@
           {/if}
         {/if}
       {/foreach}
-      </div>
-      <div class="ever-slider-nav">
-        <button class="ever-slider-prev" type="button" aria-label="Previous"></button>
-        <button class="ever-slider-next" type="button" aria-label="Next"></button>
       </div>
     </div>
   {else}


### PR DESCRIPTION
### Motivation

- Fix incorrect vertical/horizontal placement of prev/next arrows when the Simple Image block is used as a slider.  
- Ensure arrows are always centered relative to the actually displayed image (portrait/landscape/responsive/lazyload) and not the global slide or viewport.  
- Preserve the existing behavior for non-slider (simple image) mode.

### Description

- Update template `prettyblock_img.tpl` to add `everblock-simple-image slider-active` on the slider container, wrap each slide image in a `div.image-wrapper`, and move per-slide arrow buttons into that wrapper (`<button class="slider-arrow prev ever-slider-prev">` / `next`).
- Add CSS rules in `views/css/everblock.css` to position arrows relative to `.image-wrapper` using `.everblock-simple-image.slider-active .image-wrapper` and `.slider-arrow` so arrows are vertically centered with `top: 50%; transform: translateY(-50%)` and placed left/right of the image (`left: -48px` / `right: -48px`).
- Update `views/js/everblock-slider.js` to support multiple prev/next buttons per slider by introducing `prevButtons`/`nextButtons` arrays and updating `setupSlider`, `bindControls`, and `updateButtons` to operate over those arrays (event binding and enabled/disabled state handled per-button).
- Replace the previous global nav approach for this block with the per-image wrapper arrows so no JS height calculations or manual repositioning are required and the simple-image mode remains unaffected.

### Testing

- No automated tests were run against these changes (no CI/unit tests executed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b32503cb88322bfdbdd6796ee7e5d)