### PR TITLE
Center Prettyblock Simple Image images by default

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -147,7 +147,7 @@
                      {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
                      {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
                      {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
-                     class="d-block w-100 img img-fluid lazyload" loading="lazy" draggable="false">
+                     class="d-block w-100 img img-fluid lazyload mx-auto" loading="lazy" draggable="false">
               </picture>
 
               <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
@@ -236,7 +236,7 @@
                      {if isset($state.alt)}alt="{$state.alt}"{else}alt="{$shop.name}"{/if}
                      {if $state.image_width} width="{$state.image_width|escape:'htmlall':'UTF-8'}"{/if}
                      {if $state.image_height} height="{$state.image_height|escape:'htmlall':'UTF-8'}"{/if}
-                     class="img img-fluid lazyload" loading="lazy">
+                     class="img img-fluid lazyload d-block mx-auto" loading="lazy">
               </picture>
 
               <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">


### PR DESCRIPTION
### Motivation
- Ensure images rendered by the Prettyblock "Simple image" block are visually centered by default in both slider and grid modes for better presentation.

### Description
- Add Bootstrap centering classes to the image elements in the Prettyblock template by updating `views/templates/hook/prettyblocks/prettyblock_img.tpl` to include `d-block mx-auto` on the `<img>` tags in both slider and grid render paths.

### Testing
- No automated tests were run for this template change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807d26eda883229bd2f154d83fd9c0)