### PR TITLE
Center Prettyblock Reassurance items

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_reassurance.tpl
@@ -48,9 +48,9 @@
 {assign var='rowClass' value=''}
 {if $shouldRenderRow}
   {if $block.settings.default.force_full_width}
-    {assign var='rowClass' value='row g-10px'}
+    {assign var='rowClass' value='row g-10px justify-content-center'}
   {else}
-    {assign var='rowClass' value='row'}
+    {assign var='rowClass' value='row justify-content-center'}
   {/if}
 {/if}
 


### PR DESCRIPTION
### Motivation
- Center all repeater items in the Prettyblock Reassurance block so the layout matches the provided mockup.

### Description
- Added the Bootstrap centering class by appending `justify-content-center` to the computed `rowClass` in `views/templates/hook/prettyblocks/prettyblock_reassurance.tpl` for both full-width and normal container cases so rows (including carousel rows) are centered.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698080ff83008322bbb7368b73ea2128)