### PR TITLE
Fix category tabs desktop product grid sizing

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -72,7 +72,7 @@
                     {if $desktopItems < 1}
                         {assign var='desktopItems' value=1}
                     {/if}
-                    {if $sliderImagesCount > 0}
+                    {if $sliderImagesCount > 0 && $useDesktopSlider}
                         {assign var='desktopItems' value=2}
                     {/if}
                     {if $productCount > 0 && $productCount < $desktopItems}
@@ -145,13 +145,16 @@
                             {if isset($block.extra.products[$key]) && $block.extra.products[$key]}
                                 {if $hasSliderImages && !$useDesktopSlider}
                                     {assign var='sideProductsCount' value=2}
+                                    {assign var='sideProductColumnClasses' value="col-"|cat:$mobileColumnWidth}
+                                    {assign var='sideProductColumnClasses' value=$sideProductColumnClasses|cat:" col-sm-"|cat:$tabletColumnWidth}
+                                    {assign var='sideProductColumnClasses' value=$sideProductColumnClasses|cat:" col-lg-6 col-xl-6"}
                                     <div class="col-12 col-lg-8">
                                         <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             <div class="products row">
                                                 {foreach from=$block.extra.products[$key] item=product name=desktopSideProducts}
                                                     {if $smarty.foreach.desktopSideProducts.index < $sideProductsCount}
-                                                        {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$productColumnClasses}
+                                                        {include file="catalog/_partials/miniatures/product.tpl" product=$product productClasses=$sideProductColumnClasses}
                                                     {/if}
                                                 {/foreach}
                                             </div>


### PR DESCRIPTION
### Motivation
- The category tabs block was assigning `col-lg-6 col-xl-6` to products incorrectly when slider images were present even if the desktop slider was disabled, breaking the expected 4-per-row desktop layout.
- The goal is to ensure the template only forces a 2-per-row layout when the desktop slider is actually in use and to isolate the two side products' column classes when the slider images are shown but desktop slider is disabled.

### Description
- Updated `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` to only set `desktopItems = 2` when `{$sliderImagesCount > 0 && $useDesktopSlider}` so desktop column forcing occurs only when the desktop slider is enabled.
- Added a dedicated `sideProductColumnClasses` value and applied it to the two side products when `hasSliderImages && !$useDesktopSlider` so those two items render as `col-lg-6 col-xl-6` while the remaining products use the normal `productColumnClasses`.
- This change prevents remaining products from inheriting the half-width classes and restores the normal 4-per-row behavior on desktop.
- Committed the template update with the message `Fix desktop product columns in category tabs block`.

### Testing
- Inspected the template diff with `git diff -- views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` and verified the intended changes were present (success).
- Confirmed the change was staged and recorded with `git status --short` and `git commit -m "Fix desktop product columns in category tabs block"` (success).
- Attempted to validate the UI with a Playwright screenshot but the local web server was not available and the run failed with `net::ERR_EMPTY_RESPONSE` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aecce563f883228a19d558a233ec58)