### PR TITLE
Allow HTML rendering in Prettyblock Title headings

### DIFF
--- a/views/templates/hook/prettyblocks/prettyblock_heading.tpl
+++ b/views/templates/hook/prettyblocks/prettyblock_heading.tpl
@@ -38,7 +38,7 @@
         {/if}
         <div class="row justify-content-center text-center">
           <div class="col-auto">
-            <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading px-4 py-2 {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title|escape:'htmlall':'UTF-8'}</{$block.settings.level|default:'h2'}>
+            <{$block.settings.level|default:'h2'} id="{$block.id_prettyblocks}" class="everblock everblock-heading px-4 py-2 {$block.settings.css_class|escape:'htmlall':'UTF-8'}"{if $heading_styles|trim} style="{$heading_styles}"{/if}>{$block.settings.title nofilter}</{$block.settings.level|default:'h2'}>
           </div>
         </div>
     {if $block.settings.default.container}


### PR DESCRIPTION
### Motivation
- Allow authors to include inline HTML (for example `<span>`) inside Prettyblock titles so H1–H6 headings can contain formatted fragments while keeping the same back-office input field and settings.

### Description
- Replaced the escaped title output with raw Smarty output in `views/templates/hook/prettyblocks/prettyblock_heading.tpl` by changing `{$block.settings.title|escape:'htmlall':'UTF-8'}` to `{$block.settings.title nofilter}` to allow HTML rendering inside the heading element.

### Testing
- Ran `git diff -- views/templates/hook/prettyblocks/prettyblock_heading.tpl` to confirm the exact template change and it succeeded.
- Inspected the updated file content with `nl -ba views/templates/hook/prettyblocks/prettyblock_heading.tpl | sed -n '30,50p'` to verify the new `nofilter` usage and it succeeded.
- No automated unit tests were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcfd82a48083229028aeebb5f6d63e)