### PR TITLE
Fix Prettyblock Category Tabs product layout after first row

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -164,7 +164,7 @@
                                                 <div class="products row">
                                                     {foreach from=$block.extra.products[$key] item=product name=desktopBottomProducts}
                                                         {if $smarty.foreach.desktopBottomProducts.index >= $sideProductsCount}
-                                                            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses='col-12'}
+                                                            {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
                                                         {/if}
                                                     {/foreach}
                                                 </div>


### PR DESCRIPTION
### Motivation
- The Category Tabs prettyblock rendered the first two products correctly but forced subsequent products to full-width, breaking the expected grid (should render N per row, typically 4 on desktop). 
- The issue occurred in the desktop-with-slider branch where a hardcoded `col-12` was used for remaining products instead of the computed column classes.

### Description
- Updated the template `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to replace the hardcoded `col-12` with the dynamic `$productColumnClasses` for the desktop bottom-products branch. 
- This change ensures all product items use the same computed grid classes (`$mobileColumnWidth`, `$tabletColumnWidth`, `$desktopColumnWidth`) so the layout displays the configured number of columns (e.g. 4 per row) consistently.

### Testing
- Reviewed the template diff to confirm the single-line change and that only the intended include argument was updated (success).  
- Inspected the updated lines with `nl`/`sed` to verify the `productClasses` now reference `$productColumnClasses` (success).  
- Attempted an automated Playwright screenshot to validate rendering, but the headless Chromium run failed in this environment (Playwright/Chromium crash), so visual validation could not be produced here (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec884ec448322bb698b2742e48b24)