### PR TITLE
Limit Prettyblocks to first guides listing page

### DIFF
--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -73,6 +73,7 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
 
         $structuredData = $this->buildItemListStructuredData($pages, $pageLinks);
         $isPrettyBlocksEnabled = $this->isPrettyBlocksEnabled();
+        $showPageOneBlocks = $isPrettyBlocksEnabled && $currentPage === 1;
         $pagination = $this->buildPagination(
             $currentPage,
             $totalPages,
@@ -84,9 +85,10 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
             'everblock_pages' => $pages,
             'everblock_page_links' => $pageLinks,
             'everblock_structured_data' => $structuredData,
-            'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
-            'everblock_prettyblocks_top_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone_top' : '',
-            'everblock_prettyblocks_bottom_zone_name' => $isPrettyBlocksEnabled ? 'everblock_pages_listing_zone_bottom' : '',
+            'everblock_prettyblocks_enabled' => $showPageOneBlocks,
+            'everblock_prettyblocks_top_zone_name' => $showPageOneBlocks ? 'everblock_pages_listing_zone_top' : '',
+            'everblock_prettyblocks_bottom_zone_name' => $showPageOneBlocks ? 'everblock_pages_listing_zone_bottom' : '',
+            'everblock_is_first_page' => $currentPage === 1,
             'everblock_pagination' => $pagination,
         ]);
 


### PR DESCRIPTION
### Motivation
- Allow editors to add content (top/bottom zones) that appears only on the first guides listing page and provide a flag for template-level customizations (e.g. header/footer text on page 1).

### Description
- Compute `$showPageOneBlocks` as `isPrettyBlocksEnabled && $currentPage === 1` in `controllers/front/pages.php`.
- Use `$showPageOneBlocks` to set `everblock_prettyblocks_enabled` and the top/bottom zone names passed to Smarty.
- Expose `everblock_is_first_page` boolean to the template for future use.
- Changes are limited to `controllers/front/pages.php` template variable assignments.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5b7f7e6c83228b721d44a22a942c)