### PR TITLE
Fix Heroe carousel translate offset

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -437,8 +437,17 @@ $(document).ready(function(){
                         computedGap = 0;
                     }
                 }
+                if (!slideWidth || !carouselWidth) {
+                    track.style.transform = 'translateX(0px)';
+                    return;
+                }
                 var offset = index * (slideWidth + computedGap) - (carouselWidth - slideWidth) / 2;
-                track.style.transform = 'translateX(-' + offset + 'px)';
+                var translateX = -offset;
+                if (!isFinite(translateX)) {
+                    track.style.transform = 'translateX(0px)';
+                    return;
+                }
+                track.style.transform = 'translateX(' + translateX + 'px)';
                 slides.forEach(function (slide, i) {
                     slide.classList.remove('is-active', 'is-next', 'is-prev');
                     if (i === index) {


### PR DESCRIPTION
### Motivation
- Prevent the Heroe carousel from computing invalid `translateX` offsets when slide or carousel sizes are zero/NaN which can break click/touch navigation.

### Description
- Add guards in `initHeroeCarousels` `updateSlides()` in `views/js/everblock.js` to early-return when `slideWidth` or `carouselWidth` are falsy and to validate `translateX` with `isFinite`, falling back to `translateX(0px)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b65e98a8c8322b81c6c6e46d583ad)