### PR TITLE
Adjust category tabs desktop layout to 50/50 split

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl
@@ -108,7 +108,7 @@
                         <div class="row prettyblock-category-tabs__layout{if $hasSliderImages} prettyblock-category-tabs__layout--with-slider{/if}">
                             {if $hasSliderImages}
                                 {assign var='carouselId' value="category-tabs-slider-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}
-                                <div class="col-12 col-lg-4">
+                                <div class="col-12 col-lg-6">
                                     <div class="prettyblock-category-tabs__slider mt-3">
                                         <div id="{$carouselId}" class="prettyblocks-image-slider carousel slide" data-ride="carousel" data-bs-ride="carousel" data-bs-wrap="true" data-autoplay="0" data-transition-speed="600">
                                             <div class="prettyblock-category-tabs__slider-header">
@@ -148,7 +148,7 @@
                                     {assign var='sideProductColumnClasses' value="col-"|cat:$mobileColumnWidth}
                                     {assign var='sideProductColumnClasses' value=$sideProductColumnClasses|cat:" col-sm-"|cat:$tabletColumnWidth}
                                     {assign var='sideProductColumnClasses' value=$sideProductColumnClasses|cat:" col-lg-6 col-xl-6"}
-                                    <div class="col-12 col-lg-8">
+                                    <div class="col-12 col-lg-6">
                                         <section class="ever-featured-products featured-products clearfix mt-3 category_tabs d-none d-md-block">
                                             {hook h='displayBeforeProductMiniature' products=$block.extra.products[$key] origin='category_tabs' page_name=$page.page_name}
                                             <div class="products row">
@@ -217,7 +217,7 @@
                                         {/if}
                                     </div>
                                 {else}
-                                    <div class="col-12{if $hasSliderImages} col-lg-8{/if}">
+                                    <div class="col-12{if $hasSliderImages} col-lg-6{/if}">
                                         {if $useDesktopSlider || $useMobileSlider}
                                             {if $useDesktopSlider}
                                                 {assign var='carouselIdDesktop' value="category-tabs-carousel-desktop-"|cat:$block.id_prettyblocks|cat:"-"|cat:$key|cat:"-"|cat:mt_rand(1000,999999)}


### PR DESCRIPTION
### Motivation
- Ensure the category-tabs block renders the image slider at 50% width on desktop and the next two products occupy the remaining 50% as requested, while keeping mobile behavior unchanged.

### Description
- Updated Bootstrap grid classes in the category tabs template so the slider column uses `col-lg-6` instead of `col-lg-4` and the adjacent product column uses `col-lg-6` instead of `col-lg-8`.
- Harmonized the conditional/fallback branches that applied slider-aware widths to also use `col-lg-6` for desktop.
- Changes made in `views/templates/hook/prettyblocks/prettyblock_category_tabs.tpl` and only touch template grid classes (no CSS files were modified).

### Testing
- Verified the template diff with `git diff` to confirm only the intended class replacements occurred and the working tree shows the modified file (succeeded).
- Searched the template with `rg` to confirm updated `col-lg-6` occurrences (succeeded).
- Attempted an automated visual check via Playwright to capture a screenshot, but the container had no local webserver accessible at `http://127.0.0.1:8080` so the page capture failed with `ERR_EMPTY_RESPONSE` (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee32ce8748322b7dbe3ed3af2d869)