### PR TITLE
Fix everblock status toggle UPDATE query (remove LIMIT 1)

### DIFF
--- a/controllers/admin/AdminEverBlockController.php
+++ b/controllers/admin/AdminEverBlockController.php
@@ -276,7 +276,7 @@ class AdminEverBlockController extends ModuleAdminController
                 $updated = $db->execute(
                     'UPDATE `' . _DB_PREFIX_ . 'everblock`
                     SET `active` = (1 - `active`)
-                    WHERE `' . $this->identifier . '` = ' . (int) $idObj .' LIMIT 1'
+                    WHERE `' . $this->identifier . '` = ' . (int) $idObj
                 );
             }
             if (isset($updated) && $updated) {


### PR DESCRIPTION
### Motivation
- Remove the `LIMIT 1` clause from the `UPDATE` used by the everblock status toggle because it produced a MariaDB syntax error (`SQLSTATE[42000]`) in certain server versions.

### Description
- Update `controllers/admin/AdminEverBlockController.php` to remove the trailing `LIMIT 1` from the `UPDATE `' . _DB_PREFIX_ . 'everblock` SET `active` = (1 - `active`) WHERE ...` statement used when toggling the `active` flag.

### Testing
- No automated tests were run for this one-line SQL syntax fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c722b9c483228a28777881381bb3)