### PR TITLE
Optimize best-seller category SQL to prefilter products

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2151,18 +2151,21 @@ class EverblockTools extends ObjectModel
 
         $sql = '
             SELECT od.product_id, SUM(od.product_quantity) AS total_quantity
-            FROM ' . _DB_PREFIX_ . 'order_detail od
-            INNER JOIN ' . _DB_PREFIX_ . 'orders o
+            FROM ' . _DB_PREFIX_ . 'orders o
+            INNER JOIN ' . _DB_PREFIX_ . 'order_detail od
                 ON o.id_order = od.id_order
-            INNER JOIN ' . _DB_PREFIX_ . 'product_shop ps
-                ON ps.id_product = od.product_id
-            INNER JOIN ' . _DB_PREFIX_ . 'category_product cp
-                ON cp.id_product = od.product_id
+            INNER JOIN (
+                SELECT ps.id_product
+                FROM ' . _DB_PREFIX_ . 'product_shop ps
+                INNER JOIN ' . _DB_PREFIX_ . 'category_product cp
+                    ON cp.id_product = ps.id_product
+                WHERE ps.id_shop = ' . $shopId . '
+                  AND ps.active = 1
+                  AND cp.id_category = ' . (int) $categoryId . '
+            ) filtered_products
+                ON filtered_products.id_product = od.product_id
             WHERE o.id_shop = ' . $shopId . '
-              AND o.valid = 1
-              AND ps.id_shop = ' . $shopId . '
-              AND ps.active = 1
-              AND cp.id_category = ' . (int) $categoryId;
+              AND o.valid = 1';
 
         if ($days !== null) {
             $dateFrom = date('Y-m-d H:i:s', strtotime('-' . (int) $days . ' days'));


### PR DESCRIPTION
### Motivation
- Reduce database work and integration cost by avoiding expensive joins over all products when computing best-sellers for a category.
- Improve query planner efficiency by prefiltering active category products before aggregating order details.

### Description
- Rewrote the best-seller-by-category SQL in `src/Service/EverblockTools.php` to join `orders` -> `order_detail` and then inner-join a derived subquery (`filtered_products`) that preselects `product_shop` rows joined with `category_product` filtered by `id_shop`, `active`, and `id_category`.
- Removed the direct joins to `product_shop` and `category_product` from the main query and moved their filtering into the subquery while preserving `o.id_shop`, `o.valid`, optional `o.date_add` filtering, grouping, ordering and limit semantics.
- Preserved the existing caching behavior (`EverblockCache::cacheStore`) and SQL escaping for the date condition.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d22483b08322bcf7efbca1d945b8)