### PR TITLE
Add obfme class to Prettyblock social links

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_social_links.tpl
@@ -65,7 +65,7 @@
               {assign var='prettyblock_social_link_style_attr' value=$smarty.capture.prettyblock_social_link_style_attr|trim}
               <span class="everblock-social-link{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}"{if $prettyblock_social_link_style_attr} style="{$prettyblock_social_link_style_attr}"{/if}>
                 <a href="{$state.url|escape:'htmlall'}"
-                   class="{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}"
+                   class="obfme{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--block{/if}"
                    title="{$state.url|escape:'htmlall'}"
                    target="_blank"
                    style="{if isset($block.settings.icon_color) && $block.settings.icon_color}color:{$block.settings.icon_color|escape:'htmlall'};{/if}">


### PR DESCRIPTION
### Motivation
- Ensure every anchor in the Prettyblock Social links output includes the `obfme` class so social links have the required class applied.

### Description
- Updated `views/templates/hook/prettyblocks/prettyblock_social_links.tpl` to add `obfme` to the anchor `class` attribute as `class="obfme{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--block{/if}"`, preserving the existing conditional hover class.

### Testing
- No automated tests were run because this is a template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b04bb1908322b09bbf18c54ebf29)