### PR TITLE
Add obfme class to PrettyBlock link list off homepage

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_link_list.tpl
@@ -36,7 +36,7 @@
             {foreach from=$block.states item=state key=key}
               {include file='module:everblock/views/templates/hook/prettyblocks/_partials/spacing_style.tpl' spacing=$state assign='prettyblock_state_spacing_style'}
               <li class="{if $state.css_class}{$state.css_class|escape:'htmlall'}{/if}" style="{$prettyblock_state_spacing_style}">
-                <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
+                <a href="{$state.url|escape:'htmlall'}" class="text-decoration-none link-secondary{if !isset($page.page_name) || $page.page_name != 'index'} obfme{/if}{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--text{/if}" title="{$state.name|escape:'htmlall'}"{if $state.target_blank} target="_blank"{/if}>{$state.name|escape:'htmlall'}</a>
               </li>
             {/foreach}
           </ul>


### PR DESCRIPTION
### Motivation
- Ensure PrettyBlock Link List links include the `obfme` class on non-home pages so they receive the intended styling/behavior while keeping homepage links unchanged.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_link_list.tpl` to add a Smarty conditional that appends `obfme` to the anchor's `class` when `{$page.page_name}` is not `'index'`.

### Testing
- No automated tests were run for this template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a9952ed08322a3b528dfbd172792)