### PR TITLE
Fix global `easter_date` invocation in holiday helper

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -3846,7 +3846,7 @@ class EverblockTools extends ObjectModel
 
     public static function getFrenchHolidays($year)
     {
-        $easterDate = easter_date($year);
+        $easterDate = \easter_date($year);
         $holidays = [
             // Jours fixes
             sprintf('%s-01-01', $year), // Jour de l'an


### PR DESCRIPTION
### Motivation
- Avoid accidental namespaced resolution of the PHP global function `easter_date` when building French holiday dates.

### Description
- Qualify the call to the global function by changing `easter_date($year)` to `\easter_date($year)` in `getFrenchHolidays` within `src/Service/EverblockTools.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f9134d5c8322b3de70328bc4030f)