### PR TITLE
Amélioration du rendu Apple-like pour le slider Simple Image (mode slider actif)

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1112,23 +1112,6 @@
     filter: none;
 }
 
-.ever-slider-item.is-active {
-    opacity: 1;
-    filter: none;
-    transform: scale(1.15);
-    z-index: 2;
-}
-
-.ever-slider-item.is-inactive {
-    opacity: 0.4;
-    filter: brightness(0.85);
-}
-
-.ever-slider-item.is-adjacent {
-    opacity: 0.6;
-    filter: brightness(0.9);
-}
-
 .ever-slider--simple-image .ever-slider-item {
     text-align: center;
 }
@@ -1145,6 +1128,38 @@
     display: inline-block;
 }
 
+.everblock-simple-image.slider-active .ever-slider-track {
+    align-items: center;
+}
+
+.everblock-simple-image.slider-active,
+.everblock-simple-image.slider-active .ever-slider-item {
+    overflow: visible !important;
+}
+
+.everblock-simple-image.slider-active .ever-slider-item {
+    transition: transform 0.45s ease, opacity 0.45s ease;
+    transform-origin: center center;
+}
+
+.everblock-simple-image.slider-active .ever-slider-item.is-active {
+    transform: scale(1.2);
+    opacity: 1;
+    z-index: 3;
+}
+
+.everblock-simple-image.slider-active .ever-slider-item.is-adjacent {
+    transform: scale(0.9);
+    opacity: 0.6;
+    z-index: 2;
+}
+
+.everblock-simple-image.slider-active .ever-slider-item.is-inactive {
+    transform: scale(0.8);
+    opacity: 0.35;
+    z-index: 1;
+}
+
 .everblock-simple-image.slider-active img {
     display: block;
     pointer-events: none;
@@ -1155,7 +1170,7 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    z-index: 20;
+    z-index: 9999;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
### Motivation
- Rendre le mode "slider actif" du block Simple Image visuellement proche d'un carousel Apple en mettant en avant le slide central sans impacter le mode image simple.
- Appliquer l'effet uniquement via CSS pour éviter tout calcul JS de taille et préserver le comportement swipe/drag existant.

### Description
- Ajout et scope des règles CSS sous `.everblock-simple-image.slider-active` pour centrer la piste (`align-items: center`) et autoriser le débordement (`overflow: visible !important`) afin de supporter le scale des slides.
- Remplacement/affinage des transitions par item et ajout de `transform-origin: center center` avec un `scale(1.2)` plus prononcé pour `.is-active`, `scale(0.9)` pour `.is-adjacent` et `scale(0.8)` pour `.is-inactive`, ainsi que ajustements d'opacité et de `z-index` pour hiérarchiser visuellement les slides.
- Les flèches du slider conservent leur position mais voient leur `z-index` accru à `9999` pour rester au-dessus des images agrandies.
- Aucun changement JavaScript effectué, le mécanisme de swipe/drag et le moteur `ever-slider` existants restent inchangés.

### Testing
- Aucun test automatisé exécuté (modification CSS uniquement).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b36e63a088322a37099f4a8614fba)