### PR TITLE
Add Heroe Carousel Prettyblock

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -182,6 +182,7 @@ class EverblockPrettyBlocks
             $layoutTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_layout.tpl';
             $featuredCategoryTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl';
             $imgSliderTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_img_slider.tpl';
+            $heroeCarouselTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl';
             $tabTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_tab.tpl';
             $categoryTabsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl';
             $dividerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_divider.tpl';
@@ -2386,6 +2387,71 @@ class EverblockPrettyBlocks
                         'end_date' => [
                             'type' => 'text',
                             'label' => $module->l('End date (YYYY-MM-DD HH:MM:SS)'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('Heroe Carousel'),
+                'description' => $module->l('Premium hero carousel with smooth transitions'),
+                'code' => 'everblock_heroe_carousel',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $heroeCarouselTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'loop' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Loop slides'),
+                            'default' => 1,
+                        ],
+                        'show_arrows' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Show navigation arrows'),
+                            'default' => 1,
+                        ],
+                    ], $module),
+                ],
+                'repeater' => [
+                    'name' => 'Slide',
+                    'nameFrom' => 'title',
+                    'groups' => static::appendSpacingFields([
+                        'image' => [
+                            'type' => 'fileupload',
+                            'label' => 'Hero image',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'image_mobile' => [
+                            'type' => 'fileupload',
+                            'label' => 'Mobile hero image',
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'title' => [
+                            'type' => 'text',
+                            'label' => 'Title',
+                            'default' => Configuration::get('PS_SHOP_NAME'),
+                        ],
+                        'content' => [
+                            'type' => 'textarea',
+                            'label' => 'Text',
+                            'default' => '',
+                        ],
+                        'cta_label' => [
+                            'type' => 'text',
+                            'label' => 'CTA label',
+                            'default' => '',
+                        ],
+                        'cta_link' => [
+                            'type' => 'text',
+                            'label' => 'CTA link',
                             'default' => '',
                         ],
                     ], $module),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3473,3 +3473,168 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Heroe carousel */
+.everblock-heroe-carousel {
+  position: relative;
+  height: 560px;
+  overflow: hidden;
+  background: #0b0b0b;
+  color: #fff;
+  touch-action: pan-y;
+}
+
+.everblock-heroe-carousel .heroe-carousel-track {
+  position: relative;
+  height: 100%;
+}
+
+.everblock-heroe-carousel .heroe-slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: scale(0.92);
+  transition: opacity 0.7s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform, opacity;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.everblock-heroe-carousel .heroe-slide.is-active {
+  opacity: 1;
+  transform: scale(1);
+  z-index: 3;
+}
+
+.everblock-heroe-carousel .heroe-slide.is-next,
+.everblock-heroe-carousel .heroe-slide.is-prev {
+  opacity: 0.35;
+  transform: scale(0.9);
+  z-index: 2;
+}
+
+.everblock-heroe-carousel .heroe-media {
+  position: absolute;
+  inset: 0;
+}
+
+.everblock-heroe-carousel .heroe-media picture,
+.everblock-heroe-carousel .heroe-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.everblock-heroe-carousel .heroe-slide::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0));
+  z-index: 1;
+}
+
+.everblock-heroe-carousel .heroe-content {
+  position: relative;
+  z-index: 2;
+  max-width: 520px;
+  padding: 0 8%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.everblock-heroe-carousel .heroe-title {
+  font-size: clamp(2rem, 3vw, 3.5rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.everblock-heroe-carousel .heroe-text {
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.everblock-heroe-carousel .heroe-cta {
+  align-self: flex-start;
+  padding: 12px 28px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #111827;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.everblock-heroe-carousel .heroe-cta:hover,
+.everblock-heroe-carousel .heroe-cta:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.everblock-heroe-carousel .heroe-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  border: none;
+  z-index: 10;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.everblock-heroe-carousel .heroe-nav::before {
+  content: '';
+  width: 12px;
+  height: 12px;
+  border-top: 2px solid #111827;
+  border-right: 2px solid #111827;
+  display: block;
+  transform: rotate(135deg);
+}
+
+.everblock-heroe-carousel .heroe-next::before {
+  transform: rotate(-45deg);
+}
+
+.everblock-heroe-carousel .heroe-prev {
+  left: 32px;
+}
+
+.everblock-heroe-carousel .heroe-next {
+  right: 32px;
+}
+
+@media (max-width: 1024px) {
+  .everblock-heroe-carousel {
+    height: 500px;
+  }
+}
+
+@media (max-width: 768px) {
+  .everblock-heroe-carousel {
+    height: 420px;
+  }
+
+  .everblock-heroe-carousel .heroe-slide.is-next,
+  .everblock-heroe-carousel .heroe-slide.is-prev {
+    opacity: 0;
+    transform: scale(1);
+  }
+
+  .everblock-heroe-carousel .heroe-content {
+    padding: 0 10%;
+    text-align: center;
+    align-items: center;
+  }
+
+  .everblock-heroe-carousel .heroe-cta {
+    align-self: center;
+  }
+}

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -392,8 +392,102 @@ $(document).ready(function(){
             buildEverblockCarousel($carousel);
         });
     }
+
+    function initHeroeCarousels($context) {
+        var $scope = $context && $context.length ? $context : $(document);
+        $scope.find('.everblock-heroe-carousel').each(function () {
+            var carousel = this;
+            if (carousel.dataset.heroeInit === '1') {
+                return;
+            }
+            var slides = Array.prototype.slice.call(carousel.querySelectorAll('.heroe-slide'));
+            if (!slides.length) {
+                return;
+            }
+            var index = 0;
+            var loop = carousel.dataset.loop !== '0';
+            var showArrows = carousel.dataset.showArrows !== '0';
+            var prevButton = carousel.querySelector('.heroe-prev');
+            var nextButton = carousel.querySelector('.heroe-next');
+            function updateSlides() {
+                var nextIndex = loop ? (index + 1) % slides.length : index + 1;
+                var prevIndex = loop ? (index - 1 + slides.length) % slides.length : index - 1;
+                slides.forEach(function (slide, i) {
+                    slide.classList.remove('is-active', 'is-next', 'is-prev');
+                    if (i === index) {
+                        slide.classList.add('is-active');
+                    } else if (nextIndex >= 0 && nextIndex < slides.length && i === nextIndex) {
+                        slide.classList.add('is-next');
+                    } else if (prevIndex >= 0 && prevIndex < slides.length && i === prevIndex) {
+                        slide.classList.add('is-prev');
+                    }
+                });
+            }
+            function goNext() {
+                if (!loop && index >= slides.length - 1) {
+                    return;
+                }
+                index = loop ? (index + 1) % slides.length : Math.min(index + 1, slides.length - 1);
+                updateSlides();
+            }
+            function goPrev() {
+                if (!loop && index <= 0) {
+                    return;
+                }
+                index = loop ? (index - 1 + slides.length) % slides.length : Math.max(index - 1, 0);
+                updateSlides();
+            }
+
+            updateSlides();
+
+            if (!showArrows || slides.length < 2) {
+                if (prevButton) {
+                    prevButton.style.display = 'none';
+                }
+                if (nextButton) {
+                    nextButton.style.display = 'none';
+                }
+            } else {
+                if (nextButton) {
+                    nextButton.addEventListener('click', function () {
+                        goNext();
+                    });
+                }
+                if (prevButton) {
+                    prevButton.addEventListener('click', function () {
+                        goPrev();
+                    });
+                }
+            }
+
+            if (slides.length > 1) {
+                var touchStartX = 0;
+                var touchStartY = 0;
+                carousel.addEventListener('touchstart', function (event) {
+                    var touch = event.changedTouches[0];
+                    touchStartX = touch.clientX;
+                    touchStartY = touch.clientY;
+                }, { passive: true });
+                carousel.addEventListener('touchend', function (event) {
+                    var touch = event.changedTouches[0];
+                    var deltaX = touch.clientX - touchStartX;
+                    var deltaY = touch.clientY - touchStartY;
+                    if (Math.abs(deltaX) > 50 && Math.abs(deltaX) > Math.abs(deltaY)) {
+                        if (deltaX < 0) {
+                            goNext();
+                        } else {
+                            goPrev();
+                        }
+                    }
+                }, { passive: true });
+            }
+
+            carousel.dataset.heroeInit = '1';
+        });
+    }
     initPrettyblocksImageSlider();
     initEverblockCarousels();
+    initHeroeCarousels();
     var everblockCarouselResizeTimeout = null;
     $(window).on('resize', function () {
         if (everblockCarouselResizeTimeout) {

--- a/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
@@ -1,0 +1,105 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+
+{assign var='heroeLoop' value=(isset($block.settings.loop) && $block.settings.loop)}
+{assign var='showArrows' value=(isset($block.settings.show_arrows) && $block.settings.show_arrows)}
+{assign var='visibleStatesCount' value=0}
+
+{if isset($block.states) && $block.states}
+  {foreach from=$block.states item=state}
+    {assign var='isStateVisible' value=true}
+    {if (not isset($state.image.url) or $state.image.url eq '') and (not isset($state.image_mobile.url) or $state.image_mobile.url eq '')}
+      {assign var='isStateVisible' value=false}
+    {/if}
+    {if $isStateVisible}
+      {assign var='visibleStatesCount' value=$visibleStatesCount+1}
+    {/if}
+  {/foreach}
+{/if}
+
+{if $visibleStatesCount > 0}
+  {assign var='lastVisibleIndex' value=$visibleStatesCount-1}
+  <section id="block-{$block.id_prettyblocks}" class="everblock-heroe-carousel{$prettyblock_visibility_class}" data-loop="{if $heroeLoop}1{else}0{/if}" data-show-arrows="{if $showArrows}1{else}0{/if}" style="{$prettyblock_spacing_style}{if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};{/if}">
+    <div class="heroe-carousel-track">
+      {assign var='slideIndex' value=0}
+      {foreach from=$block.states item=state key=key}
+        {assign var='isStateVisible' value=true}
+        {if (not isset($state.image.url) or $state.image.url eq '') and (not isset($state.image_mobile.url) or $state.image_mobile.url eq '')}
+          {assign var='isStateVisible' value=false}
+        {/if}
+        {if $isStateVisible}
+          {assign var='desktopImageUrl' value=$state.image.url|default:''}
+          {assign var='desktopImageJpgUrl' value=$desktopImageUrl|replace:'.webp':'.jpg'}
+          {assign var='mobileImageUrl' value=$state.image_mobile.url|default:''}
+          {assign var='mobileImageJpgUrl' value=$mobileImageUrl|replace:'.webp':'.jpg'}
+          {if $mobileImageUrl eq '' && $desktopImageUrl ne ''}
+            {assign var='mobileImageUrl' value=$desktopImageUrl}
+            {assign var='mobileImageJpgUrl' value=$desktopImageJpgUrl}
+          {/if}
+          {assign var='fallbackImageUrl' value=$desktopImageUrl|default:$mobileImageUrl}
+          {assign var='fallbackImageJpgUrl' value=$desktopImageJpgUrl|default:$mobileImageJpgUrl}
+          {assign var='fallbackWidth' value=''}
+          {assign var='fallbackHeight' value=''}
+          {if isset($state.image.width) && $state.image.width > 0}
+            {assign var='fallbackWidth' value=$state.image.width|intval}
+          {elseif isset($state.image_mobile.width) && $state.image_mobile.width > 0}
+            {assign var='fallbackWidth' value=$state.image_mobile.width|intval}
+          {/if}
+          {if isset($state.image.height) && $state.image.height > 0}
+            {assign var='fallbackHeight' value=$state.image.height|intval}
+          {elseif isset($state.image_mobile.height) && $state.image_mobile.height > 0}
+            {assign var='fallbackHeight' value=$state.image_mobile.height|intval}
+          {/if}
+          <article class="heroe-slide{if $slideIndex == 0} is-active{elseif $slideIndex == 1} is-next{elseif $slideIndex == $lastVisibleIndex} is-prev{/if}" data-slide-index="{$slideIndex}">
+            <div class="heroe-media">
+              <picture>
+                {if $mobileImageUrl ne ''}
+                  <source media="(max-width: 767.98px)" srcset="{$mobileImageUrl}" type="image/webp">
+                  <source media="(max-width: 767.98px)" srcset="{$mobileImageJpgUrl}" type="image/jpeg">
+                {/if}
+                {if $desktopImageUrl ne ''}
+                  <source media="(min-width: 768px)" srcset="{$desktopImageUrl}" type="image/webp">
+                  <source media="(min-width: 768px)" srcset="{$desktopImageJpgUrl}" type="image/jpeg">
+                {/if}
+                <img src="{$fallbackImageJpgUrl}" alt="{$state.title|default:''|escape:'htmlall':'UTF-8'}"{if $fallbackWidth ne ''} width="{$fallbackWidth}"{/if}{if $fallbackHeight ne ''} height="{$fallbackHeight}"{/if}>
+              </picture>
+            </div>
+            <div class="heroe-content">
+              {if $state.title}
+                <h2 class="heroe-title">{$state.title|escape:'htmlall':'UTF-8'}</h2>
+              {/if}
+              {if $state.content}
+                <div class="heroe-text">{$state.content nofilter}</div>
+              {/if}
+              {if $state.cta_label && $state.cta_link}
+                <a class="heroe-cta" href="{$state.cta_link|escape:'htmlall':'UTF-8'}" title="{$state.cta_label|escape:'htmlall':'UTF-8'}">{$state.cta_label|escape:'htmlall':'UTF-8'}</a>
+              {/if}
+            </div>
+          </article>
+          {assign var='slideIndex' value=$slideIndex+1}
+        {/if}
+      {/foreach}
+    </div>
+    {if $showArrows && $visibleStatesCount > 1}
+      <button class="heroe-nav heroe-prev" type="button" aria-label="{l s='Previous' mod='everblock'}"></button>
+      <button class="heroe-nav heroe-next" type="button" aria-label="{l s='Next' mod='everblock'}"></button>
+    {/if}
+  </section>
+{/if}


### PR DESCRIPTION
### Motivation
- Provide a dedicated premium hero carousel block for hero banners that does not reuse `ever-slider` or bootstrap carousels and respects strict UX/layout rules (fixed height, out-of-flow, CLS=0). 
- Deliver an autonomous, minimal JS + template + CSS implementation tuned for a dominant center slide, adjacent secondary slides, smooth transitions and mobile swipe.

### Description
- Register a new prettyblock type `everblock_heroe_carousel` in `src/Service/EverblockPrettyBlocks.php` with configurable `loop` and `show_arrows` fields and a slide repeater (image, image_mobile, title, content, CTA).
- Add the Smarty template `views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl` implementing the required HTML structure (`.everblock-heroe-carousel` / `.heroe-carousel-track` / `.heroe-slide` with `.is-active/.is-next/.is-prev`) and picture sources for desktop/mobile.
- Add CSS rules in `views/css/everblock.css` that enforce the hero constraints: fixed heights (desktop/tablet/mobile), slides positioned `absolute`, transitions via `opacity` + `transform`, overlay nav styling and responsive adjustments.
- Add autonomous, dependency-free JS in `views/js/everblock.js` (function `initHeroeCarousels`) providing index tracking, `next` / `prev` handlers, arrow visibility logic, and mobile touch swipe handling; initialization is idempotent via a `data-heroe-init` flag.

### Testing
- No automated tests were executed for this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b59cf7b588322874198e4fb037c34)