### PR TITLE
Adjust Heroe carousel layout for Apple-style slider presentation

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3236,6 +3236,8 @@
 
 /* Heroe carousel */
 .everblock-heroe-carousel {
+  --heroe-slide-width: 70%;
+  --heroe-slide-gap: 32px;
   position: relative;
   height: 560px;
   overflow: hidden;
@@ -3247,6 +3249,8 @@
 .everblock-heroe-carousel .heroe-carousel-track {
   position: relative;
   display: flex;
+  align-items: center;
+  gap: var(--heroe-slide-gap);
   height: 100%;
   width: 100%;
   transition: transform 0.8s cubic-bezier(0.4, 0, 0.2, 1);
@@ -3255,8 +3259,9 @@
 
 .everblock-heroe-carousel .heroe-slide {
   position: relative;
-  flex: 0 0 100%;
-  min-width: 100%;
+  flex: 0 0 var(--heroe-slide-width);
+  min-width: var(--heroe-slide-width);
+  height: 100%;
   opacity: 0;
   transform: scale(0.92);
   transition: opacity 0.7s cubic-bezier(0.4, 0, 0.2, 1),
@@ -3278,6 +3283,15 @@
   opacity: 0.35;
   transform: scale(0.9);
   z-index: 2;
+}
+
+.everblock-heroe-carousel .heroe-slide.is-next {
+  filter: grayscale(1);
+  opacity: 0.55;
+}
+
+.everblock-heroe-carousel .heroe-slide.is-prev {
+  opacity: 0.45;
 }
 
 .everblock-heroe-carousel .heroe-media {
@@ -3369,11 +3383,13 @@
 }
 
 .everblock-heroe-carousel .heroe-prev {
-  left: 32px;
+  left: 50%;
+  transform: translate(calc(-50% - (var(--heroe-slide-width) * 0.5) - 24px), -50%);
 }
 
 .everblock-heroe-carousel .heroe-next {
-  right: 32px;
+  left: 50%;
+  transform: translate(calc(-50% + (var(--heroe-slide-width) * 0.5) + 24px), -50%);
 }
 
 @media (max-width: 1024px) {
@@ -3385,6 +3401,8 @@
 @media (max-width: 768px) {
   .everblock-heroe-carousel {
     height: 420px;
+    --heroe-slide-width: 100%;
+    --heroe-slide-gap: 0px;
   }
 
   .everblock-heroe-carousel .heroe-slide.is-next,

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -416,7 +416,18 @@ $(document).ready(function(){
             function updateSlides() {
                 var nextIndex = loop ? (index + 1) % slides.length : index + 1;
                 var prevIndex = loop ? (index - 1 + slides.length) % slides.length : index - 1;
-                track.style.transform = 'translateX(-' + (index * 100) + '%)';
+                var slideWidth = slides[0].getBoundingClientRect().width;
+                var carouselWidth = carousel.getBoundingClientRect().width;
+                var computedGap = 0;
+                if (window.getComputedStyle) {
+                    var trackStyle = window.getComputedStyle(track);
+                    computedGap = parseFloat(trackStyle.columnGap || trackStyle.gap || 0);
+                    if (isNaN(computedGap)) {
+                        computedGap = 0;
+                    }
+                }
+                var offset = index * (slideWidth + computedGap) - (carouselWidth - slideWidth) / 2;
+                track.style.transform = 'translateX(-' + offset + 'px)';
                 slides.forEach(function (slide, i) {
                     slide.classList.remove('is-active', 'is-next', 'is-prev');
                     if (i === index) {
@@ -516,6 +527,10 @@ $(document).ready(function(){
                     }
                 }, { passive: true });
             }
+
+            window.addEventListener('resize', function () {
+                updateSlides();
+            });
 
             carousel.dataset.heroeInit = '1';
         });


### PR DESCRIPTION
### Motivation
- Make the Prettyblock Heroe slider behave like an Apple-style carousel showing three items with a centered active slide, faded/grayscale side slides and directional arrows around the focused item.

### Description
- Update `views/css/everblock.css` to introduce `--heroe-slide-width` and `--heroe-slide-gap`, size slides to a centered fraction, apply grayscale/opacity to side slides and reposition navigation buttons around the active slide.
- Update `views/js/everblock.js` to compute a dynamic `translateX` offset using the slide width and gap so the active slide stays centered and add a `resize` handler to keep layout correct on viewport changes.
- Add responsive override in CSS to fall back to full-width slides on small screens by setting `--heroe-slide-width: 100%` and removing gaps.

### Testing
- Captured an automated visual snapshot using a Playwright script which successfully produced `artifacts/heroe-carousel.png` and completed without errors.
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b62047b608322b71c1bf1dda15b29)