### PR TITLE
Add PrettyBlocks FAQ selection block and allowlist template

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -319,6 +319,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_everblock.tpl',
     'views/templates/hook/prettyblocks/prettyblock_exit_intent.tpl',
     'views/templates/hook/prettyblocks/prettyblock_faq.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_faq_selection.tpl',
     'views/templates/hook/prettyblocks/prettyblock_flash_deals.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gallery.tpl',
     'views/templates/hook/prettyblocks/prettyblock_gmap.tpl',

--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -178,6 +178,7 @@ class EverblockPrettyBlocks
             $shoppingCartTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_shopping_cart.tpl';
             $accordeonTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_accordeon.tpl';
             $faqTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_faq.tpl';
+            $faqSelectionTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_faq_selection.tpl';
             $textAndImageTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_text_and_image.tpl';
             $layoutTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_layout.tpl';
             $featuredCategoryTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_category_highlight.tpl';
@@ -668,6 +669,44 @@ class EverblockPrettyBlocks
                             'tab' => 'design',
                             'type' => 'color',
                             'label' => $module->l('Badge text color'),
+                            'default' => '',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('FAQ selection'),
+                'description' => $module->l('Display selected registered FAQs as an accordion list.'),
+                'code' => 'everblock_faq_selection',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $faqSelectionTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'title' => [
+                            'type' => 'text',
+                            'label' => $module->l('Section title'),
+                            'default' => $module->l('Frequently asked questions'),
+                        ],
+                    ], $module),
+                ],
+                'repeater' => [
+                    'name' => 'FAQ',
+                    'nameFrom' => 'faq',
+                    'groups' => static::appendSpacingFields([
+                        'faq' => [
+                            'type' => 'selector',
+                            'label' => $module->l('FAQ entry'),
+                            'collection' => 'EverblockFaq',
+                            'selector' => '{id} - {title}',
                             'default' => '',
                         ],
                         'css_class' => [

--- a/views/templates/hook/prettyblocks/prettyblock_faq_selection.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_faq_selection.tpl
@@ -1,0 +1,53 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    Team Ever <https://www.team-ever.com/>
+ * @copyright 2019-2025 Team Ever
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/visibility_class.tpl'}
+{include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$block.settings assign='prettyblock_spacing_style'}
+{capture name='prettyblock_faq_selection_wrapper_style'}
+  {$prettyblock_spacing_style}
+{/capture}
+{assign var='prettyblock_faq_selection_wrapper_style' value=$smarty.capture.prettyblock_faq_selection_wrapper_style|trim}
+
+<section id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_faq_selection_wrapper_style} style="{$prettyblock_faq_selection_wrapper_style}"{/if}>
+  {if $block.settings.title}
+    <h2 class="mb-4">{$block.settings.title|escape:'htmlall':'UTF-8'}</h2>
+  {/if}
+  {assign var=faqIds value=[]}
+  {if isset($block.states) && $block.states}
+    {foreach from=$block.states item=state}
+      {assign var=faqId value=0}
+      {if isset($state.faq.id) && $state.faq.id}
+        {assign var=faqId value=$state.faq.id|intval}
+      {elseif isset($state.faq.id_everblock_faq) && $state.faq.id_everblock_faq}
+        {assign var=faqId value=$state.faq.id_everblock_faq|intval}
+      {elseif $state.faq|default:''}
+        {assign var=faqId value=$state.faq|intval}
+      {/if}
+      {if $faqId}
+        {assign var=faqIds value=$faqIds|@array_merge:[$faqId]}
+      {/if}
+    {/foreach}
+  {/if}
+  {assign var=faqIds value=$faqIds|@array_unique}
+  {if $faqIds}
+    {assign var=context value=Context::getContext()}
+    {assign var=everFaqs value=EverblockFaq::getByIds($faqIds, (int) $context->language->id, (int) $context->shop->id, true)}
+    {if $everFaqs}
+      {include file='module:everblock/views/templates/hook/faq.tpl'}
+    {/if}
+  {/if}
+</section>


### PR DESCRIPTION
### Motivation
- Provide a PrettyBlocks block that lets editors pick registered FAQ entries via a repeater selector so selected FAQs can be displayed as an accordion using existing FAQ markup and schema.
- Ensure the new PrettyBlocks template file is recognized by the module by adding it to the module allowlist.

### Description
- Register a new block `everblock_faq_selection` in `src/Service/EverblockPrettyBlocks.php` and expose a `faq` selector via the `EverblockFaq` collection for use in the block repeater.
- Add `views/templates/hook/prettyblocks/prettyblock_faq_selection.tpl` which resolves selected FAQ IDs, loads entries with `EverblockFaq::getByIds`, and includes the existing `module:everblock/views/templates/hook/faq.tpl` for rendering.
- Add the new template path to `config/allowed_files.php` so the template is included in the module allowlist.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698066711b1883229fa27827f6871aab)