### PR TITLE
Fix desktop click on Prettyblock link list title

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -123,6 +123,11 @@
     .prettyblock-link-list__icon {
         display: none;
     }
+
+    .prettyblock-link-list__summary {
+        cursor: default;
+        pointer-events: none;
+    }
 }
 
 /* Prettyblock LLM links */


### PR DESCRIPTION
### Motivation
- Prevent the link-list title from being clickable on desktop so the expand/collapse behavior only applies on mobile.

### Description
- Added CSS in `views/css/everblock.css` under `@media (min-width: 992px)` to set `.prettyblock-link-list__summary { cursor: default; pointer-events: none; }`, disabling pointer interactions on desktop.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980af72f6148322a047cec465552541)