### PR TITLE
Start Heroe carousel on second slide and center active slide

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -452,7 +452,11 @@ $(document).ready(function(){
                     var viewportWidth = viewport.offsetWidth;
                     var maxOffset = Math.max(0, track.scrollWidth - viewportWidth);
                     var slideWidth = activeSlide.offsetWidth;
-                    offset = Math.min(Math.max(0, index * slideWidth), maxOffset);
+                    if (slideWidth > 0) {
+                        var slidesPerView = Math.max(1, Math.round(viewportWidth / slideWidth));
+                        var centerOffset = Math.floor(slidesPerView / 2);
+                        offset = Math.min(Math.max(0, (index - centerOffset) * slideWidth), maxOffset);
+                    }
                 }
                 track.style.transform = 'translateX(-' + offset + 'px)';
                 slides.forEach(function (slide, i) {

--- a/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl
@@ -36,8 +36,11 @@
 
 {if $visibleStatesCount > 0}
   {assign var='lastVisibleIndex' value=$visibleStatesCount-1}
-  {assign var='middleVisibleIndex' value=($visibleStatesCount/2)|floor}
-  <section id="block-{$block.id_prettyblocks}" class="everblock-heroe-carousel{$prettyblock_visibility_class}" data-loop="{if $heroeLoop}1{else}0{/if}" data-show-arrows="{if $showArrows}1{else}0{/if}" data-start-index="{$middleVisibleIndex}" style="{$prettyblock_spacing_style}">
+  {assign var='startVisibleIndex' value=0}
+  {if $visibleStatesCount > 1}
+    {assign var='startVisibleIndex' value=1}
+  {/if}
+  <section id="block-{$block.id_prettyblocks}" class="everblock-heroe-carousel{$prettyblock_visibility_class}" data-loop="{if $heroeLoop}1{else}0{/if}" data-show-arrows="{if $showArrows}1{else}0{/if}" data-start-index="{$startVisibleIndex}" style="{$prettyblock_spacing_style}">
     <div class="heroe-carousel">
       <div class="heroe-viewport">
         <div class="heroe-track">
@@ -70,7 +73,7 @@
               {elseif isset($state.image_mobile.height) && $state.image_mobile.height > 0}
                 {assign var='fallbackHeight' value=$state.image_mobile.height|intval}
               {/if}
-              <article class="heroe-slide{if $slideIndex == $middleVisibleIndex} is-active{/if}" data-slide-index="{$slideIndex}">
+              <article class="heroe-slide{if $slideIndex == $startVisibleIndex} is-active{/if}" data-slide-index="{$slideIndex}">
                 <div class="heroe-media">
                   <picture>
                     {if $mobileImageUrl ne ''}


### PR DESCRIPTION
### Motivation
- Ensure the Her oe (Heroe) slider always starts with the second visible image active while keeping the first image visible and opaque and scrolling one image at a time.

### Description
- Template change: set `data-start-index` to `1` when more than one visible state and mark that slide as `is-active` in `views/templates/hook/prettyblocks/prettyblock_heroe_carousel.tpl` so the carousel initially shows image 2 as active while image 1 remains visible.
- JS change: update `updateSlides()` in `views/js/everblock.js` to compute `slidesPerView` from `viewportWidth / slideWidth` and apply a `centerOffset` so the active slide is centered in the viewport when possible.
- The offset calculation clamps between `0` and `maxOffset` to avoid overflowing the track and only runs when `slideWidth > 0` to prevent NaN/invalid arithmetic.
- No other interactive behaviors (touch swipe, navigation) were changed; the carousel still advances one slide per navigation action.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8d5a6c8c8322a4931a314c3f0d5e)