### PR TITLE
Optimize best-selling product query by category

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2154,10 +2154,14 @@ class EverblockTools extends ObjectModel
             FROM ' . _DB_PREFIX_ . 'order_detail od
             INNER JOIN ' . _DB_PREFIX_ . 'orders o
                 ON o.id_order = od.id_order
+            INNER JOIN ' . _DB_PREFIX_ . 'product_shop ps
+                ON ps.id_product = od.product_id
             INNER JOIN ' . _DB_PREFIX_ . 'category_product cp
                 ON cp.id_product = od.product_id
             WHERE o.id_shop = ' . $shopId . '
               AND o.valid = 1
+              AND ps.id_shop = ' . $shopId . '
+              AND ps.active = 1
               AND cp.id_category = ' . (int) $categoryId;
 
         if ($days !== null) {
@@ -2167,7 +2171,7 @@ class EverblockTools extends ObjectModel
 
         $sql .= '
             GROUP BY od.product_id
-            ORDER BY ' . $orderBy . ' ' . $orderWay . '
+            ORDER BY ' . pSQL($orderBy) . ' ' . pSQL($orderWay) . '
             LIMIT ' . (int) $limit;
 
         $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);


### PR DESCRIPTION
### Motivation
- Reduce query time and avoid scanning unrelated products when building best-seller lists for a category, while ensuring ordering parameters are safely used.

### Description
- Added an `INNER JOIN` to `product_shop` and added `ps.id_shop = $shopId` and `ps.active = 1` filters so only active products from the current shop are considered.
- Applied `pSQL()` to the `ORDER BY` and `ORDER WAY` expressions to ensure the ordering parts are sanitized before concatenation into the SQL string.
- Kept existing `GROUP BY` and caching behavior in place and continue to cache category best-seller results for 24 hours.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d038f7f0832280f5c28ba13930f5)