### PR TITLE
Validate ordering options for product shortcodes

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2739,14 +2739,22 @@ class EverblockTools extends ObjectModel
             $orderBy = isset($match[4]) ? strtolower($match[4]) : '';
             $orderWay = isset($match[5]) ? strtoupper($match[5]) : 'ASC';
 
+            $allowedOrderBy = ['id_product', 'price', 'date_add', 'rand'];
+            if (!in_array($orderBy, $allowedOrderBy, true)) {
+                $orderBy = '';
+            }
+            if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+                $orderWay = 'ASC';
+            }
+
             $sql = 'SELECT p.id_product
                     FROM ' . _DB_PREFIX_ . 'product_shop p
                     WHERE p.id_shop = ' . (int) $context->shop->id . '
                     ';
-            if ($orderBy) {
-                $sql .= 'ORDER BY p.' . pSQL($orderBy) . ' ' . pSQL($orderWay);
-            } else {
+            if ($orderBy === 'rand' || $orderBy === '') {
                 $sql .= 'ORDER BY RAND()';
+            } else {
+                $sql .= 'ORDER BY p.' . pSQL($orderBy) . ' ' . pSQL($orderWay);
             }
             $sql .= ' LIMIT ' . (int) $limit;
             $productIds = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -2795,11 +2803,19 @@ class EverblockTools extends ObjectModel
             $orderBy = isset($match[5]) ? strtolower($match[5]) : 'date_add';
             $orderWay = isset($match[6]) ? strtoupper($match[6]) : 'DESC';
 
+            $allowedOrderBy = ['id_product', 'price', 'date_add', 'rand'];
+            if (!in_array($orderBy, $allowedOrderBy, true)) {
+                $orderBy = 'date_add';
+            }
+            if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+                $orderWay = 'DESC';
+            }
+
             $sql = 'SELECT p.id_product
                     FROM ' . _DB_PREFIX_ . 'product_shop p
                     WHERE p.id_shop = ' . (int) $context->shop->id . '
                     AND p.active = 1
-                    ORDER BY p.' . pSQL($orderBy) . ' ' . pSQL($orderWay) . '
+                    ORDER BY ' . ($orderBy === 'rand' ? 'RAND()' : 'p.' . pSQL($orderBy) . ' ' . pSQL($orderWay)) . '
                     LIMIT ' . (int) $limit;
             $productIds = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
 
@@ -2882,12 +2898,20 @@ class EverblockTools extends ObjectModel
             $orderBy = isset($match[5]) ? strtolower($match[5]) : 'date_add';
             $orderWay = isset($match[6]) ? strtoupper($match[6]) : 'DESC';
 
+            $allowedOrderBy = ['id_product', 'price', 'date_add', 'rand'];
+            if (!in_array($orderBy, $allowedOrderBy, true)) {
+                $orderBy = 'date_add';
+            }
+            if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+                $orderWay = 'DESC';
+            }
+
             $sql = 'SELECT p.id_product
                     FROM ' . _DB_PREFIX_ . 'product_shop p
                     WHERE p.id_shop = ' . (int) $context->shop->id . '
                     AND p.active = 1
                     AND p.on_sale = 1
-                    ORDER BY p.' . pSQL($orderBy) . ' ' . pSQL($orderWay) . '
+                    ORDER BY ' . ($orderBy === 'rand' ? 'RAND()' : 'p.' . pSQL($orderBy) . ' ' . pSQL($orderWay)) . '
                     LIMIT ' . (int) $limit;
             $productIds = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
 


### PR DESCRIPTION
### Motivation
- Prevent malformed SQL and runtime errors coming from empty or invalid `orderby`/`orderway` values used in product shortcodes that led to SQL syntax issues (e.g. near `LIMIT 1`).
- Harden `random_product`, `last-products` and `promo-products` shortcode handlers so only safe ordering options are used.
- Ensure explicit support for `rand` ordering and sensible fallbacks when inputs are missing or invalid.

### Description
- Added whitelists (`$allowedOrderBy`) and normalization for `orderBy` and `orderWay` in `getRandomProductsShortcode`, `getLastProductsShortcode` and `getPromoProductsShortcode` to reject unexpected values and enforce `ASC|DESC` for direction.
- Updated SQL construction to use `ORDER BY RAND()` when `orderBy` is `'rand'` or empty, otherwise build `ORDER BY p.<column> <direction>` using `pSQL` for safety.
- Defaulted to safe fallback values (`''` / `'date_add'` for `orderBy` and `'ASC'`/`'DESC'` for `orderWay`) when inputs are invalid.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ce6da67483229ed93794bea18edf)