### PR TITLE
Ensure mobile carousels show at least two products

### DIFF
--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -26,6 +26,9 @@
   {if $mobileItems < 1}
     {assign var='mobileItems' value=1}
   {/if}
+  {if isset($carousel) && $carousel && $mobileItems < 2}
+    {assign var='mobileItems' value=2}
+  {/if}
   {assign var='tabletItems' value=$carouselTabletItems|default:2|intval}
   {if $tabletItems < 1}
     {assign var='tabletItems' value=1}


### PR DESCRIPTION
### Motivation
- Prevent mobile carousels (used by the `[crosselling]` and other presented-products shortcodes) from showing a single product per slide when `carousel=true`, by enforcing a minimum of two items on mobile.

### Description
- Adjust `views/templates/hook/ever_presented_products.tpl` to set `mobileItems` to `2` when `carousel` is enabled and the configured mobile item count is less than `2`.

### Testing
- No automated tests were run because this is a template-only change; manual verification is expected in the frontend environment to confirm at least two products per mobile carousel slide when `carousel=true`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982145e6610832284aad0f4539c201c)