### PR TITLE
Add LLM links prettyblock (AI assistant links with prefilled prompts)

### DIFF
--- a/src/Service/EverblockPrettyBlocks.php
+++ b/src/Service/EverblockPrettyBlocks.php
@@ -217,6 +217,7 @@ class EverblockPrettyBlocks
         $googleReviewsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_google_reviews.tpl';
         $sharerTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_sharer.tpl';
         $linkListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_link_list.tpl';
+        $llmLinksTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_llm_links.tpl';
         $downloadsTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_downloads.tpl';
         $socialLinksTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_social_links.tpl';
         $brandListTemplate = 'module:' . $module->name . '/views/templates/hook/prettyblocks/prettyblock_brands.tpl';
@@ -2451,6 +2452,74 @@ class EverblockPrettyBlocks
                             'type' => 'checkbox',
                             'label' => $module->l('Open in new tab'),
                             'default' => '0',
+                        ],
+                        'css_class' => [
+                            'type' => 'text',
+                            'label' => $module->l('Custom CSS class'),
+                            'default' => '',
+                        ],
+                    ], $module),
+                ],
+            ];
+            $blocks[] = [
+                'name' => $module->l('LLM links'),
+                'description' => $module->l('Display AI assistant links with a prefilled prompt'),
+                'code' => 'everblock_llm_links',
+                'tab' => 'general',
+                'icon_path' => $defaultLogo,
+                'need_reload' => true,
+                'templates' => [
+                    'default' => $llmLinksTemplate,
+                ],
+                'config' => [
+                    'fields' => static::appendSpacingFields([
+                        'heading_text' => [
+                            'type' => 'text',
+                            'label' => $module->l('Heading text'),
+                            'default' => $module->l('Summarize this article with:'),
+                        ],
+                        'link_hover_effect' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Enable hover effect on links'),
+                            'default' => '1',
+                        ],
+                    ], $module),
+                ],
+                'repeater' => [
+                    'name' => 'LLM link',
+                    'nameFrom' => 'label',
+                    'groups' => static::appendSpacingFields([
+                        'label' => [
+                            'type' => 'text',
+                            'label' => $module->l('Link label'),
+                            'default' => $module->l('ChatGPT'),
+                        ],
+                        'base_url' => [
+                            'type' => 'text',
+                            'label' => $module->l('Base URL'),
+                            'default' => 'https://chat.openai.com/?prompt=',
+                        ],
+                        'prompt_template' => [
+                            'type' => 'textarea',
+                            'label' => $module->l('Prompt template'),
+                            'default' => $module->l('Summarize this article in a concise way. Title: {{title}} — URL: {{url}}'),
+                        ],
+                        'icon' => [
+                            'type' => 'fileupload',
+                            'label' => $module->l('Icon'),
+                            'default' => [
+                                'url' => '',
+                            ],
+                        ],
+                        'icon_alt' => [
+                            'type' => 'text',
+                            'label' => $module->l('Icon alt text'),
+                            'default' => '',
+                        ],
+                        'open_in_new_tab' => [
+                            'type' => 'checkbox',
+                            'label' => $module->l('Open in new tab'),
+                            'default' => '1',
                         ],
                         'css_class' => [
                             'type' => 'text',
@@ -4710,6 +4779,7 @@ class EverblockPrettyBlocks
             'everblock_custom_code',
             'everblock_img_slider',
             'everblock_link_list',
+            'everblock_llm_links',
             'everblock_downloads',
             'everblock_podcasts',
             'everblock_sharer',

--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -67,6 +67,48 @@
     transform: scale(1.04);
 }
 
+/* Prettyblock LLM links */
+.prettyblock-llm-links__inner {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.prettyblock-llm-links__heading {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.prettyblock-llm-links__list {
+    row-gap: 1rem;
+}
+
+.prettyblock-llm-links__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    text-align: center;
+    padding: 0.75rem 0.5rem;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    background-color: #f8f9fa;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    color: inherit;
+}
+
+.prettyblock-llm-links__item:hover,
+.prettyblock-llm-links__item:focus {
+    text-decoration: none;
+    color: inherit;
+}
+
+.prettyblock-llm-links__icon {
+    max-width: 92px;
+    height: auto;
+}
+
 /* Lookbook product markers */
 
 .lookbook-marker {

--- a/views/templates/hook/prettyblocks/prettyblock_llm_links.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_llm_links.tpl
@@ -51,7 +51,7 @@
                 {assign var='link_target' value='_blank'}
               {/if}
               <div class="col-6 col-md-4 col-lg-3" style="{$prettyblock_state_spacing_style}">
-                <a class="prettyblock-llm-links__item {if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect}everblock-link-hover--block{/if}" href="{$base_url}{$prompt_text|escape:'url'}" data-base-url="{$base_url|escape:'htmlall':'UTF-8'}" data-prompt-template="{$state.prompt_template|escape:'htmlall':'UTF-8'}" target="{$link_target}"{if $link_target === '_blank'} rel="noopener noreferrer"{/if}>
+                <a class="prettyblock-llm-links__item{if isset($block.settings.link_hover_effect) && $block.settings.link_hover_effect} everblock-link-hover--block{/if}{if isset($state.css_class) && $state.css_class} {$state.css_class|escape:'htmlall':'UTF-8'}{/if}" href="{$base_url}{$prompt_text|escape:'url'}" data-base-url="{$base_url|escape:'htmlall':'UTF-8'}" data-prompt-template="{$state.prompt_template|escape:'htmlall':'UTF-8'}" target="{$link_target}"{if $link_target === '_blank'} rel="noopener noreferrer"{/if}>
                   {if isset($state.icon.url) && $state.icon.url}
                     <img class="prettyblock-llm-links__icon" src="{$state.icon.url|escape:'htmlall':'UTF-8'}" alt="{$state.icon_alt|default:$state.label|default:''|escape:'htmlall':'UTF-8'}" loading="lazy" width="92" height="92">
                   {/if}


### PR DESCRIPTION
### Motivation
- Provide a Prettyblock that renders AI assistant links (ChatGPT, Claude, etc.) which prefill a prompt with the current page title and URL so editors can add a block that links readers to LLMs with a ready-made prompt. 
- Allow editors to configure multiple assistants (base URL, prompt template, icon, label, open-in-new-tab) per block and to add per-item CSS classes for custom styling. 
- Integrate the new block into the existing PrettyBlocks registry and ensure the frontend uses the existing Bootstrap-compatible layout system.

### Description
- Registered a new Prettyblock in `src/Service/EverblockPrettyBlocks.php` with code `everblock_llm_links`, including `config` fields (`heading_text`, `link_hover_effect`) and a `repeater` for per-link options (`label`, `base_url`, `prompt_template`, `icon`, `icon_alt`, `open_in_new_tab`, `css_class`).
- Added the template path variable and included the block in the blocks list so it is available to the PrettyBlocks UI (`$llmLinksTemplate` and `'everblock_llm_links'` code entry).
- Extended `views/templates/hook/prettyblocks/prettyblock_llm_links.tpl` to output the LLM links, replace `{{title}}` and `{{url}}` in the prompt template with the page title and URL, and accept a per-item `css_class`; anchors respect `open_in_new_tab` and include `rel="noopener noreferrer"` when appropriate.
- Added styling to `views/css/everblock.css` to style the LLM links block and tiles while keeping the layout compatible with Bootstrap 4/5 grid classes used in templates.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698205514c2483228b0fee0e8263fcb5)