### PR TITLE
Centralize prettyblocks availability check and expose flag to Smarty

### DIFF
--- a/controllers/front/page.php
+++ b/controllers/front/page.php
@@ -174,9 +174,7 @@ class EverblockPageModuleFrontController extends ModuleFrontController
 
     protected function isPrettyBlocksEnabled(): bool
     {
-        return (bool) Module::isInstalled('prettyblocks') === true
-            && (bool) Module::isEnabled('prettyblocks') === true
-            && (bool) Everblock\Tools\Service\EverblockTools::moduleDirectoryExists('prettyblocks') === true;
+        return (bool) Everblock\Tools\Service\EverblockTools::isPrettyblocksAvailable($this->context);
     }
 
     protected function ensureEverblockPage(array $customerGroups = []): ?EverblockPage

--- a/controllers/front/pages.php
+++ b/controllers/front/pages.php
@@ -183,9 +183,7 @@ class EverblockPagesModuleFrontController extends ModuleFrontController
 
     protected function isPrettyBlocksEnabled(): bool
     {
-        return (bool) Module::isInstalled('prettyblocks') === true
-            && (bool) Module::isEnabled('prettyblocks') === true
-            && (bool) Everblock\Tools\Service\EverblockTools::moduleDirectoryExists('prettyblocks') === true;
+        return (bool) Everblock\Tools\Service\EverblockTools::isPrettyblocksAvailable($this->context);
     }
 
     protected function setTemplateMeta(string $title, string $description): void

--- a/everblock.php
+++ b/everblock.php
@@ -508,9 +508,7 @@ class Everblock extends Module
 
     private function hasPrettyblocksModule(): bool
     {
-        return (bool) Module::isInstalled('prettyblocks')
-            && (bool) Module::isEnabled('prettyblocks')
-            && (bool) EverblockTools::moduleDirectoryExists('prettyblocks');
+        return (bool) EverblockTools::isPrettyblocksAvailable($this->context);
     }
 
     public function checkHooks()
@@ -1640,9 +1638,7 @@ class Everblock extends Module
             'pages' => $this->l('Pages'),
         ];
 
-        $isPrettyBlocksEnabled = (bool) Module::isInstalled('prettyblocks') === true
-            && (bool) Module::isEnabled('prettyblocks') === true
-            && (bool) EverblockTools::moduleDirectoryExists('prettyblocks') === true;
+        $isPrettyBlocksEnabled = $this->hasPrettyblocksModule();
 
         if ($isPrettyBlocksEnabled) {
             $tabs['prettyblock'] = $this->l('Prettyblock');
@@ -3717,10 +3713,7 @@ class Everblock extends Module
 
     public function hookDisplayWrapperTop()
     {
-        if ((bool) Module::isInstalled('prettyblocks') === true
-            && (bool) Module::isEnabled('prettyblocks') === true
-            && (bool) EverblockTools::moduleDirectoryExists('prettyblocks') === true
-        ) {
+        if ($this->hasPrettyblocksModule()) {
             if (Tools::getValue('id_product')) {
                 $idObj = (int) Tools::getValue('id_product');
                 $objectName = 'Product';
@@ -3754,10 +3747,7 @@ class Everblock extends Module
 
     public function hookDisplayWrapperBottom()
     {
-        if ((bool) Module::isInstalled('prettyblocks') === true
-            && (bool) Module::isEnabled('prettyblocks') === true
-            && (bool) EverblockTools::moduleDirectoryExists('prettyblocks') === true
-        ) {
+        if ($this->hasPrettyblocksModule()) {
             if (Tools::getValue('id_product')) {
                 $idObj = (int) Tools::getValue('id_product');
                 $objectName = 'Product';
@@ -5108,14 +5098,11 @@ class Everblock extends Module
                     'args' => $args,
                 ]
             );
-            if ((bool) Module::isInstalled('prettyblocks') === true
-                && (bool) Module::isEnabled('prettyblocks') === true
-                && (bool) EverblockTools::moduleDirectoryExists('prettyblocks') === true
-            ) {
+            if ($this->hasPrettyblocksModule()) {
                 $context->smarty->assign([
                     'prettyblocks_installed' => true,
                 ]);
-            }   
+            }
             $context->smarty->assign([
                 'everhook' => trim($method),
                 $this->name => $currentBlock,

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -75,6 +75,28 @@ if (!defined('_PS_VERSION_')) {
 
 class EverblockTools extends ObjectModel
 {
+    public static function isPrettyblocksAvailable(?Context $context = null, bool $assignSmarty = true): bool
+    {
+        static $isAvailable = null;
+
+        if ($isAvailable === null) {
+            $isAvailable = (bool) Module::isInstalled('prettyblocks') === true
+                && (bool) Module::isEnabled('prettyblocks') === true
+                && (bool) static::moduleDirectoryExists('prettyblocks') === true;
+        }
+
+        if ($assignSmarty) {
+            $context = $context ?: Context::getContext();
+            if ($context && isset($context->smarty)) {
+                $context->smarty->assign([
+                    'everblock_prettyblocks_available' => $isAvailable,
+                ]);
+            }
+        }
+
+        return $isAvailable;
+    }
+
     public static function renderShortcodes(string $txt, Context $context, Everblock $module): string
     {
         Hook::exec('displayBeforeRenderingShortcodes', ['html' => &$txt]);


### PR DESCRIPTION
### Motivation
- Remove duplicated `Module::isInstalled`/`isEnabled`/`moduleDirectoryExists` checks scattered in controllers and module code and provide a single helper that caches the result per-request. 
- Make the prettyblocks availability easily shareable in Smarty templates when needed.

### Description
- Add `EverblockTools::isPrettyblocksAvailable(?Context $context = null, bool $assignSmarty = true)` which caches the availability check in a static variable and optionally assigns `everblock_prettyblocks_available` to Smarty. (`src/Service/EverblockTools.php`).
- Replace repeated availability logic in `controllers/front/page.php` and `controllers/front/pages.php` with calls to `EverblockTools::isPrettyblocksAvailable($this->context)`.
- Replace duplicated checks inside the main module (`everblock.php`) with a single `hasPrettyblocksModule()` that delegates to `EverblockTools::isPrettyblocksAvailable($this->context)` and use it where appropriate, including assigning `prettyblocks_installed` to Smarty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f06390dc8322a20dbe621bdfc6eb)