### PR TITLE
Optimize PrettyBlocks caching and invalidation

### DIFF
--- a/src/Service/EverblockCache.php
+++ b/src/Service/EverblockCache.php
@@ -178,4 +178,41 @@ class EverblockCache
             }
         }
     }
+
+    public static function invalidatePrettyBlocks(int $idShop, int $idLang): void
+    {
+        $structureKey = 'EverblockPrettyBlocks_structure_' . $idLang . '_' . $idShop;
+        $structure = null;
+
+        try {
+            if (static::isCacheStored($structureKey)) {
+                $structure = static::cacheRetrieve($structureKey);
+            }
+        } catch (Exception $e) {
+            $structure = null;
+        }
+
+        if (is_array($structure)) {
+            foreach ($structure as $block) {
+                if (!isset($block['id_block'])) {
+                    continue;
+                }
+                $htmlKey = 'EverblockPrettyBlock_html_'
+                    . (int) $block['id_block']
+                    . '_'
+                    . $idLang
+                    . '_'
+                    . $idShop;
+                static::cacheDrop($htmlKey);
+            }
+        } else {
+            if (static::useNativeCache()) {
+                Cache::clean('EverblockPrettyBlock_html_');
+            } else {
+                static::cacheDropByPattern('EverblockPrettyBlock_html_');
+            }
+        }
+
+        static::cacheDrop($structureKey);
+    }
 }


### PR DESCRIPTION
### Motivation

- Réduire drastiquement le temps d'exécution de `Everblock::getEverPrettyBlocks()` en éliminant les traitements lourds et les requêtes SQL quand le cache est valide. 
- Introduire un cache de « structure » léger et un cache de `HTML` final par block pour servir directement le rendu sans hydratation d'objets ni exécution inutile de hooks. 
- Offrir une invalidation ciblée et fiable des caches afin de garder compatibilité PrestaShop 1.7/8 et pouvoir déployer le cache sans effets secondaires.

### Description

- Ajout d'une nouvelle stratégie de rendu dans `src/Service/EverblockPrettyBlocks.php` qui retourne rapidement `HTML` pré-calculé quand applicable via `shouldUsePrettyBlocksHtmlCache()` et `getPrettyBlocksHtml()`; le flux lit d'abord le `structure` cache puis, pour chaque `id_block`, injecte le `HTML` cache ou le calcule et le stocke.
- Implémentation d'un cache de structure léger (`EverblockPrettyBlocks_structure_{id_lang}_{id_shop}`) et d'un cache HTML final par block (`EverblockPrettyBlock_html_{id_block}_{id_lang}_{id_shop}`) avec stockage via l'utilitaire `EverblockCache` (fichiers natives ou cache natif selon config). 
- Nouveau rendu minimal `renderPrettyBlockHtml()` qui tente d'appeler directement les méthodes du module PrettyBlocks via `Reflection` (`renderBlock`, `renderBlockById`, `renderPrettyBlock`, `renderWidget`) et ne tombe sur `Hook::exec()` qu'en dernier recours, évitant ainsi les exécutions inutiles de hooks quand le HTML est en cache.
- Ajout de `EverblockCache::invalidatePrettyBlocks($id_shop, $id_lang)` dans `src/Service/EverblockCache.php` qui supprime proprement le `structure` et les clés `HTML` associées (avec gestion du cache natif vs fichier). 
- Intégration de l'invalidation dans l'admin `controllers/admin/AdminEverBlockPrettyblockController.php` pour les opérations pertinentes (`add`, `update`, `duplicate`, `bulk change`, `bulk delete`, `duplicate shop/lang`, `clear cache`) et lors des duplications pour invalider les shops/langs concernés. 
- Ajout d'un mode debug contrôlé par `EVERBLOCK_DEBUG` qui journalise les temps par étape et les hits/miss de cache via `logDebug`, `logCacheFailure` et `logRenderFailure` sans impact lorsque désactivé.

### Testing

- Aucune suite de tests automatisés n'a été exécutée sur ces changements. 
- Validation manuelle et commits effectués dans le dépôt (no automated CI run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e2ac22608322b43867be605bbe80)