### PR TITLE
Optimize shortcode detection before rendering

### DIFF
--- a/src/Service/EverblockTools.php
+++ b/src/Service/EverblockTools.php
@@ -81,8 +81,15 @@ class EverblockTools extends ObjectModel
      */
     public static function hasShortcodeToken(string $txt): bool
     {
+        if ($txt === '') {
+            return false;
+        }
+
+        if (strpos($txt, '[') === false && strpos($txt, '{') === false) {
+            return false;
+        }
+
         $needles = [
-            '[',
             '{hook h=',
             '{$',
             '{if',
@@ -96,7 +103,9 @@ class EverblockTools extends ObjectModel
             }
         }
 
-        return false;
+        // Shortcode shape: [tag] or [tag ...] where tag starts with a letter.
+        // This avoids triggering the heavy renderer on plain HTML/JS arrays.
+        return (bool) preg_match('/\[[a-z][a-z0-9_-]*(?:\s[^\]]*)?\]/i', $txt);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- The shortcode pipeline was being invoked for pages that contained `[` characters in HTML/JS, causing unnecessary CPU time in `hookActionOutputHTMLBefore`.
- The goal is to skip the heavy shortcode renderer when no real shortcode or Smarty/hook token is present.

### Description
- Tighten `EverblockTools::hasShortcodeToken()` by returning early for empty content and when the string contains neither `[` nor `{` to avoid needless work.
- Remove the broad `[` needle and instead keep Smarty/hook tokens (`{hook h=`, `{$`, `{if`, `{foreach`, `{include}`) detection while adding a regex check for shortcode shapes like `[tag]` or `[tag ...]`.
- Change is implemented in `src/Service/EverblockTools.php` and preserves detection for Smarty/hook markers while reducing false positives from plain HTML/JS.

### Testing
- Ran PHP lint on the modified file with `php -l src/Service/EverblockTools.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1542e6ad0832283ed0344f6f5cb0e)