### PR TITLE
Reduce mobile spacing and align caret in Prettyblock Link List

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -110,8 +110,17 @@
 
 @media (max-width: 991.98px) {
     .prettyblock-link-list__summary {
-        padding: 0.75rem 0;
+        padding: 0.5rem 0;
         border-bottom: 1px solid currentColor;
+        align-items: flex-start;
+    }
+
+    .prettyblock-link-list__list li {
+        padding: 0.2rem 0;
+    }
+
+    .prettyblock-link-list__icon {
+        margin-top: 0.25rem;
     }
 
     .prettyblock-link-list__details[open] .prettyblock-link-list__summary {


### PR DESCRIPTION
### Motivation
- Tighten spacing in the Prettyblock Link List on small screens and align the caret icon with the list title to improve compactness and visual alignment.

### Description
- Modify `views/css/everblock.css` to reduce `.prettyblock-link-list__summary` mobile padding to `0.5rem 0`, add `align-items: flex-start`, reduce `.prettyblock-link-list__list li` padding to `0.2rem 0`, and add `margin-top: 0.25rem` to `.prettyblock-link-list__icon` under the `@media (max-width: 991.98px)` rule.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b3390e888322ae1d3f9c246d39e8)