### PR TITLE
Add explicit image dimensions for page cover and Instagram thumbnails

### DIFF
--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -99,12 +99,13 @@ class EverblockPageModuleFrontController extends ModuleFrontController
 
         $this->everblockPage = $page;
 
+        $coverImageData = $page->getCoverImageData($this->context);
+
         $this->context->smarty->assign([
             'everblock_page' => $page,
             'everblock_page_content' => $renderedContent,
-            'everblock_page_image' => $page->cover_image
-                ? $this->context->link->getMediaLink(_PS_IMG_ . 'pages/' . $page->cover_image)
-                : '',
+            'everblock_page_image' => $coverImageData['url'] ?? '',
+            'everblock_page_image_data' => $coverImageData,
             'everblock_page_author' => $authorData,
             'everblock_structured_data' => $this->buildItemListStructuredData($pages, $pageLinks),
             'everblock_prettyblocks_enabled' => $isPrettyBlocksEnabled,

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -5507,6 +5507,21 @@ class EverblockTools extends ObjectModel
                         }
                     }
 
+                    $width = 0;
+                    $height = 0;
+                    if (is_file($filePath)) {
+                        $imageSize = @getimagesize($filePath);
+                        if ($imageSize) {
+                            $width = (int) $imageSize[0];
+                            $height = (int) $imageSize[1];
+                        }
+                    }
+
+                    if ($width <= 0 || $height <= 0) {
+                        $width = 320;
+                        $height = 320;
+                    }
+
                     $imgs[] = [
                         'id' => isset($post['id']) ? $post['id'] : $post['id'],
                         'permalink' => isset($post['permalink']) ? $post['permalink'] : '',
@@ -5515,6 +5530,8 @@ class EverblockTools extends ObjectModel
                         'standard_resolution' => $webPath,
                         'caption' => isset($post['caption']) ? $post['caption'] : '',
                         'is_video' => strpos($mediaUrl, '.mp4') !== false,
+                        'width' => $width,
+                        'height' => $height,
                     ];
                 }
             }

--- a/views/templates/front/page.tpl
+++ b/views/templates/front/page.tpl
@@ -4,9 +4,14 @@
   <article class="everblock-page" itemscope itemtype="https://schema.org/Article">
     <header class="everblock-page__header">
       <h1 itemprop="headline">{$everblock_page->title|default:''}</h1>
-      {if $everblock_page_image}
+      {if !empty($everblock_page_image_data.url)}
         <figure class="everblock-page__cover">
-            <img src="{$everblock_page_image}" alt="{$everblock_page->title|default:''|escape:'htmlall':'UTF-8'}" loading="lazy" itemprop="image">
+            <img src="{$everblock_page_image_data.url|escape:'htmlall':'UTF-8'}"
+                 alt="{$everblock_page->title|default:''|escape:'htmlall':'UTF-8'}"
+                 loading="lazy"
+                 itemprop="image"
+                 width="{$everblock_page_image_data.width|intval}"
+                 height="{$everblock_page_image_data.height|intval}">
         </figure>
       {/if}
       {if $everblock_page->short_description}

--- a/views/templates/hook/instagram.tpl
+++ b/views/templates/hook/instagram.tpl
@@ -35,6 +35,8 @@
                 src="{$img.thumbnail|escape:'quotes':'UTF-8'}"
                 alt="{$img.caption|escape:'html':'UTF-8'}"
                 loading="lazy"
+                width="{$img.width|intval}"
+                height="{$img.height|intval}"
               />
             </picture>
           </a>


### PR DESCRIPTION
### Motivation
- Reduce cumulative layout shift (CLS) by ensuring images render with explicit `width` and `height` attributes. 
- The page cover (hero) and Instagram carousel thumbnails previously lacked dimensions, causing layout shifts that hurt Core Web Vitals and SEO. 

### Description
- Use `EverblockPage::getCoverImageData` in `controllers/front/page.php` and expose `everblock_page_image_data` (URL, `width`, `height`, `alt`) to templates. 
- Render the page cover `<img>` with `width` and `height` in `views/templates/front/page.tpl` using `{$everblock_page_image_data.width}` and `{$everblock_page_image_data.height}`. 
- When fetching Instagram posts in `src/Service/EverblockTools.php`, compute image dimensions with `getimagesize()` (with a fallback size) and include `width`/`height` in each cached item. 
- Output `width` and `height` attributes for Instagram thumbnails in `views/templates/hook/instagram.tpl` to stabilize the carousel layout. 

### Testing
- No automated tests were executed for this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dabba664c8322a7e27642734dc36d)