### PR TITLE
Add per-link media upload to Social Links (replace SVG icons)

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2779,6 +2779,13 @@ class EverblockPrettyBlocks
                             'label' => $module->l('Link URL'),
                             'default' => '#',
                         ],
+                        'media' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Media (replaces SVG icon)'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
                         'icon' => [
                             'type' => 'select',
                             'label' => $module->l('Select an icon'),

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -45,11 +45,10 @@
                 {assign var="icon_url" value=$smarty.const._PS_MODULE_DIR_|cat:'everblock/views/img/svg/'|cat:$state.icon|cat:'.svg'}
               {/if}
             {/if}
-            {if $icon_url}
-              {assign var="svg_content" value=$icon_url|@file_get_contents}
-              {if isset($block.settings.icon_color) && $block.settings.icon_color}
-                {assign var="svg_content" value=$svg_content|regex_replace:'/fill="[^"]+"/':'fill="currentColor"'}
-              {/if}
+            {assign var="media_url" value=''}
+            {if (is_array($state.media) || is_object($state.media)) && isset($state.media.url) && $state.media.url}
+              {assign var="media_url" value=$state.media.url}
+            {/if}
 
               {* ✅ Chaque icône dans un wrapper séparé *}
               {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_social_link_style'}
@@ -63,11 +62,18 @@
                    title="{$state.url|escape:'htmlall'}"
                    target="_blank"
                    style="{if isset($block.settings.icon_color) && $block.settings.icon_color}color:{$block.settings.icon_color|escape:'htmlall'};{/if}">
-                  {$svg_content nofilter}
+                  {if $media_url}
+                    <img src="{$media_url|escape:'htmlall':'UTF-8'}" alt="{$state.url|escape:'htmlall':'UTF-8'}" loading="lazy">
+                  {elseif $icon_url}
+                    {assign var="svg_content" value=$icon_url|@file_get_contents}
+                    {if isset($block.settings.icon_color) && $block.settings.icon_color}
+                      {assign var="svg_content" value=$svg_content|regex_replace:'/fill="[^"]+"/':'fill="currentColor"'}
+                    {/if}
+                    {$svg_content nofilter}
+                  {/if}
                 </a>
               </span>
 
-            {/if}
           {/if}
         {/foreach}
       </div>


### PR DESCRIPTION
### Motivation
- Enable uploading a media asset for each social link repeater so editors can override the default SVG icon with an uploaded image.

### Description
- Add a `media` `fileupload` field to the Social Links repeater configuration in `src/Service/EverblockPrettyBlocks.php`.
- Update `views/templates/hook/prettyblocks/prettyblock_social_links.tpl` to render the uploaded `media.url` as an `<img>` when present and fall back to the configured SVG icon otherwise.
- Preserve existing `icon_color` handling by applying the color to the SVG when rendering the fallback.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807ab7b47c8322be1a440caef23bcf)