### PR TITLE
Enhance simple image slider focus styling

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1130,7 +1130,7 @@
 
 .everblock-simple-image.slider-active .ever-slider-track {
     align-items: center;
-    gap: 40px;
+    gap: 64px;
 }
 
 .everblock-simple-image.slider-active,
@@ -1139,28 +1139,31 @@
 }
 
 .everblock-simple-image.slider-active .ever-slider-item {
-    transition: transform 0.5s cubic-bezier(.4,0,.2,1), opacity 0.5s ease, filter 0.5s ease;
-    transform-origin: center center;
+    transition:
+        transform 0.6s cubic-bezier(.4,0,.2,1),
+        opacity 0.6s ease,
+        filter 0.6s ease;
+    will-change: transform;
 }
 
 .everblock-simple-image.slider-active .ever-slider-item.is-active {
-    transform: scale(1.18) translateZ(0);
+    transform: scale(1.25);
     opacity: 1;
     filter: none;
-    z-index: 3;
+    z-index: 5;
 }
 
 .everblock-simple-image.slider-active .ever-slider-item.is-adjacent {
-    transform: scale(0.88) translateX(20px);
-    opacity: 0.55;
-    filter: blur(0.5px);
+    transform: scale(0.78) translateX(40px);
+    opacity: 0.35;
+    filter: blur(1px);
     z-index: 2;
 }
 
 .everblock-simple-image.slider-active .ever-slider-item.is-inactive {
-    transform: scale(0.75);
-    opacity: 0.25;
-    filter: blur(1px);
+    transform: scale(0.65);
+    opacity: 0.15;
+    filter: blur(2px);
     z-index: 1;
 }
 


### PR DESCRIPTION
### Motivation
- Intensify the visual hierarchy of the Simple Image slider so the center slide is ultra-dominant and adjacent/inactive slides are strongly attenuated to recreate an Apple-like carousel effect using CSS only.
- Address the current issue where adjacent slides remain too visible and the central slide lacks the necessary dominance without touching the `ever-slider` engine or adding layout JS.

### Description
- Updated `views/css/everblock.css` to increase the track spacing from `40px` to `64px` for more breathing room.
- Extended slide transitions to `0.6s` and added `will-change: transform` for smoother, Apple-like motion.
- Made the active slide visually dominant by changing it to `transform: scale(1.25)` and raising `z-index` to `5`.
- Strongly attenuated adjacent and inactive slides by changing adjacent to `scale(0.78) translateX(40px)`, `opacity: 0.35`, `filter: blur(1px)` and inactive to `scale(0.65)`, `opacity: 0.15`, `filter: blur(2px)`, while preserving `overflow: visible !important` to avoid clipping.

### Testing
- Ran a headless Playwright script that opened `http://localhost:8000` at `1400x900` and captured a screenshot to `artifacts/simple-image-slider.png`, which completed successfully.
- No unit tests were required or modified because this is a CSS-only visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3c487af48322b79fbad5c4116657)