### PR TITLE
feat: mobile slider for Featured Category block

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -3358,3 +3358,30 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Featured subcategories mobile slider */
+@media (max-width: 767.98px) {
+  .featured-subcategories .subcategories {
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: #c3c3c3 transparent;
+  }
+
+  .featured-subcategories .subcategories > [class*="subcategory-"] {
+    scroll-snap-align: start;
+  }
+
+  .featured-subcategories .subcategories::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .featured-subcategories .subcategories::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .featured-subcategories .subcategories::-webkit-scrollbar-thumb {
+    background: #c3c3c3;
+    border-radius: 999px;
+  }
+}

--- a/views/templates/hook/subcategories.tpl
+++ b/views/templates/hook/subcategories.tpl
@@ -17,10 +17,10 @@
 *}
 {if isset($everSubCategories) && $everSubCategories}
 <section class="featured-subcategories clearfix mt-3">
-    <div class="subcategories row">
+    <div class="subcategories row flex-nowrap flex-md-wrap overflow-auto overflow-md-visible pb-2 pb-md-0">
     {foreach $everSubCategories item=subcategory}
-    	<div class="col-12 col-md-4 subcategory-{$subcategory.id_category}">
-    		<a href="{$subcategory.link}" title="{$subcategory.meta_description}">
+	<div class="col-6 col-md-4 flex-shrink-0 flex-md-shrink-1 subcategory-{$subcategory.id_category}">
+			<a href="{$subcategory.link}" title="{$subcategory.meta_description}">
 	    		<p class="h3 text-center">{$subcategory.name}</p>
 	    		{if isset($subcategory.image_link) && $subcategory.image_link}
 	    		<img src="{$subcategory.image_link}" alt="{$subcategory.meta_description}" class="text-center lazyload img img-fluid" loading="lazy">


### PR DESCRIPTION
### Motivation
- Provide a mobile-only horizontal slider for the Featured Category (subcategories) block that shows two categories at once and uses native swipe with a visible bottom scrollbar, without dots or arrows.

### Description
- Updated `views/templates/hook/subcategories.tpl` to render the subcategories container as horizontal scroll on small screens by adding `flex-nowrap`, `overflow-auto`, and responsive `flex-md-wrap` to preserve desktop behavior.
- Changed item markup to `col-6 col-md-4 flex-shrink-0` so two category cards are visible on small screens while keeping the existing desktop grid at `col-md-4`.
- Added mobile-only CSS to `views/css/everblock.css` (`@media (max-width: 767.98px)`) to enable `scroll-snap-type`, `scroll-snap-align` on items, touch scrolling, and a thin bottom scrollbar styled via `::-webkit-scrollbar` and `scrollbar-width`/`scrollbar-color`.

### Testing
- Ran `git diff --check` which passed.
- Attempted an automated visual check with Playwright against `http://localhost:80`, but the request failed with `ERR_EMPTY_RESPONSE` because no local web server responded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedbdf0b808322aee4004bd13cdd6f)