### PR TITLE
Prefer Tools::str2url for slug normalization (PS 9 compatibility, fallback to link_rewrite)

### DIFF
--- a/controllers/admin/AdminEverBlockPageController.php
+++ b/controllers/admin/AdminEverBlockPageController.php
@@ -378,7 +378,9 @@ class AdminEverBlockPageController extends ModuleAdminController
                 if (!$rewrite) {
                     $rewrite = Tools::getValue('name_' . $langId);
                 }
-                $page->link_rewrite[$langId] = Tools::link_rewrite($rewrite);
+                $page->link_rewrite[$langId] = method_exists('Tools', 'str2url')
+                    ? Tools::str2url($rewrite)
+                    : Tools::link_rewrite($rewrite);
                 $page->content[$langId] = Tools::getValue('content_' . $langId, false);
             }
 

--- a/controllers/front/slotmachine.php
+++ b/controllers/front/slotmachine.php
@@ -579,7 +579,11 @@ class EverblockSlotmachineModuleFrontController extends ModuleFrontController
         foreach ($symbols as $symbol) {
             $key = isset($symbol['symbol_key']) && $symbol['symbol_key'] !== ''
                 ? (string) $symbol['symbol_key']
-                : Tools::strtolower(Tools::link_rewrite((string) ($symbol['label'] ?? 'symbol')));
+                : Tools::strtolower(
+                    method_exists('Tools', 'str2url')
+                        ? Tools::str2url((string) ($symbol['label'] ?? 'symbol'))
+                        : Tools::link_rewrite((string) ($symbol['label'] ?? 'symbol'))
+                );
             $label = '';
             if (isset($symbol['label'])) {
                 if (is_array($symbol['label'])) {

--- a/everblock.php
+++ b/everblock.php
@@ -3197,7 +3197,9 @@ class Everblock extends Module
         }
         Configuration::updateValue(
             'EVERBLOCK_PAGES_BASE_URL',
-            Tools::link_rewrite($pagesBaseUrl)
+            method_exists('Tools', 'str2url')
+                ? Tools::str2url($pagesBaseUrl)
+                : Tools::link_rewrite($pagesBaseUrl)
         );
         $pagesPerPage = (int) Tools::getValue('EVERBLOCK_PAGES_PER_PAGE');
         if ($pagesPerPage <= 0) {
@@ -3213,7 +3215,9 @@ class Everblock extends Module
         }
         Configuration::updateValue(
             'EVERBLOCK_FAQ_BASE_URL',
-            Tools::link_rewrite($faqBaseUrl)
+            method_exists('Tools', 'str2url')
+                ? Tools::str2url($faqBaseUrl)
+                : Tools::link_rewrite($faqBaseUrl)
         );
         $faqPerPage = (int) Tools::getValue('EVERBLOCK_FAQ_PER_PAGE');
         if ($faqPerPage <= 0) {
@@ -6027,7 +6031,9 @@ class Everblock extends Module
         foreach ($states as &$state) {
             $question = isset($state['question']) ? trim($state['question']) : '';
             $state['question'] = $question;
-            $state['key'] = Tools::link_rewrite($question);
+            $state['key'] = method_exists('Tools', 'str2url')
+                ? Tools::str2url($question)
+                : Tools::link_rewrite($question);
 
             $answers = [];
             $lines = preg_split("/(\r\n|\r|\n)/", $state['answers'] ?? '');
@@ -6041,7 +6047,9 @@ class Everblock extends Module
                 $answers[] = [
                     'text' => $text,
                     'link' => $link,
-                    'value' => Tools::link_rewrite($text),
+                    'value' => method_exists('Tools', 'str2url')
+                        ? Tools::str2url($text)
+                        : Tools::link_rewrite($text),
                 ];
             }
             $state['answers'] = $answers;
@@ -6222,10 +6230,14 @@ class Everblock extends Module
     public function hookModuleRoutes($params)
     {
         $base = Configuration::get('EVERBLOCK_PAGES_BASE_URL') ?: 'guide';
-        $base = Tools::link_rewrite($base ? (string) $base : 'guide');
+        $base = method_exists('Tools', 'str2url')
+            ? Tools::str2url($base ? (string) $base : 'guide')
+            : Tools::link_rewrite($base ? (string) $base : 'guide');
 
         $faqBase = Configuration::get('EVERBLOCK_FAQ_BASE_URL') ?: 'faq';
-        $faqBase = Tools::link_rewrite($faqBase ? (string) $faqBase : 'faq');
+        $faqBase = method_exists('Tools', 'str2url')
+            ? Tools::str2url($faqBase ? (string) $faqBase : 'faq')
+            : Tools::link_rewrite($faqBase ? (string) $faqBase : 'faq');
 
         return [
             'module-everblock-pages' => [

--- a/models/EverblockPage.php
+++ b/models/EverblockPage.php
@@ -353,7 +353,9 @@ class EverblockPage extends ObjectModel
             if (!$rewrite) {
                 $rewrite = $name;
             }
-            $this->link_rewrite[$langId] = Tools::link_rewrite((string) $rewrite);
+            $this->link_rewrite[$langId] = method_exists('Tools', 'str2url')
+                ? Tools::str2url((string) $rewrite)
+                : Tools::link_rewrite((string) $rewrite);
         }
     }
 

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -6029,7 +6029,10 @@ class EverblockTools extends ObjectModel
 
         $filenameBase = pathinfo($path, PATHINFO_FILENAME);
         if (!$filenameBase) {
-            $filenameBase = Tools::link_rewrite($title) ?: 'image';
+            $filenameBase = method_exists('Tools', 'str2url')
+                ? Tools::str2url($title)
+                : Tools::link_rewrite($title);
+            $filenameBase = $filenameBase ?: 'image';
         }
         $filenameBase = self::sanitizeFileName($filenameBase);
         if ($filenameBase === '') {
@@ -6080,7 +6083,9 @@ class EverblockTools extends ObjectModel
 
     private static function sanitizeFileName(string $fileName): string
     {
-        $normalized = Tools::link_rewrite($fileName);
+        $normalized = method_exists('Tools', 'str2url')
+            ? Tools::str2url($fileName)
+            : Tools::link_rewrite($fileName);
         $normalized = preg_replace('/[^a-z0-9\-]+/i', '-', (string) $normalized);
         $normalized = preg_replace('/-+/', '-', (string) $normalized);
 


### PR DESCRIPTION
### Motivation
- Prestashop 9 deprecates/changes `Tools::link_rewrite` in favor of `Tools::str2url`, so the module must prefer `str2url` while remaining compatible with Prestashop 8.
- Ensure slug/filename normalization and route rules produce correct, stable rewrites across PS versions.

### Description
- Replace direct `Tools::link_rewrite` calls with a conditional that uses `Tools::str2url` when available and falls back to `Tools::link_rewrite` otherwise across the module. 
- Update module configuration handling for `EVERBLOCK_PAGES_BASE_URL` and `EVERBLOCK_FAQ_BASE_URL` and route generation in `hookModuleRoutes` in `everblock.php`.
- Normalize guided selector keys/answers and route rewrites in `everblock.php` to use the new conditional logic.
- Update admin, model and front-end generation of slugs and filenames in `controllers/admin/AdminEverBlockPageController.php`, `models/EverblockPage.php`, `controllers/front/slotmachine.php`, and `src/Service/EverblockTools.php` to prefer `Tools::str2url` with fallback.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce5cd79a483228666932b4e3e9074)