### PR TITLE
Ensure guide author column is added on existing installs

### DIFF
--- a/controllers/admin/AdminEverBlockPageController.php
+++ b/controllers/admin/AdminEverBlockPageController.php
@@ -256,6 +256,8 @@ class AdminEverBlockPageController extends ModuleAdminController
             $coverImage = _PS_IMG_ . 'pages/' . $obj->cover_image;
         }
 
+        $employeeChoices = $this->getEmployeeChoices();
+
         $this->fields_form = [
             'legend' => [
                 'title' => $this->l('Page'),
@@ -298,6 +300,18 @@ class AdminEverBlockPageController extends ModuleAdminController
                     'label' => $this->l('Meta description'),
                     'name' => 'meta_description',
                     'lang' => true,
+                ],
+                [
+                    'type' => 'select',
+                    'label' => $this->l('Author'),
+                    'name' => 'id_employee',
+                    'required' => false,
+                    'options' => [
+                        'query' => $employeeChoices,
+                        'id' => 'id_employee',
+                        'name' => 'name',
+                    ],
+                    'desc' => $this->l('Select a PrestaShop employee to display as the guide author.'),
                 ],
                 [
                     'type' => 'textarea',
@@ -361,6 +375,8 @@ class AdminEverBlockPageController extends ModuleAdminController
         if (Tools::isSubmit('submitAdd' . $this->table) || Tools::isSubmit('submitAdd' . $this->table . 'AndStay')) {
             $page = new EverblockPage((int) Tools::getValue($this->identifier));
             $page->id_shop = (int) $this->context->shop->id;
+            $authorId = (int) Tools::getValue('id_employee');
+            $page->id_employee = $authorId > 0 ? $authorId : null;
             $page->active = (int) Tools::getValue('active');
             $page->groups = json_encode($this->getSelectedGroups());
             $positionInput = Tools::getValue('position');
@@ -421,6 +437,26 @@ class AdminEverBlockPageController extends ModuleAdminController
         }
 
         return array_values(array_unique(array_map('intval', $groups)));
+    }
+
+    protected function getEmployeeChoices(): array
+    {
+        $choices = [
+            [
+                'id_employee' => 0,
+                'name' => $this->l('No author'),
+            ],
+        ];
+
+        $employees = Employee::getEmployees((int) $this->context->language->id, true);
+        foreach ($employees as $employee) {
+            $choices[] = [
+                'id_employee' => (int) $employee['id_employee'],
+                'name' => trim($employee['firstname'] . ' ' . $employee['lastname']),
+            ];
+        }
+
+        return $choices;
     }
 
     protected function handleImageUpload()

--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -86,6 +86,17 @@ class EverblockPageModuleFrontController extends ModuleFrontController
             );
         }
 
+        $authorData = null;
+        if (!empty($page->id_employee)) {
+            $employee = new Employee((int) $page->id_employee);
+            if (Validate::isLoadedObject($employee)) {
+                $authorData = [
+                    'name' => trim($employee->firstname . ' ' . $employee->lastname),
+                    'email' => (string) $employee->email,
+                ];
+            }
+        }
+
         $this->everblockPage = $page;
 
         $this->context->smarty->assign([
@@ -94,6 +105,7 @@ class EverblockPageModuleFrontController extends ModuleFrontController
             'everblock_page_image' => $page->cover_image
                 ? $this->context->link->getMediaLink(_PS_IMG_ . 'pages/' . $page->cover_image)
                 : '',
+            'everblock_page_author' => $authorData,
             'everblock_structured_data' => $this->buildItemListStructuredData($pages, $pageLinks),
             'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,
             'everblock_prettyblocks_zone_name' => $isPrettyBlocksEnabled ? 'everblock_page_zone_' . (int) $page->id : '',

--- a/models/EverblockPage.php
+++ b/models/EverblockPage.php
@@ -28,6 +28,7 @@ class EverblockPage extends ObjectModel
 {
     public $id_everblock_page;
     public $id_shop;
+    public $id_employee;
     public $groups;
     public $active;
     public $cover_image;
@@ -52,6 +53,12 @@ class EverblockPage extends ObjectModel
                 'lang' => false,
                 'validate' => 'isUnsignedInt',
                 'required' => true,
+            ],
+            'id_employee' => [
+                'type' => self::TYPE_INT,
+                'lang' => false,
+                'validate' => 'isUnsignedInt',
+                'required' => false,
             ],
             'groups' => [
                 'type' => self::TYPE_STRING,

--- a/sql/install.php
+++ b/sql/install.php
@@ -178,6 +178,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_game_play` (
 $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'everblock_page` (
         `id_everblock_page` int(10) unsigned NOT NULL auto_increment,
         `id_shop` int(10) unsigned NOT NULL DEFAULT 1,
+        `id_employee` int(10) unsigned DEFAULT NULL,
         `groups` text DEFAULT NULL,
         `cover_image` varchar(255) DEFAULT NULL,
         `active` int(10) unsigned NOT NULL DEFAULT 1,

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -4584,6 +4584,7 @@ class EverblockTools extends ObjectModel
     public static function checkAndFixDatabase()
     {
         $db = Db::getInstance(_PS_USE_SQL_SLAVE_);
+        $dbMaster = Db::getInstance();
         $tableNames = [
             _DB_PREFIX_ . 'everblock',
             _DB_PREFIX_ . 'everblock_lang',
@@ -4816,9 +4817,15 @@ class EverblockTools extends ObjectModel
             $columnsToAdd,
             'Unable to update Ever Block game play database'
         );
+        $pageTable = _DB_PREFIX_ . 'everblock_page';
+        $columnExists = $dbMaster->executeS('SHOW COLUMNS FROM `' . $pageTable . '` LIKE "id_employee"');
+        if (!$columnExists) {
+            $dbMaster->execute('ALTER TABLE `' . $pageTable . '` ADD `id_employee` int(10) unsigned DEFAULT NULL AFTER `id_shop`');
+        }
         // Ajoute les colonnes manquantes à la table everblock_page
         $columnsToAdd = [
             'id_shop' => 'int(10) unsigned NOT NULL DEFAULT 1',
+            'id_employee' => 'int(10) unsigned DEFAULT NULL',
             'groups' => 'text DEFAULT NULL',
             'cover_image' => 'varchar(255) DEFAULT NULL',
             'active' => 'int(10) unsigned NOT NULL DEFAULT 1',

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -24,6 +24,14 @@
     <div class="everblock-page__content rte" itemprop="articleBody">
       {$everblock_page_content nofilter}
     </div>
+    {if !empty($everblock_page_author)}
+      <footer class="everblock-page__footer mt-4">
+        <p class="everblock-page__author small text-muted mb-0" itemprop="author" itemscope itemtype="https://schema.org/Person">
+          <span class="everblock-page__author-label">{l s='Author' mod='everblock' d='Modules.Everblock.Front'}:</span>
+          <span itemprop="name">{$everblock_page_author.name|escape:'htmlall':'UTF-8'}</span>
+        </p>
+      </footer>
+    {/if}
   </article>
 
   {if $everblock_prettyblocks_enabled}


### PR DESCRIPTION
### Motivation
- Ensure existing installations receive the `id_employee` author column automatically so the author feature does not break on upgrades.

### Description
- Add a master DB connection and an explicit check in `EverblockTools::checkAndFixDatabase` that runs `SHOW COLUMNS ... LIKE "id_employee"` and executes `ALTER TABLE ... ADD id_employee` when the column is missing, by introducing `$dbMaster` and guarding the schema change.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf52b495c83229517d4180517e9ea)