### PR TITLE
Remove admin module form-group styles

### DIFF
--- a/views/css/ever.css
+++ b/views/css/ever.css
@@ -436,29 +436,11 @@
     padding-top: 1.5rem;
 }
 
-#module_form .form-group {
-    background: #f9f9ff;
-    border: 1px solid #e5e7ff;
-    border-radius: 16px;
-    padding: 1.35rem 1.5rem;
-    margin-bottom: 1.5rem;
-    transition: box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-#module_form .form-group:hover {
-    border-color: #c7cafc;
-    box-shadow: 0 16px 32px rgba(67, 56, 202, 0.16);
-}
-
 #module_form .everblock-form-group--doc {
     background: transparent;
     border: 0;
     padding: 0;
     box-shadow: none;
-}
-
-#module_form .form-group:last-of-type {
-    margin-bottom: 0;
 }
 
 #module_form .everblock-prettyblocks-action {


### PR DESCRIPTION
### Motivation
- Remove custom rounded card styling applied to module form groups in the admin stylesheet to let the admin UI use the global or alternative styles and avoid visual conflicts.

### Description
- Deleted the `#module_form .form-group` rule that set background, border, border-radius, padding, margin-bottom, and transition in `views/css/ever.css`.
- Removed the `#module_form .form-group:hover` rule that applied a border-color and large box-shadow.
- Removed the `#module_form .form-group:last-of-type` rule that adjusted the bottom margin.
- Kept related admin form helper rules (like `.everblock-form-group--doc` and `.everblock-prettyblocks-action`) intact.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698451b205ac8322955d67640e1298ff)