### PR TITLE
Fix LIMIT binding in low stock query

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -558,8 +558,6 @@ class EverblockTools extends ObjectModel
                     'id_shop_group' => $idShopGroup,
                     'id_lang' => $idLang,
                     'threshold' => $threshold,
-                    'offset' => $offset,
-                    'limit' => $limit,
                 ];
 
                 $visPlaceholders = [];
@@ -656,7 +654,7 @@ class EverblockTools extends ObjectModel
                     $sql .= ' ORDER BY ' . $fieldMap[$order] . ' ' . strtoupper($way);
                 }
 
-                $sql .= ' LIMIT :offset, :limit';
+                $sql .= ' LIMIT ' . (int) $offset . ', ' . (int) $limit;
 
                 $rows = $db->executeS($sql, $params);
 


### PR DESCRIPTION
### Motivation
- Work around MariaDB/PDO syntax errors caused by binding `LIMIT`/`OFFSET` as parameters by inlining integer values in the SQL to avoid invalid SQL generation.

### Description
- Removed bound `offset` and `limit` parameters and replaced `LIMIT :offset, :limit` with `LIMIT ' . (int) $offset . ', ' . (int) $limit` in `src/Service/EverblockTools.php` to ensure numeric values are inlined into the query string.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981cbd7ac408322bf413c4c9fb7fd7b)