### PR TITLE
Remove highlight fields from simple image prettyblock template

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_img.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_img.tpl
@@ -146,14 +146,6 @@
                      class="img img-fluid lazyload" loading="lazy">
               </picture>
 
-              <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
-                {if $state.text_highlight_1}
-                  <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
-                {/if}
-                {if $state.text_highlight_2}
-                  <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
-                {/if}
-              </div>
             {if isset($state.url) && $state.url}
               </a>
             {/if}
@@ -230,14 +222,6 @@
                      class="img img-fluid lazyload" loading="lazy">
               </picture>
 
-              <div class="position-absolute bottom-0 start-0 end-0 p-3 text-center text-white">
-                {if $state.text_highlight_1}
-                  <div class="fw-bold small">{$state.text_highlight_1 nofilter}</div>
-                {/if}
-                {if $state.text_highlight_2}
-                  <div class="fw-bold small mb-2">{$state.text_highlight_2 nofilter}</div>
-                {/if}
-              </div>
             {if isset($state.url) && $state.url}
               </a>
             {/if}


### PR DESCRIPTION
### Motivation
- The `Simple Image` prettyblock no longer declares `text_highlight_1`/`text_highlight_2`, so the template should not render those fields to avoid stale markup and potential undefined-key warnings.

### Description
- Remove the highlight text markup (two occurrences) from `views/templates/hook/prettyblocks/prettyblock_img.tpl` so the template no longer outputs `text_highlight_1`/`text_highlight_2` containers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69845a1d0fc48322b3295643912c602e)