### PR TITLE
Add per-item CSS class to Social links repeater and template

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -2870,6 +2870,11 @@ class EverblockPrettyBlocks
                             'choices' => EverblockTools::getAvailableSvgIcons(),
                             'default' => 'facebook.svg',
                         ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
                     ], $module),
                 ],
             ];

--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -63,7 +63,7 @@
                 {$prettyblock_social_link_style}
               {/capture}
               {assign var='prettyblock_social_link_style_attr' value=$smarty.capture.prettyblock_social_link_style_attr|trim}
-              <span class="everblock-social-link"{if $prettyblock_social_link_style_attr} style="{$prettyblock_social_link_style_attr}"{/if}>
+              <span class="everblock-social-link{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}"{if $prettyblock_social_link_style_attr} style="{$prettyblock_social_link_style_attr}"{/if}>
                 <a href="{$state.url|escape:'htmlall'}"
                    class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}"
                    title="{$state.url|escape:'htmlall'}"


### PR DESCRIPTION
### Motivation
- Allow each Social link repeater item to carry a custom CSS class so individual icon wrappers can be styled, and satisfy the inline request to add the field to the block declaration.

### Description
- Added a `css_class` repeater field to the `everblock_social_links` block in `src/Service/EverblockPrettyBlocks.php`.
- Updated `views/templates/hook/prettyblocks/prettyblock_social_links.tpl` to append `{$state.css_class}` to the wrapper `<span class="everblock-social-link">` and escape it using Smarty (`|escape:'htmlall':'UTF-8'`).

### Testing
- No automated tests were run; changes were committed and verified by examining the modified files and diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a8654c0883228e761bb629a29ac1)