### PR TITLE
Fix nested container overflow in heading prettyblock

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -25,7 +25,7 @@
     <div class="row">
   {/if}
 <!-- Module Ever Block -->
-<div class="{if $block.settings.default.container}container{/if}" style="{$prettyblock_spacing_style}">
+<div class="{if $block.settings.default.force_full_width}container{/if}" style="{$prettyblock_spacing_style}">
     {if $block.settings.default.container}
         <div class="row">
     {/if}


### PR DESCRIPTION
### Motivation
- Prevent horizontal overflow caused by rendering a nested `.container` inside an existing `.container > .row` for heading/title blocks.

### Description
- Adjusted the wrapper condition in `views/templates/hook/prettyblocks/prettyblock_heading.tpl` so the inner `.container` is rendered only when `default.force_full_width` is true instead of when `default.container` is true.
- This removes the problematic `container > row > container` structure while preserving the constrained inner wrapper for full-width blocks.

### Testing
- Inspected the template diff with `git diff` to confirm the conditional change and the single-line edit succeeded; result was as expected (success).
- Verified the file contents with `nl -ba views/templates/hook/prettyblocks/prettyblock_heading.tpl | sed -n '20,45p'` to ensure the new condition appears in the correct location (success).
- Committed the change with `git commit` and prepared the PR metadata via the repository helper (commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee52c3cc48322a5dba9fc6ba41bd6)