### PR TITLE
Heroe carousel: real horizontal track with translateX, index and swipe navigation

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3478,7 +3478,7 @@
 .everblock-heroe-carousel {
   position: relative;
   height: 560px;
-  overflow: hidden;
+  overflow: visible;
   background: #0b0b0b;
   color: #fff;
   touch-action: pan-y;
@@ -3486,12 +3486,15 @@
 
 .everblock-heroe-carousel .heroe-carousel-track {
   position: relative;
+  display: flex;
   height: 100%;
+  transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
 }
 
 .everblock-heroe-carousel .heroe-slide {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  flex: 0 0 100%;
   opacity: 0;
   transform: scale(0.92);
   transition: opacity 0.7s cubic-bezier(0.4, 0, 0.2, 1),

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -404,6 +404,10 @@ $(document).ready(function(){
             if (!slides.length) {
                 return;
             }
+            var track = carousel.querySelector('.heroe-carousel-track');
+            if (!track) {
+                return;
+            }
             var index = 0;
             var loop = carousel.dataset.loop !== '0';
             var showArrows = carousel.dataset.showArrows !== '0';
@@ -412,6 +416,7 @@ $(document).ready(function(){
             function updateSlides() {
                 var nextIndex = loop ? (index + 1) % slides.length : index + 1;
                 var prevIndex = loop ? (index - 1 + slides.length) % slides.length : index - 1;
+                track.style.transform = 'translateX(-' + (index * 100) + '%)';
                 slides.forEach(function (slide, i) {
                     slide.classList.remove('is-active', 'is-next', 'is-prev');
                     if (i === index) {
@@ -474,6 +479,36 @@ $(document).ready(function(){
                     var deltaY = touch.clientY - touchStartY;
                     if (Math.abs(deltaX) > 50 && Math.abs(deltaX) > Math.abs(deltaY)) {
                         if (deltaX < 0) {
+                            goNext();
+                        } else {
+                            goPrev();
+                        }
+                    }
+                }, { passive: true });
+                carousel.addEventListener('pointerdown', function (event) {
+                    if (event.pointerType === 'mouse') {
+                        return;
+                    }
+                    touchStartX = event.clientX;
+                    touchStartY = event.clientY;
+                }, { passive: true });
+                carousel.addEventListener('pointerup', function (event) {
+                    if (event.pointerType === 'mouse') {
+                        return;
+                    }
+                    var deltaXPointer = event.clientX - touchStartX;
+                    var deltaYPointer = event.clientY - touchStartY;
+                    if (Math.abs(deltaXPointer) > 50 && Math.abs(deltaXPointer) > Math.abs(deltaYPointer)) {
+                        if (deltaXPointer < 0) {
+                            goNext();
+                        } else {
+                            goPrev();
+                        }
+                    }
+                }, { passive: true });
+                carousel.addEventListener('wheel', function (event) {
+                    if (Math.abs(event.deltaX) > Math.abs(event.deltaY) && Math.abs(event.deltaX) > 20) {
+                        if (event.deltaX > 0) {
                             goNext();
                         } else {
                             goPrev();


### PR DESCRIPTION
### Motivation
- The existing Heroe carousel behaved like a static/vertical section and lacked a real horizontal track, index, translate-based movement and proper swipe/trackpad navigation. 
- The goal was to convert the current implementation into a true, controlled horizontal carousel with visible adjacent slides and a prominent central slide. 
- Ensure navigation works via `prev`/`next` buttons, touch swipes and trackpad gestures without relying on page vertical scroll.

### Description
- CSS: updated `views/css/everblock.css` to use a real horizontal track by making `.heroe-carousel-track` `display: flex` and adding `transition: transform 0.8s ...` and `will-change: transform`, changed `.heroe-slide` from `position: absolute` to `position: relative` with `flex: 0 0 100%`, and set container overflow to `visible` to allow adjacent slides to be visible. 
- JS: updated `views/js/everblock.js` to wire a real index/track movement by selecting the track and applying `track.style.transform = 'translateX(-' + (index * 100) + '%)'`, preserved the `is-active`/`is-next`/`is-prev` state logic, and added guards for missing track. 
- Interaction: added pointer/touch and `wheel` handlers to support tactile swipes and trackpad horizontal gestures, plus preserved `prev`/`next` button behavior and loop handling; the carousel now advances using the index and transform rather than any vertical scroll or absolute-position illusion.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5d9d6f248322b22d1e87b02dabbb)