### PR TITLE
Fix Prettyblock Title container option rendering

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -36,11 +36,9 @@
         {if isset($block.settings.default.bg_color) && $block.settings.default.bg_color}
           {assign var='heading_styles' value="{$heading_styles}background-color:{$block.settings.default.bg_color|escape:'htmlall':'UTF-8'};"}
         {/if}
-        <div class="container">
-          <div class="row justify-content-center text-center">
-            <div class="col-auto">
-              <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading px-4 py-2 {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
-            </div>
+        <div class="row justify-content-center text-center">
+          <div class="col-auto">
+            <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading px-4 py-2 {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
           </div>
         </div>
     {if $block.settings.default.container}


### PR DESCRIPTION
### Motivation
- Ensure the "Placer le contenu dans une colonne centrée (container)" setting is actually respected for the Prettyblock Title so the block does not always force a `.container` wrapper.

### Description
- Remove the forced `<div class="container">` wrapper in `views/templates/hook/prettyblocks/prettyblock_heading.tpl` and keep the existing `row justify-content-center` + `col-auto` structure so the heading stays centered while honoring `block.settings.default.container`.

### Testing
- Ran `git diff --check` to validate there are no whitespace or merge marker issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee27238708322bebfc071615204ea)