### PR TITLE
Adjust mobile hero carousel navigation placement

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3409,4 +3409,21 @@
   .everblock-heroe-carousel .heroe-cta {
     align-self: center;
   }
+
+  .everblock-heroe-carousel .heroe-nav {
+    top: auto;
+    bottom: 16px;
+    transform: none;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
+  }
+
+  .everblock-heroe-carousel .heroe-prev {
+    left: 16px;
+  }
+
+  .everblock-heroe-carousel .heroe-next {
+    left: auto;
+    right: 16px;
+  }
 }


### PR DESCRIPTION
### Motivation
- On small screens the hero slider navigation buttons overlay the hero image and reduce content readability, so the nav buttons need to be moved out of the image area and given contrast for accessibility.

### Description
- Update `views/css/everblock.css` to add mobile-specific rules under `@media (max-width: 768px)` that reposition `.heroe-nav` to the bottom (`bottom: 16px`), remove the vertical translate, add a semi-opaque white `background` and `box-shadow` for contrast, and place `.heroe-prev` at `left: 16px` and `.heroe-next` at `right: 16px` so controls no longer sit on top of the image.

### Testing
- No automated tests were executed for this visual/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b8f375b04832288320c04ada182ba)