### PR TITLE
Add cached PrettyBlocks zone rendering and invalidation

### DIFF
--- a/controllers/admin/AdminEverBlockPrettyblockController.php
+++ b/controllers/admin/AdminEverBlockPrettyblockController.php
@@ -21,6 +21,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+use Everblock\Tools\Service\EverblockPrettyBlocks;
 use Everblock\Tools\Service\EverblockTools;
 use Everblock\Tools\Service\ShortcodeDocumentationProvider;
 
@@ -369,6 +370,10 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
         if (Tools::getValue('cachecleared')) {
             $this->confirmations[] = $this->l('Cache has been cleared');
         }
+
+        if ($this->shouldInvalidatePrettyblocksCache()) {
+            $this->invalidatePrettyblocksCache();
+        }
     }
 
     public function renderList()
@@ -625,6 +630,7 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->l('%d PrettyBlocks updated with the selected hook.'),
             count($ids)
         );
+        $this->invalidatePrettyblocksCache();
     }
 
     private function processDuplicateShop(): void
@@ -679,6 +685,7 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->l('%d PrettyBlocks duplicated to the selected shop.'),
             $inserted
         );
+        $this->invalidatePrettyblocksCache();
     }
 
     private function processDuplicateLang(): void
@@ -733,6 +740,7 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
             $this->l('%d PrettyBlocks duplicated to the selected language.'),
             $inserted
         );
+        $this->invalidatePrettyblocksCache();
     }
 
     protected function processBulkDelete()
@@ -743,6 +751,8 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
                 $this->errors[] = $this->l('An error has occurred: Can\'t delete the current object');
             }
         }
+
+        $this->invalidatePrettyblocksCache();
     }
 
     private function duplicatePrettyblock(int $id): void
@@ -773,6 +783,34 @@ class AdminEverBlockPrettyblockController extends ModuleAdminController
 
         if (!$db->insert('prettyblocks', $block)) {
             $this->errors[] = $this->l('An error has occurred: Can\'t duplicate the current object');
+            return;
         }
+
+        $this->invalidatePrettyblocksCache();
+    }
+
+    private function shouldInvalidatePrettyblocksCache(): bool
+    {
+        if (Tools::getIsset('duplicate' . $this->table)) {
+            return true;
+        }
+
+        if (Tools::isSubmit('submitAdd' . $this->table)
+            || Tools::isSubmit('submitAdd' . $this->table . 'AndStay')
+            || Tools::isSubmit('submitAdd' . $this->table . 'AndPreview')
+            || Tools::isSubmit('submitUpdate' . $this->table)
+            || Tools::isSubmit('submitUpdate' . $this->table . 'AndStay')
+            || Tools::isSubmit('delete' . $this->table)
+            || Tools::isSubmit('submitDel' . $this->table)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function invalidatePrettyblocksCache(): void
+    {
+        EverblockPrettyBlocks::clearRenderCache();
     }
 }

--- a/models/EverblockPage.php
+++ b/models/EverblockPage.php
@@ -19,6 +19,7 @@
  */
 
 use Everblock\Tools\Service\EverblockCache;
+use Everblock\Tools\Service\EverblockPrettyBlocks;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -157,7 +158,12 @@ class EverblockPage extends ObjectModel
         }
         $this->sanitizeLinkRewrite();
 
-        return parent::save($nullValues, $autoDate, $useCache);
+        $saved = parent::save($nullValues, $autoDate, $useCache);
+        if ($saved) {
+            EverblockPrettyBlocks::clearRenderCache();
+        }
+
+        return $saved;
     }
 
     public static function getPages(

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2427,21 +2427,15 @@ class EverblockTools extends ObjectModel
             && (bool) static::moduleDirectoryExists('prettyblocks') === true
         ) {
             try {
-                // Définir le chemin vers le template
-                $templatePath = static::getTemplatePath('hook/prettyblocks.tpl', $module);
                 // Regex pour trouver les shortcodes de type [prettyblocks name="mon_nom"]
                 $pattern = '/\[prettyblocks name="([^"]+)"\]/';
 
                 // Fonction de remplacement pour traiter chaque shortcode trouvé
-                $replacementFunction = function ($matches) use ($context, $templatePath) {
+                $replacementFunction = function ($matches) use ($context, $module) {
                     $zoneName = $matches[1];
 
                     try {
-                        // Assigner le nom de la zone à Smarty
-                        $context->smarty->assign('zone_name', $zoneName);
-
-                        // Récupérer le rendu du template avec Smarty
-                        return $context->smarty->fetch($templatePath);
+                        return EverblockPrettyBlocks::renderZoneWithCache($zoneName, $context, $module);
                     } catch (\Throwable $e) {
                         PrestaShopLogger::addLog(
                             sprintf('Prettyblocks shortcode rendering failed for zone "%s": %s', $zoneName, $e->getMessage()),


### PR DESCRIPTION
### Motivation
- Improve performance by caching final HTML output of PrettyBlocks zones keyed by zone + shop + lang + customer group.
- Reuse the existing `EverblockCache` helpers to store and retrieve rendered HTML.
- Ensure cache is invalidated when blocks or pages are changed so editors see updates immediately.

### Description
- Added `EverblockPrettyBlocks::renderZoneWithCache(string $zoneName, Context $context, Module $module): string` that builds a cache key (zone, shop id, lang id, customer group), uses `EverblockCache::cacheStore` / `EverblockCache::cacheRetrieve`, and returns the rendered HTML. (file: `src/Service/EverblockPrettyBlocks.php`)
- Added `EverblockPrettyBlocks::clearRenderCache()` which delegates to `EverblockCache::cacheDropByPattern` using the new cache prefix. (file: `src/Service/EverblockPrettyBlocks.php`)
- Wired shortcode rendering to use the cached renderer by calling `EverblockPrettyBlocks::renderZoneWithCache` from `EverblockTools::getPrettyblocksShortcodes`. (file: `src/Service/EverblockTools.php`)
- Invalidate the render cache on persistent changes by calling `EverblockPrettyBlocks::clearRenderCache()` after an `EverblockPage::save`. (file: `models/EverblockPage.php`)
- Invalidate the render cache from admin operations that modify PrettyBlocks (add/update/delete/duplicate/bulk actions) by adding invalidation calls and detection logic in the PrettyBlocks admin controller. (file: `controllers/admin/AdminEverBlockPrettyblockController.php`)

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f19855f083229ea12974f7a3e5ce)