### PR TITLE
Set default alignment to center for social links

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -433,7 +433,7 @@ class EverblockPrettyBlocks
                                 'center' => $module->l('Center'),
                                 'right' => $module->l('Right'),
                             ],
-                            'default' => 'left',
+                            'default' => 'center',
                         ],
                         'text_color' => [
                             'type' => 'color',
@@ -2758,6 +2758,16 @@ class EverblockPrettyBlocks
                 ],
                 'config' => [
                     'fields' => static::appendSpacingFields([
+                        'alignment' => [
+                            'type' => 'select',
+                            'label' => $module->l('Links alignment'),
+                            'choices' => [
+                                'left' => $module->l('Left'),
+                                'center' => $module->l('Center'),
+                                'right' => $module->l('Right'),
+                            ],
+                            'default' => 'center',
+                        ],
                         'icon_color' => [
                             'type' => 'color',
                             'label' => $module->l('Icon color'),

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -414,6 +414,18 @@
     align-items: center;
 }
 
+.everblock-social-links--left {
+    justify-content: flex-start;
+}
+
+.everblock-social-links--center {
+    justify-content: center;
+}
+
+.everblock-social-links--right {
+    justify-content: flex-end;
+}
+
 .everblock-social-links a,
 .everblock-social-links span {
     display: inline-flex;

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -24,6 +24,13 @@
   {/if}
 {/capture}
 {assign var='prettyblock_social_links_wrapper_style' value=$smarty.capture.prettyblock_social_links_wrapper_style|trim}
+{assign var='prettyblock_social_links_alignment' value=$block.settings.alignment|default:'left'}
+{assign var='prettyblock_social_links_alignment_class' value='everblock-social-links--left'}
+{if $prettyblock_social_links_alignment == 'center'}
+  {assign var='prettyblock_social_links_alignment_class' value='everblock-social-links--center'}
+{elseif $prettyblock_social_links_alignment == 'right'}
+  {assign var='prettyblock_social_links_alignment_class' value='everblock-social-links--right'}
+{/if}
 
 <!-- Module Ever Block -->
 <div id="block-{$block.id_prettyblocks}" class="{if $block.settings.default.force_full_width}container-fluid px-0 mx-0{elseif $block.settings.default.container}container{/if}{$prettyblock_visibility_class}"{if $prettyblock_social_links_wrapper_style} style="{$prettyblock_social_links_wrapper_style}"{/if}>
@@ -32,7 +39,7 @@
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
-    <div class="everblock-social-links d-flex flex-row flex-wrap">
+    <div class="everblock-social-links {$prettyblock_social_links_alignment_class} d-flex flex-row flex-wrap">
         {foreach from=$block.states item=state}
           {if isset($state.url) && $state.url}
             {assign var="icon_url" value=false}


### PR DESCRIPTION
### Motivation
- Ensure the Prettyblock Social Links and title alignment default to centered to match the provided design/modeled layout.

### Description
- Set the default `alignment` value for the `everblock_social_links` prettyblock to `center` in `src/Service/EverblockPrettyBlocks.php`.
- Set the default `title_alignment` to `center` in `src/Service/EverblockPrettyBlocks.php` to align headings with the updated layout.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807b94acac8322a2958c0d8bee9a49)