### PR TITLE
Fix mobile featured products to display two columns

### DIFF
--- a/views/css/everblock.css
+++ b/views/css/everblock.css
@@ -322,6 +322,13 @@
     height: 100%;
     object-fit: contain;
 }
+
+@media (max-width: 767.98px) {
+    .ever-featured-products .products.row > * {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+}
 /* Style pour les boutons de partage */
 
 .everblock-sharer {


### PR DESCRIPTION
### Motivation
- On narrow screens product miniatures in `.ever-featured-products` could be rendered one per row when theme CSS overrides Bootstrap, so enforce a two-column layout as a fallback for mobile.

### Description
- Add a mobile media query in `views/css/everblock.css` that sets `.ever-featured-products .products.row > *` to `flex: 0 0 50%` and `max-width: 50%` for screens below `768px`.
- The change is scoped to the `.ever-featured-products` block and does not modify tablet or desktop behavior.

### Testing
- Ran `git status --short && git log -1 --oneline` which succeeded and shows the change committed.
- Performed the `git commit` operation which completed successfully and recorded the patch.
- Tried a Playwright screenshot run against `http://localhost` which failed with `ERR_EMPTY_RESPONSE` because no local server was available to render the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee93c9280832296185f068d397a8b)