### PR TITLE
Fix hero carousel overflow and slide sizing

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3478,7 +3478,7 @@
 .everblock-heroe-carousel {
   position: relative;
   height: 560px;
-  overflow: visible;
+  overflow: hidden;
   background: #0b0b0b;
   color: #fff;
   touch-action: pan-y;
@@ -3488,6 +3488,7 @@
   position: relative;
   display: flex;
   height: 100%;
+  width: 100%;
   transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
   will-change: transform;
 }
@@ -3495,6 +3496,7 @@
 .everblock-heroe-carousel .heroe-slide {
   position: relative;
   flex: 0 0 100%;
+  min-width: 100%;
   opacity: 0;
   transform: scale(0.92);
   transition: opacity 0.7s cubic-bezier(0.4, 0, 0.2, 1),


### PR DESCRIPTION
### Motivation
- Fix the heroe carousel layout where all media are visible at once (causing page overflow) and slides don't transition properly by constraining the visible area and ensuring slides occupy full width.

### Description
- Update `views/css/everblock.css` to change `.everblock-heroe-carousel` from `overflow: visible` to `overflow: hidden`, add `width: 100%` to `.heroe-carousel-track`, and add `min-width: 100%` to `.heroe-slide` so the track and slides size correctly for sliding.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5f7652488322978310e3733313bf)