### PR TITLE
Remove base background and text colors from .prettyblock-newsletter

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3547,8 +3547,6 @@
 .prettyblock-newsletter {
   border-radius: 28px;
   padding: 32px 28px;
-  background: linear-gradient(135deg, #1c1f2b 0%, #0f1118 100%);
-  color: #f5f5f5;
 }
 
 .prettyblock-newsletter__inner {


### PR DESCRIPTION
### Motivation
- Remove hardcoded background and text color from ` .prettyblock-newsletter` so the block can inherit colors from the surrounding theme or custom classes.

### Description
- Deleted the `background: linear-gradient(135deg, #1c1f2b 0%, #0f1118 100%);` and `color: #f5f5f5;` declarations from the `.prettyblock-newsletter` rule in `views/css/everblock.css`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a66afc288322822981535d71c8a6)