### PR TITLE
Fix best-seller ORDER BY handling to prevent SQL syntax errors

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -2190,11 +2190,21 @@ class EverblockTools extends ObjectModel
     protected static function getBestSellingProductIds(int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();
+        $orderBy = strtolower($orderBy);
+        $allowedOrderBy = [
+            'total_quantity' => 'total_quantity',
+            'product_id' => 'od.product_id',
+        ];
+        $orderColumn = $allowedOrderBy[$orderBy] ?? 'total_quantity';
+        $orderWay = strtoupper($orderWay);
+        if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+            $orderWay = 'DESC';
+        }
         $cacheId = 'everblock_bestSellingProductIds_'
             . (int) $context->shop->id . '_'
             . $limit . '_'
             . ($days ?? 'all') . '_'
-            . $orderBy . '_'
+            . $orderColumn . '_'
             . $orderWay;
 
         if (!EverblockCache::isCacheStored($cacheId)) {
@@ -2210,7 +2220,7 @@ class EverblockTools extends ObjectModel
             }
 
             $sql .= ' GROUP BY od.product_id'
-                . ' ORDER BY ' . pSQL($orderBy) . ' ' . pSQL($orderWay)
+                . ' ORDER BY ' . pSQL($orderColumn) . ' ' . pSQL($orderWay)
                 . ' LIMIT ' . (int) $limit;
 
             $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -2301,12 +2311,22 @@ class EverblockTools extends ObjectModel
     protected static function getBestSellingProductIdsByBrand(int $brandId, int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();
+        $orderBy = strtolower($orderBy);
+        $allowedOrderBy = [
+            'total_quantity' => 'total_quantity',
+            'product_id' => 'od.product_id',
+        ];
+        $orderColumn = $allowedOrderBy[$orderBy] ?? 'total_quantity';
+        $orderWay = strtoupper($orderWay);
+        if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+            $orderWay = 'DESC';
+        }
         $cacheId = 'everblock_bestSellingProductIds_brand_'
             . (int) $context->shop->id . '_'
             . $brandId . '_'
             . $limit . '_'
             . ($days ?? 'all') . '_'
-            . $orderBy . '_'
+            . $orderColumn . '_'
             . $orderWay;
 
         if (!EverblockCache::isCacheStored($cacheId)) {
@@ -2327,7 +2347,7 @@ class EverblockTools extends ObjectModel
             }
 
             $sql .= ' GROUP BY od.product_id'
-                . ' ORDER BY ' . pSQL($orderBy) . ' ' . pSQL($orderWay)
+                . ' ORDER BY ' . pSQL($orderColumn) . ' ' . pSQL($orderWay)
                 . ' LIMIT ' . (int) $limit;
 
             $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -2344,12 +2364,22 @@ class EverblockTools extends ObjectModel
     protected static function getBestSellingProductIdsByFeature(int $featureId, int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();
+        $orderBy = strtolower($orderBy);
+        $allowedOrderBy = [
+            'total_quantity' => 'total_quantity',
+            'product_id' => 'od.product_id',
+        ];
+        $orderColumn = $allowedOrderBy[$orderBy] ?? 'total_quantity';
+        $orderWay = strtoupper($orderWay);
+        if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+            $orderWay = 'DESC';
+        }
         $cacheId = 'everblock_bestSellingProductIds_feature_'
             . (int) $context->shop->id . '_'
             . $featureId . '_'
             . $limit . '_'
             . ($days ?? 'all') . '_'
-            . $orderBy . '_'
+            . $orderColumn . '_'
             . $orderWay;
 
         if (!EverblockCache::isCacheStored($cacheId)) {
@@ -2370,7 +2400,7 @@ class EverblockTools extends ObjectModel
             }
 
             $sql .= ' GROUP BY od.product_id'
-                . ' ORDER BY ' . pSQL($orderBy) . ' ' . pSQL($orderWay)
+                . ' ORDER BY ' . pSQL($orderColumn) . ' ' . pSQL($orderWay)
                 . ' LIMIT ' . (int) $limit;
 
             $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
@@ -2387,12 +2417,22 @@ class EverblockTools extends ObjectModel
     protected static function getBestSellingProductIdsByFeatureValue(int $featureValueId, int $limit, string $orderBy = 'total_quantity', string $orderWay = 'DESC', ?int $days = null): array
     {
         $context = Context::getContext();
+        $orderBy = strtolower($orderBy);
+        $allowedOrderBy = [
+            'total_quantity' => 'total_quantity',
+            'product_id' => 'od.product_id',
+        ];
+        $orderColumn = $allowedOrderBy[$orderBy] ?? 'total_quantity';
+        $orderWay = strtoupper($orderWay);
+        if (!in_array($orderWay, ['ASC', 'DESC'], true)) {
+            $orderWay = 'DESC';
+        }
         $cacheId = 'everblock_bestSellingProductIds_feature_value_'
             . (int) $context->shop->id . '_'
             . $featureValueId . '_'
             . $limit . '_'
             . ($days ?? 'all') . '_'
-            . $orderBy . '_'
+            . $orderColumn . '_'
             . $orderWay;
 
         if (!EverblockCache::isCacheStored($cacheId)) {
@@ -2413,7 +2453,7 @@ class EverblockTools extends ObjectModel
             }
 
             $sql .= ' GROUP BY od.product_id'
-                . ' ORDER BY ' . pSQL($orderBy) . ' ' . pSQL($orderWay)
+                . ' ORDER BY ' . pSQL($orderColumn) . ' ' . pSQL($orderWay)
                 . ' LIMIT ' . (int) $limit;
 
             $rows = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);


### PR DESCRIPTION
### Motivation
- Prevent malformed or ambiguous `ORDER BY` clauses in best-seller queries that could produce SQL syntax errors (observed error near `LIMIT`).
- Ensure cache keys reflect the normalized ordering parameters so cached results match the actual SQL ordering.

### Description
- Normalize and validate `orderBy` and `orderWay` inputs inside `getBestSellingProductIds`, `getBestSellingProductIdsByBrand`, `getBestSellingProductIdsByFeature` and `getBestSellingProductIdsByFeatureValue` by mapping allowed names to explicit SQL columns via an `$allowedOrderBy` map and deriving `$orderColumn`.
- Force `orderWay` to an uppercase `ASC`/`DESC` fallback and use `pSQL($orderColumn)` and `pSQL($orderWay)` in the generated SQL `ORDER BY` to avoid injection/invalid identifiers.
- Update cache keys to include the normalized `$orderColumn` instead of the raw `orderBy` string so cached entries correspond to the actual SQL ordering.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d04c17f883228c6ea718548dcfa8)