### PR TITLE
Add prettyblock_newsletter.tpl to allowed files

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -341,6 +341,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_modal.tpl',
     'views/templates/hook/prettyblocks/prettyblock_mystery_boxes.tpl',
     'views/templates/hook/prettyblocks/prettyblock_latest_guides.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_newsletter.tpl',
     'views/templates/hook/prettyblocks/prettyblock_podcasts.tpl',
     'views/templates/hook/prettyblocks/prettyblock_pricing_table.tpl',
     'views/templates/hook/prettyblocks/prettyblock_pages_guide.tpl',


### PR DESCRIPTION
### Motivation
- Allow the PrettyBlocks newsletter template to be accessible by the module by whitelisting it in the allowed files list.

### Description
- Added `views/templates/hook/prettyblocks/prettyblock_newsletter.tpl` to `config/allowed_files.php` and committed the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a58b3d3c8322ade49cfed83cddf7)