### PR TITLE
Make Prettyblock Link List collapsible on mobile

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -67,6 +67,64 @@
     transform: scale(1.04);
 }
 
+/* Prettyblock link list */
+.prettyblock-link-list__details {
+    border: 0;
+}
+
+.prettyblock-link-list__summary {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    cursor: pointer;
+}
+
+.prettyblock-link-list__summary::-webkit-details-marker {
+    display: none;
+}
+
+.prettyblock-link-list__list {
+    margin: 0;
+    padding: 0;
+}
+
+.prettyblock-link-list__list li {
+    padding: 0.35rem 0;
+}
+
+.prettyblock-link-list__icon {
+    display: inline-flex;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.prettyblock-link-list__details[open] .prettyblock-link-list__icon {
+    transform: rotate(-135deg);
+}
+
+@media (max-width: 991.98px) {
+    .prettyblock-link-list__summary {
+        padding: 0.75rem 0;
+        border-bottom: 1px solid currentColor;
+    }
+
+    .prettyblock-link-list__details[open] .prettyblock-link-list__summary {
+        border-bottom-color: transparent;
+    }
+}
+
+@media (min-width: 992px) {
+    .prettyblock-link-list__icon {
+        display: none;
+    }
+}
+
 /* Prettyblock LLM links */
 .prettyblock-llm-links__inner {
     display: flex;

--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -3597,6 +3597,7 @@ $(document).ready(function(){
     initPrettyblockCategoryTabs();
     initPrettyblockToc();
     initPrettyblockLlmLinks();
+    initPrettyblockLinkList();
 
     function initPrettyblockCategoryTabs() {
         var $blocks = $('.prettyblock-category-tabs');
@@ -3774,6 +3775,33 @@ $(document).ready(function(){
                 $link.attr('href', baseUrl + encodeURIComponent(promptText));
             });
         });
+    }
+
+    function initPrettyblockLinkList() {
+        var $details = $('.prettyblock-link-list__details');
+        if (!$details.length || typeof window.matchMedia !== 'function') {
+            return;
+        }
+
+        var mediaQuery = window.matchMedia('(max-width: 991.98px)');
+        var syncState = function () {
+            $details.each(function () {
+                var $detail = $(this);
+                if (mediaQuery.matches) {
+                    $detail.removeAttr('open');
+                } else {
+                    $detail.attr('open', 'open');
+                }
+            });
+        };
+
+        syncState();
+
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', syncState);
+        } else if (typeof mediaQuery.addListener === 'function') {
+            mediaQuery.addListener(syncState);
+        }
     }
 
     var $everblockImageModal = $('#everblockImageModal');

--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -23,19 +23,26 @@
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
-  {if isset($block.settings.title) && $block.settings.title}
-    <span class="h2 pb-link-list-title">{$block.settings.title|escape:'htmlall'}</span>
-  {/if}
-  {if isset($block.states) && $block.states}
-    <ul class="list-unstyled">
-      {foreach from=$block.states item=state key=key}
-        {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
-        <li class="{if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}">
-          <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
-        </li>
-      {/foreach}
-    </ul>
-  {/if}
+    <div class="prettyblock-link-list">
+      <details class="prettyblock-link-list__details" open>
+        <summary class="prettyblock-link-list__summary">
+          {if isset($block.settings.title) && $block.settings.title}
+            <span class="h2 pb-link-list-title">{$block.settings.title|escape:'htmlall'}</span>
+          {/if}
+          <span class="prettyblock-link-list__icon" aria-hidden="true"></span>
+        </summary>
+        {if isset($block.states) && $block.states}
+          <ul class="list-unstyled prettyblock-link-list__list">
+            {foreach from=$block.states item=state key=key}
+              {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
+              <li class="{if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}">
+                <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
+              </li>
+            {/foreach}
+          </ul>
+        {/if}
+      </details>
+    </div>
   {if $block.settings.default.force_full_width || $block.settings.default.container}
     </div>
   {/if}


### PR DESCRIPTION
### Motivation
- The link list block should behave as a dropdown on mobile to match the provided mockup and improve usability on small viewports.

### Description
- Wrap the link list markup in a `details`/`summary` structure and add a chevron element in `views/templates/hook/prettyblocks/prettyblock_link_list.tpl` to provide native expandable behavior.
- Add responsive styles in `views/css/everblock.css` for the summary layout, chevron rotation, list spacing, and to hide the chevron on desktop viewports.
- Add `initPrettyblockLinkList()` in `views/js/everblock.js` and call it on document ready to sync the `details[open]` state with the viewport using `window.matchMedia` so the list is expanded on desktop and collapsed on mobile.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806f70a27c8322a9307ca02e4d538f)