### PR TITLE
Guard missing content in PrettyBlocks extra states

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
@@ -33,8 +33,10 @@
       ">
         {$state.content nofilter}
         {if isset($block.extra.states) && $block.extra.states}
-        {foreach $block.extra.states as $state}
-          {$state.content nofilter}
+        {foreach $block.extra.states as $extra_state}
+          {if isset($extra_state.content)}
+            {$extra_state.content nofilter}
+          {/if}
         {/foreach}
         {/if}
     </div>


### PR DESCRIPTION
### Motivation
- Prevent PHP notices caused by rendering extra PrettyBlocks states when `content` is missing.
- Avoid accidental overwriting of the main `$state` variable when iterating extra states.

### Description
- Rename the extra-states loop variable to `$extra_state` to keep the main `$state` intact.
- Add a guard `isset($extra_state.content)` before rendering to skip missing content.
- Change applied in `views/templates/hook/prettyblocks/prettyblock_everblock.tpl`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846108cbec83229df57d9708441878)