### PR TITLE
Align Prettyblock newsletter with ps_emailsubscription controller

### DIFF
--- a/views/js/everblock.js
+++ b/views/js/everblock.js
@@ -3864,7 +3864,11 @@ $(document).ready(function(){
                             message = data;
                         } else {
                             message = data.message || data.msg || data.error || '';
-                            isSuccess = data.success === true || data.status === true || data.status === 'success';
+                            if (typeof data.nw_error !== 'undefined') {
+                                isSuccess = data.nw_error === false;
+                            } else {
+                                isSuccess = data.success === true || data.status === true || data.status === 'success';
+                            }
                         }
 
                         setMessage(message, isSuccess);

--- a/views/templates/hook/prettyblocks/prettyblock_newsletter.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_newsletter.tpl
@@ -42,7 +42,7 @@
         Native newsletter flow: submit to ps_emailsubscription controller via AJAX.
         The JS uses psemailsubscription_subscription injected by the module.
       *}
-      <form class="prettyblock-newsletter__form" data-newsletter-form>
+      <form class="prettyblock-newsletter__form" data-newsletter-form method="post" action="{$link->getModuleLink('ps_emailsubscription', 'subscription')|escape:'htmlall':'UTF-8'}">
         <div class="prettyblock-newsletter__input-group">
           <label class="sr-only" for="prettyblock-newsletter-email-{$block.id_prettyblocks}">
             {l s='Email address' mod='everblock'}
@@ -57,6 +57,8 @@
             placeholder="{if $block.settings.default.placeholder}{$block.settings.default.placeholder|escape:'htmlall':'UTF-8'}{else}{l s='Your email' mod='everblock'}{/if}"
           >
           <input type="hidden" name="action" value="0">
+          <input type="hidden" name="submitNewsletter" value="1">
+          <input type="hidden" name="ajax" value="1">
           <input type="hidden" name="blockHookName" value="{if $block.settings.default.block_hook_name}{$block.settings.default.block_hook_name|escape:'htmlall':'UTF-8'}{else}displayFooterBefore{/if}">
           <button class="btn prettyblock-newsletter__submit" type="submit">
             {if $block.settings.default.button_label}{$block.settings.default.button_label|escape:'htmlall':'UTF-8'}{else}{l s='OK' mod='everblock'}{/if}


### PR DESCRIPTION
### Motivation
- Ensure the Prettyblock Newsletter block submits natively to the `ps_emailsubscription` front controller and correctly interprets that module's JSON responses.

### Description
- Update the Prettyblock newsletter template to set the form `method="post"` and `action` to `{$link->getModuleLink('ps_emailsubscription', 'subscription')}`, and add hidden fields `submitNewsletter` and `ajax` so the controller receives the expected parameters.
- Update the frontend JS to treat `ps_emailsubscription` responses that expose `nw_error`/`msg` as success or error by checking `nw_error === false` when present.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a6f2b6948322b061cd2cefe31918)