### PR TITLE
Adjust simple image slider active scaling wrapper

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -1123,6 +1123,11 @@
     margin-right: auto;
 }
 
+.everblock-simple-image.slider-active {
+    position: relative;
+    padding-bottom: 0;
+}
+
 .everblock-simple-image.slider-active .image-wrapper {
     position: relative;
     display: inline-block;
@@ -1139,28 +1144,39 @@
 }
 
 .everblock-simple-image.slider-active .ever-slider-item {
+    position: relative;
+    height: 100%;
+    overflow: visible;
+}
+
+.everblock-simple-image.slider-active .slide-inner {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
     transition:
         transform 0.6s cubic-bezier(.4,0,.2,1),
         opacity 0.6s ease,
         filter 0.6s ease;
-    will-change: transform;
 }
 
-.everblock-simple-image.slider-active .ever-slider-item.is-active {
+.everblock-simple-image.slider-active .is-active .slide-inner {
     transform: scale(1.25);
     opacity: 1;
     filter: none;
-    z-index: 5;
+    z-index: 3;
 }
 
-.everblock-simple-image.slider-active .ever-slider-item.is-adjacent {
-    transform: scale(0.78) translateX(40px);
+.everblock-simple-image.slider-active .is-adjacent .slide-inner {
+    transform: scale(0.8);
     opacity: 0.35;
     filter: blur(1px);
     z-index: 2;
 }
 
-.everblock-simple-image.slider-active .ever-slider-item.is-inactive {
+.everblock-simple-image.slider-active .is-inactive .slide-inner {
     transform: scale(0.65);
     opacity: 0.15;
     filter: blur(2px);

--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -130,37 +130,39 @@
             {$prettyblock_state_spacing_style}
             {if isset($state.default.bg_color)}background-color:{$state.default.bg_color|escape:'htmlall':'UTF-8'};{/if}
           ">
-            <div class="image-wrapper">
-              {if isset($state.url) && $state.url}
-                <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
-              {/if}
-                <picture>
-                  {if isset($state.banner_mobile.url) && $state.banner_mobile.url}
-                    <source media="(max-width: 767px)" srcset="{$state.banner_mobile.url|replace:'.webp':'.jpg'}">
-                  {/if}
-                  <source srcset="{$state.banner.url}" type="image/webp">
-                  <source srcset="{$state.banner.url|replace:'.webp':'.jpg'}" type="image/jpeg">
-                  <img src="{$state.banner.url|replace:'.webp':'.jpg'}"
-                       {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
-                       {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
-                       {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
-                       class="img img-fluid lazyload" loading="lazy" draggable="false">
-                </picture>
+            <div class="slide-inner">
+              <div class="image-wrapper">
+                {if isset($state.url) && $state.url}
+                  <a href="{$state.url|escape:'htmlall':'UTF-8'}" class="d-block position-relative" title="{if isset($state.alt)}{$state.alt|escape:'htmlall':'UTF-8'}{else}{$shop.name|escape:'htmlall':'UTF-8'}{/if}">
+                {/if}
+                  <picture>
+                    {if isset($state.banner_mobile.url) && $state.banner_mobile.url}
+                      <source media="(max-width: 767px)" srcset="{$state.banner_mobile.url|replace:'.webp':'.jpg'}">
+                    {/if}
+                    <source srcset="{$state.banner.url}" type="image/webp">
+                    <source srcset="{$state.banner.url|replace:'.webp':'.jpg'}" type="image/jpeg">
+                    <img src="{$state.banner.url|replace:'.webp':'.jpg'}"
+                         {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
+                         {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
+                         {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
+                         class="img img-fluid lazyload" loading="lazy" draggable="false">
+                  </picture>
 
-                <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
-                  {if $state.text_highlight_1}
-                    <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
-                  {/if}
-                  {if $state.text_highlight_2}
-                    <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
-                  {/if}
-                </div>
-              {if isset($state.url) && $state.url}
-                </a>
-              {/if}
-              <button class="slider-arrow prev ever-slider-prev" type="button" aria-label="Previous"></button>
-              <button class="slider-arrow next ever-slider-next" type="button" aria-label="Next"></button>
+                  <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
+                    {if $state.text_highlight_1}
+                      <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
+                    {/if}
+                    {if $state.text_highlight_2}
+                      <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
+                    {/if}
+                  </div>
+                {if isset($state.url) && $state.url}
+                  </a>
+                {/if}
+              </div>
             </div>
+            <button class="slider-arrow prev ever-slider-prev" type="button" aria-label="Previous"></button>
+            <button class="slider-arrow next ever-slider-next" type="button" aria-label="Next"></button>
           </div>
           {if (isset($state.margin_left_mobile) && $state.margin_left_mobile) ||
               (isset($state.margin_right_mobile) && $state.margin_right_mobile) ||


### PR DESCRIPTION
### Motivation
- Fix critical layout shift when the active slide is scaled in `slider-active` mode for the Simple Image prettyblock. 
- Reproduce Apple-like behavior where the active slide is visually scaled without affecting the slider height or the rest of the page. 
- Ensure `transform: scale()` is applied out-of-flow on an absolute inner wrapper rather than the flow element `ever-slider-item` to keep CLS at 0.

### Description
- Introduce a new inner wrapper markup `div.slide-inner` inside each `.ever-slider-item` and move the image markup into that wrapper in `views/templates/hook/prettyblocks/prettyblock_img.tpl` so the scaled element is out of flow. 
- Move slider arrows outside the `.slide-inner` so controls are not affected by the scale transform. 
- Update `views/css/everblock.css` to stop scaling `.ever-slider-item` and instead position `.slide-inner` absolutely (`inset: 0`) with centering and transitions, and apply the `scale`/`opacity`/`filter` rules to `.is-active .slide-inner`, `.is-adjacent .slide-inner`, and `.is-inactive .slide-inner`. 
- Lock item sizing by setting `.ever-slider-item` to `position: relative; height: 100%; overflow: visible;` and set `.everblock-simple-image.slider-active` to `position: relative; padding-bottom: 0;` to maintain a stable slider height.

### Testing
- No automated tests were executed for this change. 
- Changes were limited to template and CSS adjustments and should be validated visually in a browser to confirm Apple-like scaling behavior and no layout shift.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b42b2e3588322a3e7e7132a5b9cc0)