### PR TITLE
Fix crosselling thumbnail cropping in Everblock carousel

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -309,6 +309,19 @@
 .ever-featured-products .carousel-control-next {
     right: -1.5rem;
 }
+
+.ever-featured-products.crosselling .thumbnail-container,
+.ever-featured-products.crosselling .product-thumbnail {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ever-featured-products.crosselling .product-thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
 /* Style pour les boutons de partage */
 
 .everblock-sharer {

--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -89,7 +89,7 @@
     {/if}
   </section>
   {if isset($carousel) && $carousel}
-  <section class="ever-featured-products featured-products mx-2 d-block d-md-none">
+  <section class="ever-featured-products featured-products mx-2 d-block d-md-none{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
     {assign var="mobileCarouselId" value="ever-presented-carousel-mobile-"|cat:mt_rand(1000,999999)}
     {assign var="mobileNumProductsPerSlide" value=$mobileItems}
     <div id="{$mobileCarouselId}" class="carousel slide" data-ride="false" data-bs-ride="false" data-bs-wrap="true" data-ever-mobile-carousel="1" data-ever-infinite-carousel="1">


### PR DESCRIPTION
### Motivation
- Cross-selling thumbnails inside Everblock blocks were being cropped on some viewports, causing poor product image display.
- The intent is to ensure the cross-selling shortcode output receives the same class-based styling on mobile and that thumbnails keep their aspect ratio.

### Description
- Add the shortcode class to the mobile featured-products section by updating `views/templates/hook/ever_presented_products.tpl` so the `shortcodeClass` (e.g. `crosselling`) is present on the mobile carousel container.
- Add cross-selling specific CSS in `views/css/everblock.css` (selector `.ever-featured-products.crosselling .thumbnail-container` and `.product-thumbnail img`) to center thumbnails and use `object-fit: contain` to avoid cropping.

### Testing
- No automated tests were run; changes are limited to a template and stylesheet and should be verifiable visually in a storefront preview.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821cd71018832284977367438bde04)