### PR TITLE
Force infinite one-by-one scrolling and keep active slide centered in Heroe carousel

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -411,7 +411,7 @@ $(document).ready(function(){
             }
             var index = 0;
             var total = slides.length;
-            var loop = carousel.dataset.loop !== '0';
+            var loop = true;
             var showArrows = carousel.dataset.showArrows !== '0';
             var prevButton = carousel.querySelector('.heroe-prev');
             var nextButton = carousel.querySelector('.heroe-next');
@@ -446,9 +446,11 @@ $(document).ready(function(){
                 var offset = 0;
                 if (activeSlide && viewport) {
                     var viewportWidth = viewport.offsetWidth;
-                    var maxOffset = Math.max(0, track.scrollWidth - viewportWidth);
                     var slideWidth = activeSlide.offsetWidth;
-                    offset = Math.min(Math.max(0, index * slideWidth), maxOffset);
+                    var centerOffset = Math.max(0, (viewportWidth - slideWidth) / 2);
+                    track.style.paddingLeft = centerOffset + 'px';
+                    track.style.paddingRight = centerOffset + 'px';
+                    offset = index * slideWidth;
                 }
                 track.style.transform = 'translateX(-' + offset + 'px)';
                 slides.forEach(function (slide, i) {


### PR DESCRIPTION
### Motivation
- Ensure the Heroe carousel always loops infinitely and advances one slide at a time while keeping the active slide visually centered in the viewport.
- Make looping unconditional to satisfy the requirement for continuous scrolling even if the dataset attribute is unset or disabled.
- No external skills were required to implement this change.

### Description
- Force `loop = true` in the `initHeroeCarousels` initialization to enable infinite scrolling unconditionally in `views/js/everblock.js`.
- Preserve and use the `updateSlides()` centering logic which computes a `centerOffset`, applies it to `track.style.paddingLeft` and `track.style.paddingRight`, and sets the horizontal translation using `offset = index * slideWidth` so the active slide is centered.
- Keep existing navigation and state logic intact so previous/next buttons remain enabled when looping and slide role classes (`is-active`, `is-prev`, `is-next`) continue to be assigned correctly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b861a1e64832287edd7fc2d912501)