### PR TITLE
Set middle slide as initial active in Heroe carousel

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -409,8 +409,12 @@ $(document).ready(function(){
             if (!track) {
                 return;
             }
-            var index = 0;
+            var index = parseInt(carousel.dataset.startIndex, 10);
             var total = slides.length;
+            if (isNaN(index)) {
+                index = 0;
+            }
+            index = Math.min(Math.max(index, 0), total - 1);
             var loop = carousel.dataset.loop !== '0';
             var showArrows = carousel.dataset.showArrows !== '0';
             var prevButton = carousel.querySelector('.heroe-prev');

--- a/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
@@ -36,7 +36,8 @@
 
 {if $visibleStatesCount > 0}
   {assign var='lastVisibleIndex' value=$visibleStatesCount-1}
-  <section id="block-{$block.id_prettyblocks}" class="everblock-heroe-carousel{$prettyblock_visibility_class}" data-loop="{if $heroeLoop}1{else}0{/if}" data-show-arrows="{if $showArrows}1{else}0{/if}" style="{$prettyblock_spacing_style}">
+  {assign var='middleVisibleIndex' value=($visibleStatesCount/2)|floor}
+  <section id="block-{$block.id_prettyblocks}" class="everblock-heroe-carousel{$prettyblock_visibility_class}" data-loop="{if $heroeLoop}1{else}0{/if}" data-show-arrows="{if $showArrows}1{else}0{/if}" data-start-index="{$middleVisibleIndex}" style="{$prettyblock_spacing_style}">
     <div class="heroe-carousel">
       <div class="heroe-viewport">
         <div class="heroe-track">
@@ -69,7 +70,7 @@
               {elseif isset($state.image_mobile.height) && $state.image_mobile.height > 0}
                 {assign var='fallbackHeight' value=$state.image_mobile.height|intval}
               {/if}
-              <article class="heroe-slide{if $slideIndex == 0} is-active{/if}" data-slide-index="{$slideIndex}">
+              <article class="heroe-slide{if $slideIndex == $middleVisibleIndex} is-active{/if}" data-slide-index="{$slideIndex}">
                 <div class="heroe-media">
                   <picture>
                     {if $mobileImageUrl ne ''}


### PR DESCRIPTION
### Motivation
- The Heroe carousel applied `is-active` to the first slide, causing opacity to be inverted; only the center slide should be fully opaque on load. 
- Ensure the center slide is marked active at render time so JS and CSS opacity rules are consistent.

### Description
- Compute the middle visible slide index in the template with `middleVisibleIndex` and expose it via `data-start-index` on the carousel section. 
- Mark the middle slide with the `is-active` class in `views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl` instead of the first slide. 
- Update `initHeroeCarousels` in `views/js/everblock.js` to read `data-start-index`, clamp it to `[0, total-1]`, and use it as the initial `index` so JS state matches the server-rendered active slide.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8a6a41248322b83f3c9c015cfdab)