### PR TITLE
Add missing prettyblock_llm_links.tpl to allowed files whitelist

### DIFF
--- a/config/allowed_files.php
+++ b/config/allowed_files.php
@@ -333,6 +333,7 @@ return [
     'views/templates/hook/prettyblocks/prettyblock_img_slider.tpl',
     'views/templates/hook/prettyblocks/prettyblock_layout.tpl',
     'views/templates/hook/prettyblocks/prettyblock_link_list.tpl',
+    'views/templates/hook/prettyblocks/prettyblock_llm_links.tpl',
     'views/templates/hook/prettyblocks/prettyblock_login.tpl',
     'views/templates/hook/prettyblocks/prettyblock_lookbook.tpl',
     'views/templates/hook/prettyblocks/prettyblock_masonry_gallery.tpl',


### PR DESCRIPTION
### Motivation
- Ensure every `views/templates/hook/prettyblocks/*.tpl` template is present in the module whitelist so templates are allowed by the `config/allowed_files.php` policy and won't be blocked at runtime.

### Description
- Add `'views/templates/hook/prettyblocks/prettyblock_llm_links.tpl'` to `config/allowed_files.php` to cover the previously-missing prettyblock template.

### Testing
- Ran a Python consistency check that compared the `views/templates/hook/prettyblocks/**/*.tpl` files with the entries in `config/allowed_files.php`, and it reported no missing or extra entries (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec6ae90688322a155e81de17a1e77)