### PR TITLE
Force 2 products per row on mobile for Prettyblock product lists

### DIFF
--- a/views/templates/hook/ever_presented_products.tpl
+++ b/views/templates/hook/ever_presented_products.tpl
@@ -22,11 +22,8 @@
   {/if}
   {assign var='carouselCounter' value=$carouselCounter+1}
 
-  {assign var='mobileItems' value=$carouselMobileItems|default:1|intval}
-  {if $mobileItems < 1}
-    {assign var='mobileItems' value=1}
-  {/if}
-  {if isset($carousel) && $carousel && $mobileItems < 2}
+  {assign var='mobileItems' value=$carouselMobileItems|default:2|intval}
+  {if $mobileItems < 2}
     {assign var='mobileItems' value=2}
   {/if}
   {assign var='tabletItems' value=$carouselTabletItems|default:2|intval}
@@ -46,7 +43,7 @@
   {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-lg-"|cat:$desktopColumnWidth}
   {assign var='productColumnClasses' value=$productColumnClasses|cat:" col-xl-"|cat:$desktopColumnWidth}
 
-  <section class="ever-featured-products featured-products clearfix mx-5 d-none d-md-block{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
+  <section class="ever-featured-products featured-products clearfix mx-5{if isset($carousel) && $carousel} d-none d-md-block{/if}{if isset($shortcodeClass)} {$shortcodeClass|escape:'htmlall':'UTF-8'}{/if}">
     {if isset($carousel) && $carousel}
       {assign var="carouselId" value="ever-presented-carousel-"|cat:mt_rand(1000,999999)}
       {assign var="numProductsPerSlide" value=$desktopItems}


### PR DESCRIPTION
### Motivation
- Ensure Prettyblock product blocks display two items per row on mobile to improve layout consistency and match the intended design.

### Description
- Change default mobile items in `views/templates/hook/ever_presented_products.tpl` to `default:2` and enforce a minimum of `mobileItems >= 2` so mobile grids produce two columns (`col-6`).
- Apply `d-none d-md-block` only when a carousel is active by wrapping it with `{if isset($carousel) && $carousel}` so non-carousel product blocks on mobile can use the 2-column layout.
- Only `views/templates/hook/ever_presented_products.tpl` was modified.

### Testing
- The patch was applied successfully using `apply_patch` and the file was updated as expected.
- Changes were reviewed with `git diff -- views/templates/hook/ever_presented_products.tpl` which shows the intended modifications.
- The change was committed with `git add` and `git commit` and `git status --short` reports no other uncommitted changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedc531e048322a9b9ed38691c4d30)