### PR TITLE
Add cache to ActionRegisterBlock hook

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -5285,7 +5285,14 @@ class Everblock extends Module
     public function hookActionRegisterBlock($params)
     {
         EverblockTools::checkAndFixDatabase();
-        return EverblockPrettyBlocks::getEverPrettyBlocks($this->context);
+        $cacheId = $this->name . '_ActionRegisterBlock_'
+        . (int) $this->context->language->id
+        . '_'
+        . (int) $this->context->shop->id;
+        if (!EverblockCache::isCacheStored($cacheId)) {
+            EverblockCache::cacheStore($cacheId, EverblockPrettyBlocks::getEverPrettyBlocks($this->context));
+        }
+        return EverblockCache::cacheRetrieve($cacheId);
     }
 
     protected function compressCSSCode($css)


### PR DESCRIPTION
### Motivation
- Reduce repeated computation when rendering pretty blocks by caching the hook output per shop and language.

### Description
- Wrap the call to `EverblockPrettyBlocks::getEverPrettyBlocks($this->context)` with `EverblockCache` using a cache key built from the module name, language id and shop id while preserving `EverblockTools::checkAndFixDatabase()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980bafd83b083228d01a58d7b38a0e1)