### PR TITLE
Hide prettyblock newsletter label by adding `d-none`

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_newsletter.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_newsletter.tpl
@@ -95,7 +95,7 @@
       *}
       <form class="prettyblock-newsletter__form" data-newsletter-form method="post" action="{$link->getModuleLink('ps_emailsubscription', 'subscription')|escape:'htmlall':'UTF-8'}">
         <div class="prettyblock-newsletter__input-group">
-          <label class="sr-only" for="prettyblock-newsletter-email-{$block.id_prettyblocks}">
+          <label class="sr-only d-none" for="prettyblock-newsletter-email-{$block.id_prettyblocks}">
             {l s='Email address' mod='everblock'}
           </label>
           <input


### PR DESCRIPTION
### Motivation
- Hide the visible newsletter label in the prettyblock template for presentation/accessibility reasons by either removing it or applying a utility class to visually hide it.

### Description
- Added the `d-none` utility to the label in `views/templates/hook/prettyblocks/prettyblock_newsletter.tpl` so the label reads `<label class="sr-only d-none" for="prettyblock-newsletter-email-{$block.id_prettyblocks}">`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b7f367d88322b6fd6e9319b31d7f)