### PR TITLE
Add prettyblock_heroe_carousel.tpl to allowed files

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -327,6 +327,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_guided_selector.tpl',
     'views/templates/hook/prettyblocks/prettyblock_guides_selection.tpl',
     'views/templates/hook/prettyblocks/prettyblock_heading.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl',
     'views/templates/hook/prettyblocks/prettyblock_iframe.tpl',
     'views/templates/hook/prettyblocks/prettyblock_image_map.tpl',
     'views/templates/hook/prettyblocks/prettyblock_img.tpl',


### PR DESCRIPTION
### Motivation
- Allow the `views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl` template to be whitelisted so the module can load and use this prettyblock without being blocked by the allowed-files check.

### Description
- Inserted `'views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl'` into `config/allowed_files.php`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5b7975588322a7abcb37b55123cd)