### PR TITLE
Guard missing prettyblock content in Smarty template

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_everblock.tpl
@@ -31,7 +31,9 @@
         {if isset($state.background_color) && $state.background_color}background-color:{$state.background_color};{/if}
         {if isset($state.text_color) && $state.text_color}color:{$state.text_color};{/if}
       ">
-        {$state.content nofilter}
+        {if isset($state.content)}
+          {$state.content nofilter}
+        {/if}
         {if isset($block.extra.states) && $block.extra.states}
         {foreach $block.extra.states as $extra_state}
           {if isset($extra_state.content)}


### PR DESCRIPTION
### Motivation
- Prevent PHP notices about an undefined `content` key when rendering PrettyBlocks states by only outputting state content if it exists.

### Description
- Update `views/templates/hook/prettyblocks/prettyblock_everblock.tpl` to wrap `{$state.content nofilter}` with `{if isset($state.content)}...{/if}` so state content is rendered only when present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846266dcf08322b356687b0d1c2f7d)