### PR TITLE
Honor capitalized `Center` alignment for social links

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -39,7 +39,7 @@
   {elseif $block.settings.default.container}
     <div class="row">
   {/if}
-    <div class="everblock-social-links {$prettyblock_social_links_alignment_class} d-flex flex-row flex-wrap">
+    <div class="everblock-social-links {$prettyblock_social_links_alignment_class} d-flex flex-row flex-wrap{if $prettyblock_social_links_alignment == 'Center'} justify-content-center{/if}">
         {foreach from=$block.states item=state}
           {if isset($state.url) && $state.url}
             {assign var="icon_url" value=false}


### PR DESCRIPTION
### Motivation
- Fix the alignment check so the social links wrapper uses Bootstrap centering when the alignment setting is the capitalized `Center` value.

### Description
- Change the conditional in `views/templates/hook/prettyblocks/prettyblock_social_links.tpl` to test for `'Center'` and append `justify-content-center` to the wrapper classes when matched.

### Testing
- No automated tests were run for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a52f38508322b6acc63d08c8a3cc)