### PR TITLE
Remove WordPress posts template title

### DIFF
--- a/views/templates/hook/generated_wp_posts.tpl
+++ b/views/templates/hook/generated_wp_posts.tpl
@@ -1,9 +1,5 @@
 {if isset($everblock_wp_posts) && $everblock_wp_posts|@count > 0}
 <section class="everblock-wp-section text-center my-5"{if $everblock_wp_background_image} style="background-image:url('{$everblock_wp_background_image|escape:'htmlall':'UTF-8'}');background-size:cover;background-position:center;background-repeat:no-repeat;"{/if}>
-  <h2 class="section-title text-uppercase mb-4">
-    <span>{l s='Latest news from our blog' mod='everblock'}</span>
-  </h2>
-
   {assign var='carouselId' value='everblock-wp-posts-carousel-'|cat:mt_rand(1000,999999)}
   <div class="everblock-wp-posts container">
     <div class="row justify-content-center align-items-stretch">


### PR DESCRIPTION
### Motivation
- Remove the hardcoded section heading from the WordPress posts shortcode template so the block can be embedded without rendering its title.

### Description
- Update `views/templates/hook/generated_wp_posts.tpl` by deleting the `<h2>` section heading (`Latest news from our blog`) so the template only renders the posts grid and CTA button.

### Testing
- No automated tests were run because this is a template-only change; visual/functional verification is expected during integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983307a26908322b99d193d15a72996)