### PR TITLE
perf: avoid costly actionOutputHTMLBefore processing on plain HTML pages

### DIFF
--- a/everblock.php
+++ b/everblock.php
@@ -3855,6 +3855,9 @@ class Everblock extends Module
             );
         }
         $txt = $params['html'];
+        if (!EverblockTools::hasShortcodeToken($txt)) {
+            return $txt;
+        }
         try {
             $context = Context::getContext();
             // @Todo : move to EverblockShortcodes

--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -76,6 +76,30 @@ if (!defined('_PS_VERSION_')) {
 class EverblockTools extends ObjectModel
 {
     /**
+     * Fast pre-check used to avoid running the shortcode engine on pages that
+     * do not contain any known token.
+     */
+    public static function hasShortcodeToken(string $txt): bool
+    {
+        $needles = [
+            '[',
+            '{hook h=',
+            '{$',
+            '{if',
+            '{foreach',
+            '{include',
+        ];
+
+        foreach ($needles as $needle) {
+            if (strpos($txt, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Point d'entrée principal du moteur de shortcodes.
      *
      * Le texte est enrichi en plusieurs étapes : hooks d'extension, résolution des


### PR DESCRIPTION
### Motivation
- The `hookActionOutputHTMLBefore` was executing the full shortcode engine on every page, causing unnecessary ~500ms overhead on pages without shortcodes.
- Add a cheap pre-check to short-circuit processing for plain HTML pages and restore expected performance for non-shortcode pages.

### Description
- Added `EverblockTools::hasShortcodeToken(string $txt): bool` to `src/Service/EverblockTools.php` which performs a fast existence check for tokens such as ``[``, ``{hook h=``, ``{$``, ``{if``, ``{foreach``, and ``{include``.
- Updated `hookActionOutputHTMLBefore` in `everblock.php` to early-return the original HTML when `EverblockTools::hasShortcodeToken($txt)` is false, avoiding the full `renderShortcodes` run.
- The change is minimal and focused on a cheap string-search pre-check to prevent running the heavier shortcode pipeline on irrelevant pages.

### Testing
- Ran PHP syntax checks with `php -l everblock.php` and `php -l src/Service/EverblockTools.php`, both succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b023c4636c8322badd233ff38b84b0)